### PR TITLE
docs: require a branch per ticket, named <type>/<issue#>-<slug>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,12 @@ PORT=8000
 
 `NODE_ENV` controls error verbosity: `development` returns full stack traces; `production` sanitizes responses.
 
+## Git workflow
+
+Every ticket gets its own branch, named `<type>/<issue#>-<slug>` (e.g. `fix/98-id-validator-uncalled`),
+branched off `main` and PR'd back into `main`. Never commit ticket work directly to `main`; the legacy
+`dev` branch is retired. Full rules in `docs/agents/issue-tracker.md`.
+
 ## Active TODOs
 
 See [`todos.js`](todos.js) at the repo root for tracked tasks.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,42 @@ Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all o
 
 Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
 
+## Branching
+
+**Every ticket is implemented on its own branch.** Never commit ticket work directly to `main`.
+
+Branch name: `<type>/<issue#>-<slug>`
+
+| Part | Rule |
+|---|---|
+| `<type>` | `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, or `perf` — the conventional-commit type matching the bulk of the change |
+| `<issue#>` | the bare GitHub issue number, no `#` |
+| `<slug>` | 2-5 kebab-case words from the issue title |
+
+```
+feat/112-order-history-page
+fix/98-id-validator-uncalled
+chore/106-prisma-import-file-extension
+docs/104-adr-error-codes
+```
+
+**Base and target: `main`.** Branch off an up-to-date `main` and open the PR against `main`. The
+legacy `dev` branch is retired — do not branch from it, target it, or merge into it.
+
+```bash
+git switch main && git pull
+git switch -c <type>/<issue#>-<slug>
+# ...work, commit...
+gh pr create --base main --title "..." --body "...Closes #<issue#>"
+```
+
+Reference the issue in the commit body and the PR body with `Closes #<issue#>` so GitHub closes it
+on merge. If work has already been committed to `main` by mistake and not yet pushed, move it with
+`git branch <name>` then `git reset --hard origin/main`.
+
+**No ticket?** Process or housekeeping work that came from a direct request rather than an issue drops
+the number: `<type>/<slug>` (e.g. `docs/branching-convention`). Anything a ticket exists for keeps it.
+
 ## Pull requests as a triage surface
 
 **PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_


### PR DESCRIPTION
## Summary

Ticket work is never committed directly to `main`. Every ticket gets its own branch:

```
<type>/<issue#>-<slug>
```

| Part | Rule |
|---|---|
| `<type>` | `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf` |
| `<issue#>` | bare GitHub issue number |
| `<slug>` | 2-5 kebab-case words from the issue title |

Base and target are both `main`. The legacy `dev` branch is retired — no longer a base, target, or merge destination.

Work that came from a direct request rather than an issue drops the number (`<type>/<slug>`), which is how this branch itself is named.

## Where it lives

- Canonical rules: `docs/agents/issue-tracker.md`, new **Branching** section
- Pointer only: `CLAUDE.md`, so agents hit it on first read without duplicating the content

🤖 Generated with [Claude Code](https://claude.com/claude-code)