### PR TITLE
fix: call IdValidator in order param schemas and fix Product label

### DIFF
--- a/packages/domain/src/order.ts
+++ b/packages/domain/src/order.ts
@@ -184,7 +184,7 @@ export type CreateOrderRequest = z.infer<typeof CreateOrderRequestSchema>;
  * Get order by ID request
  */
 export const GetOrderRequestSchema = createRequestSchema({
-  params: z.object({ orderId: IdValidator }),
+  params: z.object({ orderId: IdValidator("Order") }).strict(),
 });
 
 export type GetOrderRequest = z.infer<typeof GetOrderRequestSchema>;
@@ -202,7 +202,7 @@ export type ListOrdersRequest = z.infer<typeof ListOrdersRequestSchema>;
  * Update order status request (admin only)
  */
 export const UpdateOrderStatusRequestSchema = createRequestSchema({
-  params: z.object({ orderId: IdValidator }),
+  params: z.object({ orderId: IdValidator("Order") }).strict(),
   body: UpdateOrderStatusInputSchema,
 });
 

--- a/packages/domain/src/product.ts
+++ b/packages/domain/src/product.ts
@@ -149,7 +149,7 @@ export const ProductCreateRequestSchema = createRequestSchema({
 
 // UPDATE - Update existing Product (partial)
 export const ProductUpdateByIdRequestSchema = createRequestSchema({
-  params: z.object({ id: IdValidator("Product ") }).strict(),
+  params: z.object({ id: IdValidator("Product") }).strict(),
   body: ProductPropertiesSchema.partial() satisfies z.ZodType<ProductUpdateInput>,
 });
 


### PR DESCRIPTION
## What

Two order request schemas passed the `IdValidator` **factory** into `z.object({...})` instead of calling it:

```ts
params: z.object({ orderId: IdValidator }),    // ← the function, not a schema
```

Zod 4 constructs the object fine, then throws a plain `Error` at parse time — `Invalid element at key "orderId": expected a Zod schema`. Because it is not a `ZodError`, it escapes `normalizeError` and `sendErrorProd` returns a generic **500 INTERNAL_ERROR**. Both affected routes were unconditionally broken:

- `GET /api/v1/orders/:orderId`
- `PATCH /api/v1/orders/:orderId/status`

Also drops the trailing space from the Product update-by-id id label, which produced a double space in the client-facing `"Product  Id is required"` message.

## Changes

- `packages/domain/src/order.ts:187,205` — `IdValidator` → `IdValidator("Order")`, plus `.strict()` to match every other entity request schema
- `packages/domain/src/product.ts:152` — `IdValidator("Product ")` → `IdValidator("Product")`

## Verification

A runtime probe of the exact schema shapes confirmed each acceptance criterion:

- old shape throws even under `safeParse` (the source of the 500); new shape parses a valid 24-char id
- unknown params rejected with `unrecognized_keys`
- missing id reads `"Order Id is required"`; product reads `"Product Id is required"` with a single space
- `pnpm build` (database → domain → server → client) and `pnpm lint` both pass

Both routes are mounted without `mergeParams`, so `req.params` carries exactly `orderId` — `.strict()` has nothing extra to reject.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)