### PR TITLE
fix: await database connect before listening, unify graceful shutdown

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,45 +1,19 @@
 import { prisma } from "@repo/database";
 import figlet from "figlet";
+import type { Server } from "node:http";
 import app from "./app.js";
 import { env } from "./utils/env.js";
 
 const port = env.PORT;
+const SHUTDOWN_TIMEOUT_MS = 10_000;
 
-// Handle synchronous exceptions - must be registered before any async code
-process.on("uncaughtException", (err) => {
-  console.error("UNCAUGHT EXCEPTION! Shutting down...");
-  console.error(err.name, err.message);
-  process.exit(1);
-});
+let server: Server | undefined;
+let shuttingDown = false;
 
-// Connect to database - fail fast if connection fails
-prisma
-  .$connect()
-  .then(() => {
-    if (env.NODE_ENV === "development") {
-      console.log(
-        figlet.textSync(`Mongo connected`, {
-          font: "Ogre",
-          horizontalLayout: "controlled smushing",
-          verticalLayout: "default",
-          width: 100,
-          whitespaceBreak: true,
-        }),
-      );
-    } else {
-      console.log("Database connected");
-    }
-  })
-  .catch((err) => {
-    console.error("DATABASE CONNECTION FAILED! Shutting down...");
-    console.error(err);
-    process.exit(1);
-  });
-
-const server = app.listen(port, () => {
+function logBanner(devText: string, prodText: string) {
   if (env.NODE_ENV === "development") {
     console.log(
-      figlet.textSync(`Server : port  ${port}`, {
+      figlet.textSync(devText, {
         font: "Ogre",
         horizontalLayout: "controlled smushing",
         verticalLayout: "default",
@@ -48,26 +22,80 @@ const server = app.listen(port, () => {
       }),
     );
   } else {
-    console.log(`Server listening on port ${port}`);
+    console.log(prodText);
   }
+}
+
+// Handle synchronous exceptions - must be registered before any async code
+process.on("uncaughtException", (err) => {
+  console.error("UNCAUGHT EXCEPTION! Shutting down...");
+  console.error(err.name, err.message);
+  void shutdown("uncaughtException", 1);
 });
+
+async function start() {
+  try {
+    await prisma.$connect();
+  } catch (err) {
+    console.error("DATABASE CONNECTION FAILED! Shutting down...");
+    console.error(err);
+    process.exit(1);
+  }
+
+  logBanner("Mongo connected", "Database connected");
+
+  // A signal may have arrived while we were still connecting - don't start
+  // accepting traffic into a server that's already being torn down.
+  if (shuttingDown) return;
+
+  server = app.listen(port, () => {
+    logBanner(`Server : port  ${port}`, `Server listening on port ${port}`);
+  });
+}
+
+async function shutdown(signal: string, exitCode: number) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  console.log(`${signal} received, shutting down gracefully...`);
+
+  const forceExitTimer = setTimeout(() => {
+    console.error("Shutdown timed out, forcing exit");
+    process.exit(exitCode);
+  }, SHUTDOWN_TIMEOUT_MS);
+  forceExitTimer.unref();
+
+  // Let boot finish (or fail) before touching `server`/prisma, otherwise a
+  // slow-to-connect start() can race the shutdown sequence.
+  await startPromise?.catch(() => {});
+
+  await new Promise<void>((resolve) => {
+    if (server) {
+      server.close(() => resolve());
+    } else {
+      resolve();
+    }
+  });
+
+  try {
+    await prisma.$disconnect();
+  } catch (err) {
+    console.error("Error disconnecting Prisma during shutdown:", err);
+  }
+
+  console.log("shutdown complete");
+  process.exit(exitCode);
+}
+
+// Graceful shutdown for container orchestration (Docker, K8s) and local dev (Ctrl-C)
+process.on("SIGTERM", () => void shutdown("SIGTERM", 0));
+process.on("SIGINT", () => void shutdown("SIGINT", 0));
 
 // Handle unhandled promise rejections
 process.on("unhandledRejection", (err: Error) => {
-  console.error("UNHANDLED REJECTION! Shutting down...");
+  console.error("UNHANDLED REJECTION!");
   console.error(err.name, err.message);
-  server.close(() => {
-    process.exit(1);
-  });
+  void shutdown("unhandledRejection", 1);
 });
 
-// Graceful shutdown for container orchestration (Docker, K8s)
-process.on("SIGTERM", () => {
-  console.log("SIGTERM received. Shutting down gracefully...");
-  server.close(() => {
-    prisma.$disconnect().then(() => {
-      console.log("Process terminated");
-      process.exit(0);
-    });
-  });
-});
+const startPromise = start();


### PR DESCRIPTION
Boot is now an async start(): connect to MongoDB first, exit non-zero on failure, then listen — the listening banner never prints if the connection fails. A single shutdown(signal, exitCode) now handles SIGTERM, SIGINT, unhandledRejection and uncaughtException, guarded against double-invocation and force-exiting after 10s via an unref'd timer.

shutdown() also awaits the in-flight start() before touching the server/Prisma client, closing a race where a signal arriving mid-boot could let a late app.listen() bind a socket after shutdown had already begun, and $disconnect() failures no longer block the process from exiting with the correct code.

Closes #95