### PR TITLE
fix: put types condition first in domain/database package exports

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -6,9 +6,9 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js",
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "default": "./dist/src/index.js"
     }
   },
   "scripts": {

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Export conditions resolve positionally, so listing import/default before types hid the declaration files from tooling that doesn't special-case the types condition. Fixes #96.