### PR TITLE
refactor: give GET /users/me its own controller

### DIFF
--- a/apps/server/src/controllers/user.controller.ts
+++ b/apps/server/src/controllers/user.controller.ts
@@ -1,26 +1,21 @@
 import {
-  AppError,
   createEmptyResponse,
   createListResponse,
   createSingleItemResponse,
-  ErrorCode,
 } from "@repo/domain";
-import { NextFunction, Request, RequestHandler, Response } from "express";
+import { RequestHandler } from "express";
 import { userService } from "../services/user.service.js";
 import catchAsync from "../utils/catchAsync.js";
 
-export const getMe = (req: Request, _res: Response, next: NextFunction) => {
-  if (!req.user || !req.user.id) {
-    throw new AppError("User ID not found in request", ErrorCode.UNAUTHORIZED);
-  } else {
-    req.params.id = req.user?.id!;
-    next();
-  }
-};
+// Get the authenticated user's own record
+export const getMe: RequestHandler = catchAsync(async (req, res, _next) => {
+  const dto = await userService.get(req.user!.id);
+  res.status(200).json(createSingleItemResponse(dto));
+});
 
 // Get a single user
 export const getUser: RequestHandler = catchAsync(async (req, res, _next) => {
-  const dto = await userService.get(req.verified?.params.id ?? req.params.id);
+  const dto = await userService.get(req.verified?.params.id);
   res.status(200).json(createSingleItemResponse(dto));
 });
 

--- a/apps/server/src/routes/user.route.ts
+++ b/apps/server/src/routes/user.route.ts
@@ -22,8 +22,7 @@ userRouter.use(authenticate);
 userRouter.get(
   "/me",
   validateSchema(UserGetMeRequestSchema),
-  userController.getMe,
-  userController.getUser
+  userController.getMe
 );
 
 userRouter.patch(


### PR DESCRIPTION
`/me` was served by a pre-handler that copied `req.user.id` into `req.params` and fell through to the generic get-user controller, which carried a `?? req.params.id` fallback to read it. That was the only place request data entered a controller outside `req.verified`, and the only non-`catchAsync` handler.

`getMe` is now a `catchAsync` controller that reads `req.user.id` and calls the user service directly; the fallback in `getUser` is gone. `authenticate` already guarantees `req.user`, so the unreachable UNAUTHORIZED guard goes with it.

Closes #97