### PR TITLE
refactor: route rate-limit rejections through the error envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,23 +615,33 @@ Multiple layers of security implemented:
 **Rate Limiting**:
 
 ```typescript
-// Global rate limit
-app.use(
-  "/api",
+// apps/server/src/utils/rateLimiters.ts - one factory, one rejection path.
+// A rejection leaves through next(), so the global error middleware shapes it
+// into the same envelope as every other failure instead of an ad-hoc body.
+const createRateLimiter = ({ message, ...options }: RateLimiterOptions) =>
   rateLimit({
-    limit: 500,
-    windowMs: 15 * 60 * 1000, // 15 minutes
-  }),
-);
+    ...options,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req, _res, next) => {
+      next(new AppError(message, ErrorCode.TOO_MANY_REQUESTS)); // -> 429
+    },
+  });
 
-// Strict rate limiting for sensitive endpoints
-const authLimiter = rateLimit({
-  limit: 5,
+// A flood cap on the whole API, plus stricter per-route quotas
+export const apiLimiter = createRateLimiter({ limit: 500, windowMs: 15 * 60 * 1000, ... });
+export const loginLimiter = createRateLimiter({
+  limit: 10,
   windowMs: 15 * 60 * 1000,
+  message: "Too many login attempts. Please try again in 15 minutes.",
+  skipSuccessfulRequests: true, // only failed attempts burn the quota
 });
-router.post("/auth/login", authLimiter, loginHandler);
-router.post("/auth/signup", authLimiter, signupHandler);
+
+app.use("/api", apiLimiter); // app.ts
+authRouter.post("/login", loginLimiter, /* ... */); // auth.route.ts
 ```
+
+Signup is 5/hour and order creation 20/hour, each with its own limiter.
 
 **Security Headers** (Helmet):
 
@@ -695,6 +705,7 @@ Based on recent commits and the current branch (`fix/lighthouse-a11y-bp-seo`):
 - ✅ Added Helmet middleware for security headers
 - ✅ Enhanced CORS configuration with origin validation
 - ✅ Proper middleware ordering (CORS → Rate Limit → Security → Body Parsing)
+- ✅ Rate-limit rejections return the standard error envelope (`TOO_MANY_REQUESTS`, 429) instead of an ad-hoc body
 
 **Lighthouse Optimizations** (In Progress):
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -2,12 +2,12 @@ import { AppError, ErrorCode, UserPublicInfo } from "@repo/domain";
 import cookieParser from "cookie-parser";
 import cors from "cors";
 import express, { Express } from "express";
-import rateLimit from "express-rate-limit";
 import helmet from "helmet";
 import globalErrorHandler from "./middlewares/error.middleware.js";
 import indexRoute from "./routes/index.js";
 import { env } from "./utils/env.js";
 import { httpLogger } from "./utils/logger.js";
+import { apiLimiter } from "./utils/rateLimiters.js";
 
 declare global {
   namespace Express {
@@ -52,14 +52,7 @@ app.use(
 );
 
 // 3. Rate limiting - reject abusive requests before parsing body
-const limiter = rateLimit({
-  limit: 500, // 500 requests per window (SPAs make many calls per page)
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  message: "Too many requests from this IP, please try again in 15 minutes!",
-  standardHeaders: true, // Return rate limit info in headers
-  legacyHeaders: false, // Disable X-RateLimit-* headers
-});
-app.use("/api", limiter);
+app.use("/api", apiLimiter);
 
 // 4. Security headers
 app.use(helmet());

--- a/apps/server/src/utils/rateLimiters.ts
+++ b/apps/server/src/utils/rateLimiters.ts
@@ -1,23 +1,64 @@
-import rateLimit from "express-rate-limit";
+import { AppError, ErrorCode } from "@repo/domain";
+import rateLimit, { type RateLimitRequestHandler } from "express-rate-limit";
 
 /**
- * Rate limiters for specific routes.
- * These provide stricter limits than the global API limiter for sensitive endpoints.
+ * Rate limiters. `apiLimiter` caps traffic to the whole API; the rest are
+ * stricter per-route quotas on the endpoints worth abusing.
  */
+
+type RateLimiterOptions = {
+  /** Requests allowed per window, per IP. */
+  limit: number;
+  windowMs: number;
+  /** Sent to the client verbatim as the error envelope's `message`. */
+  message: string;
+  /** Successful requests are refunded, so only failures burn the quota. */
+  skipSuccessfulRequests?: boolean;
+};
+
+/**
+ * A rejection is an error like any other: it leaves through `next()` so the
+ * global error middleware shapes it into the same envelope every other failure
+ * uses, under `ErrorCode.TOO_MANY_REQUESTS` (429). `express-rate-limit` has
+ * already set `RateLimit-*` and `Retry-After` on the response by the time
+ * `handler` runs, and `res.json()` does not clear them, so the retry
+ * information still reaches the client.
+ *
+ * `message` is deliberately not forwarded to `rateLimit()` - overriding
+ * `handler` means the library never reads it, and leaving it in would be a
+ * second, dead source of truth.
+ */
+export const createRateLimiter = ({
+  message,
+  ...options
+}: RateLimiterOptions): RateLimitRequestHandler =>
+  rateLimit({
+    ...options,
+    standardHeaders: true, // RateLimit-* (draft-6)
+    legacyHeaders: false, // no X-RateLimit-*
+    handler: (_req, _res, next) => {
+      next(new AppError(message, ErrorCode.TOO_MANY_REQUESTS));
+    },
+  });
+
+/**
+ * Global API limiter - a flood cap on the whole API, not a per-endpoint policy.
+ * 500 requests per 15 minutes per IP (SPAs make many calls per page).
+ */
+export const apiLimiter: RateLimitRequestHandler = createRateLimiter({
+  limit: 500,
+  windowMs: 15 * 60 * 1000,
+  message: "Too many requests from this IP, please try again in 15 minutes!",
+});
 
 /**
  * Login rate limiter - protects against brute force attacks
  * 10 attempts per 15 minutes per IP
  */
-export const loginLimiter = rateLimit({
+export const loginLimiter: RateLimitRequestHandler = createRateLimiter({
   limit: 10,
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  message: {
-    status: "error",
-    message: "Too many login attempts. Please try again in 15 minutes.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
+  windowMs: 15 * 60 * 1000,
+  message: "Too many login attempts. Please try again in 15 minutes.",
   skipSuccessfulRequests: true, // Don't count successful logins
 });
 
@@ -25,43 +66,31 @@ export const loginLimiter = rateLimit({
  * Signup rate limiter - prevents account creation spam
  * 5 signups per hour per IP
  */
-export const signupLimiter = rateLimit({
+export const signupLimiter: RateLimitRequestHandler = createRateLimiter({
   limit: 5,
-  windowMs: 60 * 60 * 1000, // 1 hour
-  message: {
-    status: "error",
-    message: "Too many accounts created. Please try again in an hour.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
+  windowMs: 60 * 60 * 1000,
+  message: "Too many accounts created. Please try again in an hour.",
 });
 
 /**
  * Order creation limiter - prevents order spam
  * 20 orders per hour per IP
  */
-export const createOrderLimiter = rateLimit({
+export const createOrderLimiter: RateLimitRequestHandler = createRateLimiter({
   limit: 20,
-  windowMs: 60 * 60 * 1000, // 1 hour
-  message: {
-    status: "error",
-    message: "Too many orders placed. Please try again later.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
+  windowMs: 60 * 60 * 1000,
+  message: "Too many orders placed. Please try again later.",
 });
 
 /**
  * Password reset limiter - prevents email spam
  * 3 requests per hour per IP
+ *
+ * Not mounted yet: the routes it guards are still commented out in
+ * `routes/auth.route.ts`. It holds the intended policy until they land.
  */
-export const passwordResetLimiter = rateLimit({
+export const passwordResetLimiter: RateLimitRequestHandler = createRateLimiter({
   limit: 3,
-  windowMs: 60 * 60 * 1000, // 1 hour
-  message: {
-    status: "error",
-    message: "Too many password reset requests. Please try again in an hour.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
+  windowMs: 60 * 60 * 1000,
+  message: "Too many password reset requests. Please try again in an hour.",
 });

--- a/apps/server/test/rate-limit.test.ts
+++ b/apps/server/test/rate-limit.test.ts
@@ -1,0 +1,106 @@
+import { ErrorCode } from "@repo/domain";
+import express from "express";
+import { pino } from "pino";
+import { pinoHttp } from "pino-http";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import globalErrorHandler from "../src/middlewares/error.middleware.js";
+import { httpLoggerOptions, loggerOptions } from "../src/utils/logger.js";
+import { createRateLimiter } from "../src/utils/rateLimiters.js";
+
+type LogLine = {
+  level?: number;
+  err?: { type?: string; message?: string };
+  requestId?: string;
+  res?: { statusCode?: number };
+};
+
+const collect = () => {
+  const lines: LogLine[] = [];
+  const stream = {
+    write(chunk: string) {
+      lines.push(JSON.parse(chunk));
+    },
+  };
+  const logger = pino({ ...loggerOptions, level: "info" }, stream);
+  return { lines, logger };
+};
+
+// Each call builds its own limiter, so every test owns a fresh MemoryStore and
+// nothing leaks between them. `limit: 1` makes the second request the rejected
+// one, so no test has to burn a production-sized quota - and none of this
+// touches the singleton app, whose global limiter is shared process-wide.
+const rateLimitedApp = (
+  logger: ReturnType<typeof collect>["logger"],
+  message = "slow down",
+) => {
+  const app = express();
+  app.use(pinoHttp({ ...httpLoggerOptions, logger }));
+  app.use(createRateLimiter({ limit: 1, windowMs: 60_000, message }));
+  app.get("/ping", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  app.use(globalErrorHandler);
+  return app;
+};
+
+describe("rate limiting", () => {
+  it("lets a request under the limit through", async () => {
+    const { logger } = collect();
+
+    const res = await request(rateLimitedApp(logger)).get("/ping");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("rejects over the limit with the standard error envelope", async () => {
+    const { logger } = collect();
+    const app = rateLimitedApp(logger);
+
+    await request(app).get("/ping");
+    const res = await request(app).get("/ping");
+
+    expect(res.status).toBe(429);
+    expect(res.body).toMatchObject({
+      success: false,
+      data: null,
+      error: {
+        code: ErrorCode.TOO_MANY_REQUESTS,
+        statusCode: 429,
+        message: "slow down",
+      },
+    });
+    // NODE_ENV=test takes the production branch, which never leaks a stack.
+    expect(res.body.error.stack).toBeUndefined();
+    expect(res.body.error.requestId).toBe(res.headers["x-request-id"]);
+  });
+
+  it("keeps the rate limit headers through the error middleware", async () => {
+    const { logger } = collect();
+    const app = rateLimitedApp(logger);
+
+    await request(app).get("/ping");
+    const res = await request(app).get("/ping");
+
+    expect(res.headers["retry-after"]).toBeDefined();
+    expect(res.headers["ratelimit-limit"]).toBe("1");
+    expect(res.headers["ratelimit-remaining"]).toBe("0");
+    // legacyHeaders: false
+    expect(res.headers["x-ratelimit-limit"]).toBeUndefined();
+  });
+
+  it("logs a rejection as a client error, not a server failure", async () => {
+    const { lines, logger } = collect();
+    const app = rateLimitedApp(logger);
+
+    await request(app).get("/ping");
+    const res = await request(app).get("/ping");
+
+    expect(res.status).toBe(429);
+    expect(lines).toHaveLength(2);
+    expect(lines[1]!.level).toBe(30);
+    expect(lines[1]!.err).toBeUndefined();
+    expect(lines[1]!.res?.statusCode).toBe(429);
+  });
+});

--- a/packages/domain/src/error-codes.ts
+++ b/packages/domain/src/error-codes.ts
@@ -31,6 +31,9 @@ export enum ErrorCode {
   BAD_REQUEST = "BAD_REQUEST",
   UNPROCESSABLE_ENTITY = "UNPROCESSABLE_ENTITY",
 
+  // Rate limiting errors (429)
+  TOO_MANY_REQUESTS = "TOO_MANY_REQUESTS",
+
   // Component/UI errors (400)
   COMPONENT_COMPOSITION_ERROR = "COMPONENT_COMPOSITION_ERROR",
 
@@ -86,6 +89,9 @@ export const ERROR_CODE_TO_STATUS: Record<ErrorCode, number> = {
 
   // Request errors
   [ErrorCode.UNPROCESSABLE_ENTITY]: 422,
+
+  // Rate limiting errors (429)
+  [ErrorCode.TOO_MANY_REQUESTS]: 429,
 
   // Component/UI errors (400)
   [ErrorCode.COMPONENT_COMPOSITION_ERROR]: 400,

--- a/packages/domain/test/error-codes.test.ts
+++ b/packages/domain/test/error-codes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { ErrorCode, ErrorObjectSchema, getStatusCode } from "../src/index.js";
+
+// The error envelope is closed over the enum - `ErrorObjectSchema.code` is
+// `z.enum(ErrorCode)` - so a rate-limit rejection could not be expressed as an
+// `ErrorResponse` at all until `TOO_MANY_REQUESTS` existed. These pin both
+// halves: the status mapping, and the envelope actually accepting the code.
+
+describe("TOO_MANY_REQUESTS", () => {
+  it("maps to 429", () => {
+    expect(getStatusCode(ErrorCode.TOO_MANY_REQUESTS)).toBe(429);
+  });
+
+  it("is accepted by the error envelope", () => {
+    const parsed = ErrorObjectSchema.safeParse({
+      code: ErrorCode.TOO_MANY_REQUESTS,
+      message: "Too many requests",
+      statusCode: 429,
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/todos.js
+++ b/todos.js
@@ -26,8 +26,6 @@ x;
 // TODO add errors for update same value
 // TODO checkout prices should return from backend
 // TODO handle slugs ,where is generated create update, user provide??
-// TODO add rate limiting middleware to server
-// TODO add helmet middleware to server
 
 // ============================================================================
 // ERROR HANDLING & VALIDATION


### PR DESCRIPTION
Closes #119

## The problem

Rate limiting was the one part of the server that ignored the project's error conventions. Five limiters lived in two places with three different response shapes — a bare string on the global one, `{status: "error", message}` (a JSend-era shape used nowhere else) on the four per-route ones — and none of them was the `ErrorResponse` envelope every other failure uses.

That cost two client-facing bugs. `processAxiosError` reads `error.response.data.error`; a 429 had no `.error` key, so `isAppError` failed and it fell through to `AppError("Something went very wrong!", INTERNAL_ERROR, 500)`. Therefore:

- **A rate-limited login toasted the wrong message** — the mutation's `onError` shows `normalizedError.message` verbatim, so the user got "Something went very wrong!" instead of "Too many login attempts."
- **The client retried rate-limited requests.** `react-query.ts` skips retries for 4xx, but a 429 classified as `statusCode: 500`, so it retried twice with backoff — answering "you are sending too many requests" by sending two more.

`ErrorCode` had no 429 member, and `ErrorObjectSchema.code` is `z.enum(ErrorCode)`, so the envelope was *closed over the enum*: adding `TOO_MANY_REQUESTS` was a hard prerequisite, not a nicety.

## The change

- **`packages/domain`** — `ErrorCode.TOO_MANY_REQUESTS` + its 429 entry in `ERROR_CODE_TO_STATUS`.
- **`rateLimiters.ts`** — one `createRateLimiter` factory centralizing `standardHeaders`/`legacyHeaders` and a `handler` that hands `next()` an `AppError(TOO_MANY_REQUESTS)`, so a rejection is shaped by the same boundary as everything else. `message` is deliberately destructured out rather than spread into `rateLimit()`: once `handler` is overridden the library never reads it, and `Options["message"]` is typed `any`, so leaving it in would compile silently as a second, dead source of truth.
- **`app.ts`** — the global limiter moves out as `apiLimiter`, keeping its position ahead of helmet and the body parsers, and the numbered step comments unchanged.
- **`error.middleware.ts` needed no change** — a 429 is `< 500`, so it takes the existing 4xx path, leaves `res.err` unset and stays at pino `info`.

**No client code was edited.** Both bugs are fixed by the domain change alone: `Object.values(ErrorCode).includes(...)` picks the new member up, which is what makes `isAppError` start succeeding.

`passwordResetLimiter` stays unmounted, holding the intended 3/hour policy until the forgot-password routes land.

## Verification

`pnpm test` — 21 tests pass, 6 of them new. New `apps/server/test/rate-limit.test.ts` builds a fresh mini-app per test (the `logger.test.ts` pattern) so no test touches the singleton app's process-wide limiter store; it pins the envelope, that `Retry-After`/`RateLimit-*` survive the error middleware, that `legacyHeaders: false` holds, and — mirroring the existing contract test — that a 429 stays at pino `info` with `res.err` unset.

Also verified end to end against the **real** app, repeatably: exactly 500 requests to `/api/v1/health` succeed and request 501 returns

```json
{ "success": false, "timestamp": "...", "data": null,
  "error": { "message": "Too many requests from this IP, please try again in 15 minutes!",
             "code": "TOO_MANY_REQUESTS", "statusCode": 429, "requestId": "ad2fe700-..." } }
```

with `Retry-After: 900`, `RateLimit-Limit: 500`, `RateLimit-Remaining: 0`, no `X-RateLimit-*`, and `requestId` matching the `x-request-id` header.

`pnpm --filter server lint` (0 errors) and `type-check` clean.

## Notes

- Docs drift fixed along the way: `README.md` documented an `authLimiter` (5/15min on both login and signup) that does not exist. `todos.js` had stale TODOs for rate limiting and helmet, both long since implemented. `docs/ARCHITECTURE.md` is also updated locally but is gitignored, so it isn't in this diff.
- Rate-limited responses never pass through helmet, since the limiter short-circuits at step 3 and `helmet()` is at step 4. Pre-existing, not a regression here — filed as #120.
- Open issue #111 will rewrite the `res.err` gating in `error.middleware.ts`. It must keep `AppError(TOO_MANY_REQUESTS)` on the info side: a rate-limit rejection is operational, not a programmer error. The new test asserts this, so it should fail loudly if that slips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)