### PR TITLE
refactor: share query parsing across services and whitelist sort

### DIFF
--- a/apps/server/src/services/abstract-crud.service.ts
+++ b/apps/server/src/services/abstract-crud.service.ts
@@ -1,4 +1,5 @@
-import { AppError, ErrorCode, Meta } from "@repo/domain";
+import { AppError, ErrorCode } from "@repo/domain";
+import { buildMeta, parsePagination, type Pagination } from "../utils/query.js";
 
 /**
  * Simplified abstract base class for CRUD operations.
@@ -13,7 +14,8 @@ import { AppError, ErrorCode, Meta } from "@repo/domain";
  * @description
  * This class provides a standardized interface for CRUD operations.
  * Subclasses implement 6 core persistence methods only - all query building
- * (where, select, orderBy) happens inside persistFindMany.
+ * (where, select, orderBy) happens inside persistFindMany, using the shared
+ * parsers in `utils/query.ts`.
  *
  * Benefits:
  * - Clear data flow: getAll() -> persistFindMany() -> toDTO()
@@ -35,26 +37,22 @@ import { AppError, ErrorCode, Meta } from "@repo/domain";
  *
  *   // All query logic lives here
  *   protected async persistFindMany(params) {
- *     const { page = 1, limit = 20, filters, sort, fields } = params;
+ *     const { skip, take, filters, sort, fields } = params;
  *
- *     // Build where, select, orderBy locally
  *     const where = this.buildProductWhere(filters);
- *     const select = this.parseProductSelect(fields);
- *     const orderBy = this.parseProductOrderBy(sort);
+ *     const select = parseSelect(fields, PRODUCT_QUERY_FIELDS);
+ *     const orderBy = parseOrderBy(sort, PRODUCT_QUERY_FIELDS);
  *
- *     const skip = (page - 1) * limit;
  *     const [data, total] = await prisma.$transaction([
- *       prisma.product.findMany({ where, select, orderBy, skip, take: limit }),
+ *       prisma.product.findMany({ where, select, orderBy, skip, take }),
  *       prisma.product.count({ where }),
  *     ]);
  *
  *     return { data, total };
  *   }
  *
- *   // Private helpers
+ *   // Only the entity-specific where-builder stays private to the service
  *   private buildProductWhere(filters?: any) { ... }
- *   private parseProductSelect(fields?: string) { ... }
- *   private parseProductOrderBy(sort?: string) { ... }
  * }
  * ```
  *
@@ -82,11 +80,11 @@ export abstract class AbstractCrudService<
    * @param params - Query parameters including page, limit, filters, sort, fields
    * @returns Array of entities and total count
    */
-  protected abstract persistFindMany(params: {
-    page?: number;
-    limit?: number;
-    [key: string]: any; // Allow services to pass any custom query params
-  }): Promise<{ data: Entity[]; total: number }>;
+  protected abstract persistFindMany(
+    params: Pagination & {
+      [key: string]: any; // Allow services to pass any custom query params
+    }
+  ): Promise<{ data: Entity[]; total: number }>;
 
   protected abstract persistFindById(id: string): Promise<Entity | null>;
   protected abstract persistCreate(data: CreateInput): Promise<Entity>;
@@ -99,25 +97,17 @@ export abstract class AbstractCrudService<
   // ***** Public CRUD Methods *****
 
   async getAll(query: any) {
-    const page =
-      typeof query?.page !== "undefined" ? Number(query?.page) || 1 : 1;
-    const limit =
-      typeof query?.limit !== "undefined" ? Number(query?.limit) || 20 : 20;
+    const pagination = parsePagination(query);
 
     // Pass all query params to persistFindMany - service decides what to do with them
     const { data, total } = await this.persistFindMany({
-      page,
-      limit,
       ...query, // filters, sort, fields, etc.
+      ...pagination,
     });
-
-    const totalPages = Math.ceil(total / limit);
-    const hasNext = page < totalPages;
-    const hasPrev = page > 1;
 
     return {
       data: data.map((e) => this.toDTO(e)),
-      meta: { page, limit, total, totalPages, hasNext, hasPrev } satisfies Meta,
+      meta: buildMeta({ ...pagination, total }),
     };
   }
 

--- a/apps/server/src/services/category.service.ts
+++ b/apps/server/src/services/category.service.ts
@@ -8,7 +8,16 @@ import type {
   NAME,
 } from "@repo/domain";
 import { NAME as NAME_ENUM } from "@repo/domain";
+import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
+
+const CATEGORY_QUERY_FIELDS = [
+  "id",
+  "name",
+  "createdAt",
+  "v",
+  "thumbnail",
+] as const satisfies readonly (keyof CategorySelect)[];
 
 export class CategoryService extends AbstractCrudService<
   Category,
@@ -20,23 +29,20 @@ export class CategoryService extends AbstractCrudService<
     return entity;
   }
 
-  protected async persistFindMany(params: {
-    page?: number;
-    limit?: number;
-    [key: string]: any;
-  }): Promise<{ data: Category[]; total: number }> {
-    const { page = 1, limit = 20, name, sort, fields } = params;
-    const skip = (page - 1) * limit;
+  protected async persistFindMany(
+    params: Pagination & { [key: string]: any }
+  ): Promise<{ data: Category[]; total: number }> {
+    const { skip, take, name, sort, fields } = params;
 
     const where = this.buildCategoryWhere(name);
-    const select = this.parseCategorySelect(fields);
-    const orderBy = this.parseCategoryOrderBy(sort);
+    const select = parseSelect(fields, CATEGORY_QUERY_FIELDS);
+    const orderBy = parseOrderBy(sort, CATEGORY_QUERY_FIELDS);
 
     const [data, total] = await prisma.$transaction([
       prisma.category.findMany({
         where,
         skip,
-        take: limit,
+        take,
         orderBy,
         select,
       }),
@@ -96,38 +102,6 @@ export class CategoryService extends AbstractCrudService<
     return {
       name: name as NAME,
     };
-  }
-
-  private parseCategorySelect(fields?: string) {
-    if (!fields || typeof fields !== "string") {
-      return undefined;
-    }
-
-    const selectKeys = fields.split(",");
-    const validFields = ["id", "name", "createdAt", "v", "thumbnail"] as const;
-
-    const select: Partial<CategorySelect> = {};
-    for (const key of selectKeys) {
-      if (validFields.includes(key as (typeof validFields)[number])) {
-        select[key as keyof CategorySelect] = true;
-      }
-    }
-
-    return Object.keys(select).length > 0
-      ? (select as CategorySelect)
-      : undefined;
-  }
-
-  private parseCategoryOrderBy(sort?: string) {
-    if (!sort || typeof sort !== "string") {
-      return [{ id: "desc" as const }];
-    }
-
-    return sort.split(",").map((field: string) => {
-      const isDescending = field.startsWith("-");
-      const fieldName = isDescending ? field.substring(1) : field;
-      return { [fieldName]: isDescending ? "desc" : "asc" };
-    });
   }
 }
 

--- a/apps/server/src/services/config.service.ts
+++ b/apps/server/src/services/config.service.ts
@@ -6,7 +6,15 @@ import type {
   ConfigSelect,
   ConfigUpdateInput,
 } from "@repo/domain";
+import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
+
+const CONFIG_QUERY_FIELDS = [
+  "id",
+  "name",
+  "createdAt",
+  "v",
+] as const satisfies readonly (keyof ConfigSelect)[];
 
 export class ConfigService extends AbstractCrudService<
   Config,
@@ -20,23 +28,20 @@ export class ConfigService extends AbstractCrudService<
 
   // ***** Persistence Layer Methods *****
 
-  protected async persistFindMany(params: {
-    page?: number;
-    limit?: number;
-    [key: string]: any;
-  }): Promise<{ data: Config[]; total: number }> {
-    const { page = 1, limit = 20, sort, fields } = params;
-    const skip = (page - 1) * limit;
+  protected async persistFindMany(
+    params: Pagination & { [key: string]: any }
+  ): Promise<{ data: Config[]; total: number }> {
+    const { skip, take, sort, fields } = params;
 
     const where = this.buildConfigWhere();
-    const select = this.parseConfigSelect(fields);
-    const orderBy = this.parseConfigOrderBy(sort);
+    const select = parseSelect(fields, CONFIG_QUERY_FIELDS);
+    const orderBy = parseOrderBy(sort, CONFIG_QUERY_FIELDS);
 
     const [data, total] = await prisma.$transaction([
       prisma.config.findMany({
         where,
         skip,
-        take: limit,
+        take,
         orderBy,
         select,
       }),
@@ -91,34 +96,6 @@ export class ConfigService extends AbstractCrudService<
     }
   }
 
-  protected parseSelect(fields?: string): ConfigSelect | undefined {
-    if (!fields || typeof fields !== "string") {
-      return undefined;
-    }
-
-    const selectKeys = fields.split(",");
-    const validFields = [
-      "id",
-      "name",
-      "createdAt",
-      "v",
-      "featuredProduct",
-      "showCaseProducts",
-    ] as const;
-
-    const select: Partial<ConfigSelect> = {};
-
-    for (const key of selectKeys) {
-      if (validFields.includes(key as (typeof validFields)[number])) {
-        select[key as keyof ConfigSelect] = true;
-      }
-    }
-
-    return Object.keys(select).length > 0
-      ? (select as ConfigSelect)
-      : undefined;
-  }
-
   // ===== Private Query Builders =====
 
   private buildConfigWhere() {
@@ -126,45 +103,6 @@ export class ConfigService extends AbstractCrudService<
     return {};
   }
 
-  private parseConfigSelect(fields?: string): ConfigSelect | undefined {
-    if (!fields || typeof fields !== "string") {
-      return undefined;
-    }
-
-    const selectKeys = fields.split(",");
-    const validFields = [
-      "id",
-      "name",
-      "createdAt",
-      "v",
-      "featuredProduct",
-      "showCaseProducts",
-    ] as const;
-
-    const select: Partial<ConfigSelect> = {};
-
-    for (const key of selectKeys) {
-      if (validFields.includes(key as (typeof validFields)[number])) {
-        select[key as keyof ConfigSelect] = true;
-      }
-    }
-
-    return Object.keys(select).length > 0
-      ? (select as ConfigSelect)
-      : undefined;
-  }
-
-  private parseConfigOrderBy(sort?: string) {
-    if (!sort || typeof sort !== "string") {
-      return [{ id: "desc" as const }];
-    }
-
-    return sort.split(",").map((field: string) => {
-      const isDescending = field.startsWith("-");
-      const fieldName = isDescending ? field.substring(1) : field;
-      return { [fieldName]: isDescending ? "desc" : "asc" };
-    });
-  }
   async getUniqueConfig(): Promise<ConfigDTO | null> {
     const entity = await prisma.config.findFirst();
     return entity ? this.toDTO(entity) : null;

--- a/apps/server/src/services/product.service.ts
+++ b/apps/server/src/services/product.service.ts
@@ -15,7 +15,26 @@ import {
   ProductUpdateInput,
   ProductWhereInput,
 } from "@repo/domain";
+import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
+
+const PRODUCT_QUERY_FIELDS = [
+  "id",
+  "cartLabel",
+  "name",
+  "slug",
+  "price",
+  "categoryId",
+  "createdAt",
+  "v",
+  "shortLabel",
+  "fullLabel",
+  "description",
+  "isNewProduct",
+  "featuredImageText",
+  "showCaseImageText",
+  "featuresText",
+] as const satisfies readonly (keyof Product)[];
 
 export class ProductService extends AbstractCrudService<
   Product,
@@ -52,64 +71,20 @@ export class ProductService extends AbstractCrudService<
     };
   }
 
-  private parseProductSelect(fields?: string): ProductSelect | undefined {
-    if (!fields || typeof fields !== "string") return undefined;
-    const validFields = [
-      "id",
-      "cartLabel",
-      "name",
-      "slug",
-      "price",
-      "categoryId",
-      "createdAt",
-      "v",
-      "shortLabel",
-      "fullLabel",
-      "description",
-      "isNewProduct",
-      "featuredImageText",
-      "showCaseImageText",
-      "featuresText",
-    ] satisfies readonly (keyof Product)[];
-
-    const select: Partial<ProductSelect> = {};
-    for (const field of fields.split(",")) {
-      if (validFields.includes(field as (typeof validFields)[number])) {
-        select[field as keyof ProductSelect] = true;
-      }
-    }
-    return Object.keys(select).length ? select : undefined;
-  }
-
-  private parseProductOrderBy(sort?: string) {
-    if (!sort || typeof sort !== "string") {
-      return [{ id: "desc" as const }];
-    }
-
-    return sort.split(",").map((field: string) => {
-      const isDescending = field.startsWith("-");
-      const fieldName = isDescending ? field.substring(1) : field;
-      return { [fieldName]: isDescending ? "desc" : "asc" };
-    });
-  }
-
   protected async persistFindMany(
-    params: ExtendedQueryParams<{ name: string; price: number }>
+    params: Pagination & ExtendedQueryParams<{ name: string; price: number }>
   ): Promise<{ data: Product[]; total: number }> {
-    const { page = 1, limit = 20, sort, fields, name, price } = params;
+    const { skip, take, sort, fields, name, price } = params;
 
-    const skip = (page - 1) * limit;
-
-    // Build query components locally
     const where = this.buildProductWhere(name, price);
-    const select = this.parseProductSelect(fields);
-    const orderBy = this.parseProductOrderBy(sort);
+    const select = parseSelect(fields, PRODUCT_QUERY_FIELDS);
+    const orderBy = parseOrderBy(sort, PRODUCT_QUERY_FIELDS);
 
     const [data, total] = await prisma.$transaction([
       prisma.product.findMany({
         where,
         skip,
-        take: limit,
+        take,
         orderBy,
         select,
       }),

--- a/apps/server/src/services/user.service.ts
+++ b/apps/server/src/services/user.service.ts
@@ -7,7 +7,19 @@ import type {
   UserSelect,
   UserUpdateInput,
 } from "@repo/domain";
+import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
+
+const USER_QUERY_FIELDS = [
+  "id",
+  "name",
+  "email",
+  "role",
+  "emailVerified",
+  "createdAt",
+  "active",
+  "v",
+] as const satisfies readonly (keyof UserSelect)[];
 
 export class UserService extends AbstractCrudService<
   UserPublicInfo,
@@ -31,23 +43,20 @@ export class UserService extends AbstractCrudService<
 
   // ***** Persistence Layer Methods *****
 
-  protected async persistFindMany(params: {
-    page?: number;
-    limit?: number;
-    [key: string]: any;
-  }): Promise<{ data: UserPublicInfo[]; total: number }> {
-    const { page = 1, limit = 20, role, sort, fields } = params;
-    const skip = (page - 1) * limit;
+  protected async persistFindMany(
+    params: Pagination & { [key: string]: any }
+  ): Promise<{ data: UserPublicInfo[]; total: number }> {
+    const { skip, take, role, sort, fields } = params;
 
     const where = this.buildUserWhere(role);
-    const select = this.parseUserSelect(fields);
-    const orderBy = this.parseUserOrderBy(sort);
+    const select = parseSelect(fields, USER_QUERY_FIELDS);
+    const orderBy = parseOrderBy(sort, USER_QUERY_FIELDS);
 
     const [data, total] = await prisma.$transaction([
       prisma.user.findMany({
         where,
         skip,
-        take: limit,
+        take,
         orderBy,
         select,
       }),
@@ -105,34 +114,6 @@ export class UserService extends AbstractCrudService<
     }
   }
 
-  protected parseSelect(fields?: string): UserSelect | undefined {
-    if (!fields || typeof fields !== "string") {
-      return undefined;
-    }
-
-    const selectKeys = fields.split(",");
-    const validFields = [
-      "id",
-      "name",
-      "email",
-      "role",
-      "emailVerified",
-      "createdAt",
-      "active",
-      "v",
-    ] as const;
-
-    const select: Partial<UserSelect> = {};
-
-    for (const key of selectKeys) {
-      if (validFields.includes(key as (typeof validFields)[number])) {
-        select[key as keyof UserSelect] = true;
-      }
-    }
-
-    return Object.keys(select).length > 0 ? (select as UserSelect) : undefined;
-  }
-
   // ===== Private Query Builders =====
 
   private buildUserWhere(role?: string) {
@@ -142,46 +123,6 @@ export class UserService extends AbstractCrudService<
     return {
       role: { equals: role as ROLE },
     };
-  }
-
-  private parseUserSelect(fields?: string): UserSelect | undefined {
-    if (!fields || typeof fields !== "string") {
-      return undefined;
-    }
-
-    const selectKeys = fields.split(",");
-    const validFields = [
-      "id",
-      "name",
-      "email",
-      "role",
-      "emailVerified",
-      "createdAt",
-      "active",
-      "v",
-    ] as const;
-
-    const select: Partial<UserSelect> = {};
-
-    for (const key of selectKeys) {
-      if (validFields.includes(key as (typeof validFields)[number])) {
-        select[key as keyof UserSelect] = true;
-      }
-    }
-
-    return Object.keys(select).length > 0 ? (select as UserSelect) : undefined;
-  }
-
-  private parseUserOrderBy(sort?: string) {
-    if (!sort || typeof sort !== "string") {
-      return [{ id: "desc" as const }];
-    }
-
-    return sort.split(",").map((field: string) => {
-      const isDescending = field.startsWith("-");
-      const fieldName = isDescending ? field.substring(1) : field;
-      return { [fieldName]: isDescending ? "desc" : "asc" };
-    });
   }
 }
 

--- a/apps/server/src/utils/query.ts
+++ b/apps/server/src/utils/query.ts
@@ -1,0 +1,88 @@
+import type { Meta } from "@repo/domain";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+
+export interface Pagination {
+  page: number;
+  limit: number;
+  skip: number;
+  take: number;
+}
+
+export type OrderBy = Record<string, "asc" | "desc">;
+
+export const parsePagination = (query?: {
+  page?: unknown;
+  limit?: unknown;
+}): Pagination => {
+  const page =
+    typeof query?.page !== "undefined"
+      ? Number(query.page) || DEFAULT_PAGE
+      : DEFAULT_PAGE;
+  const limit =
+    typeof query?.limit !== "undefined"
+      ? Number(query.limit) || DEFAULT_LIMIT
+      : DEFAULT_LIMIT;
+
+  return { page, limit, skip: (page - 1) * limit, take: limit };
+};
+
+export const buildMeta = ({
+  page,
+  limit,
+  total,
+}: {
+  page: number;
+  limit: number;
+  total: number;
+}): Meta => {
+  const totalPages = Math.ceil(total / limit);
+
+  return {
+    page,
+    limit,
+    total,
+    totalPages,
+    hasNext: page < totalPages,
+    hasPrev: page > 1,
+  };
+};
+
+export const parseSelect = <Field extends string>(
+  fields: unknown,
+  allowedFields: readonly Field[]
+): Record<Field, true> | undefined => {
+  if (typeof fields !== "string" || !fields) return undefined;
+
+  const select = {} as Record<Field, true>;
+  for (const field of fields.split(",")) {
+    if ((allowedFields as readonly string[]).includes(field)) {
+      select[field as Field] = true;
+    }
+  }
+
+  return Object.keys(select).length > 0 ? select : undefined;
+};
+
+export const parseOrderBy = <Field extends string>(
+  sort: unknown,
+  allowedFields: readonly Field[]
+): OrderBy[] => {
+  const defaultOrderBy: OrderBy[] = [{ id: "desc" }];
+  if (typeof sort !== "string" || !sort) return defaultOrderBy;
+
+  const orderBy = sort
+    .split(",")
+    .map((field) => {
+      const isDescending = field.startsWith("-");
+      const fieldName = isDescending ? field.substring(1) : field;
+      if (!(allowedFields as readonly string[]).includes(fieldName)) {
+        return undefined;
+      }
+      return { [fieldName]: isDescending ? "desc" : "asc" } satisfies OrderBy;
+    })
+    .filter((entry): entry is OrderBy => entry !== undefined);
+
+  return orderBy.length > 0 ? orderBy : defaultOrderBy;
+};

--- a/apps/server/test/list-query.route.test.ts
+++ b/apps/server/test/list-query.route.test.ts
@@ -1,0 +1,190 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Only Prisma is mocked, so these pin the query the real stack builds.
+const findMany = vi.fn(() => []);
+const count = vi.fn(() => 0);
+const productFindMany = vi.fn(() => []);
+const productCount = vi.fn(() => 0);
+const userFindMany = vi.fn(() => []);
+const userCount = vi.fn(() => 0);
+
+// The users list sits behind authenticate/authorize; the query parsing is what
+// is under test, so the chain is stubbed out rather than exercised.
+vi.mock("../src/middlewares/auth.middleware.js", () => ({
+  authenticate: (req: { user: unknown }, _res: unknown, next: () => void) => {
+    req.user = { id: "u1", role: "ADMIN" };
+    next();
+  },
+  authorize: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock("@repo/database", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@repo/database")>()),
+  prisma: {
+    category: {
+      findMany: (args: unknown) => findMany(args),
+      count: (args: unknown) => count(args),
+    },
+    product: {
+      findMany: (args: unknown) => productFindMany(args),
+      count: (args: unknown) => productCount(args),
+    },
+    user: {
+      findMany: (args: unknown) => userFindMany(args),
+      count: (args: unknown) => userCount(args),
+    },
+    $transaction: (operations: unknown[]) => Promise.all(operations),
+  },
+}));
+
+const app = (await import("../src/app.js")).default;
+
+const listCategories = async (queryString: string) => {
+  const res = await request(app).get(`/api/v1/categories${queryString}`);
+  return { res, args: findMany.mock.calls[0]?.[0] as Record<string, unknown> };
+};
+
+const listProducts = async (queryString: string) => {
+  const res = await request(app).get(`/api/v1/products${queryString}`);
+  return {
+    res,
+    args: productFindMany.mock.calls[0]?.[0] as Record<string, unknown>,
+  };
+};
+
+const listUsers = async (queryString: string) => {
+  const res = await request(app).get(`/api/v1/users${queryString}`);
+  return {
+    res,
+    args: userFindMany.mock.calls[0]?.[0] as Record<string, unknown>,
+  };
+};
+
+beforeEach(() => {
+  findMany.mockClear();
+  count.mockClear();
+  productFindMany.mockClear();
+  productCount.mockClear();
+  userFindMany.mockClear();
+  userCount.mockClear();
+});
+
+describe("GET /api/v1/categories", () => {
+  it("ignores an unknown sort field and falls back to the default order", async () => {
+    const { res, args } = await listCategories("?sort=hax");
+
+    expect(res.status).toBe(200);
+    expect(args.orderBy).toEqual([{ id: "desc" }]);
+  });
+
+  it("keeps a valid sort list, descending fields included", async () => {
+    const { args } = await listCategories("?sort=-name,createdAt");
+
+    expect(args.orderBy).toEqual([{ name: "desc" }, { createdAt: "asc" }]);
+  });
+
+  it("drops only the unknown members of a mixed sort list", async () => {
+    const { args } = await listCategories("?sort=hax,-createdAt");
+
+    expect(args.orderBy).toEqual([{ createdAt: "desc" }]);
+  });
+
+  it("selects only whitelisted fields", async () => {
+    const { args } = await listCategories("?fields=id,name,password");
+
+    expect(args.select).toEqual({ id: true, name: true });
+  });
+
+  it("omits select entirely when no requested field is whitelisted", async () => {
+    const { args } = await listCategories("?fields=password");
+
+    expect(args.select).toBeUndefined();
+  });
+
+  it("defaults to the first page of 20", async () => {
+    const { res, args } = await listCategories("");
+
+    expect(args).toMatchObject({ skip: 0, take: 20, where: {} });
+    expect(res.body.meta).toEqual({
+      page: 1,
+      limit: 20,
+      total: 0,
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    });
+  });
+
+  it("translates page and limit into skip and take, and reports them back", async () => {
+    count.mockReturnValueOnce(25);
+    const { res, args } = await listCategories("?page=2&limit=5");
+
+    expect(args).toMatchObject({ skip: 5, take: 5 });
+    expect(res.body.meta).toEqual({
+      page: 2,
+      limit: 5,
+      total: 25,
+      totalPages: 5,
+      hasNext: true,
+      hasPrev: true,
+    });
+  });
+
+  it("still applies the name filter alongside the parsed query", async () => {
+    const { args } = await listCategories("?name=Headphones&sort=name");
+
+    expect(args).toMatchObject({
+      where: { name: "Headphones" },
+      orderBy: [{ name: "asc" }],
+    });
+  });
+});
+
+describe("GET /api/v1/products", () => {
+  it("ignores an unknown sort field and falls back to the default order", async () => {
+    const { res, args } = await listProducts("?sort=hax");
+
+    expect(res.status).toBe(200);
+    expect(args.orderBy).toEqual([{ id: "desc" }]);
+  });
+
+  it("keeps a valid sort list and whitelisted fields", async () => {
+    const { args } = await listProducts("?sort=-price,name&fields=id,price,hax");
+
+    expect(args).toMatchObject({
+      orderBy: [{ price: "desc" }, { name: "asc" }],
+      select: { id: true, price: true },
+      skip: 0,
+      take: 20,
+    });
+  });
+});
+
+describe("GET /api/v1/users", () => {
+  it("ignores an unknown sort field and falls back to the default order", async () => {
+    const { res, args } = await listUsers("?sort=hax");
+
+    expect(res.status).toBe(200);
+    expect(args.orderBy).toEqual([{ id: "desc" }]);
+  });
+
+  it("keeps a valid sort list and whitelisted fields", async () => {
+    const { args } = await listUsers("?sort=-createdAt,email&fields=id,email,password");
+
+    expect(args).toMatchObject({
+      orderBy: [{ createdAt: "desc" }, { email: "asc" }],
+      select: { id: true, email: true },
+    });
+  });
+
+  it("still applies the role filter alongside the parsed query", async () => {
+    const { args } = await listUsers("?role=ADMIN&page=3&limit=10");
+
+    expect(args).toMatchObject({
+      where: { role: { equals: "ADMIN" } },
+      skip: 20,
+      take: 10,
+    });
+  });
+});

--- a/apps/server/test/query.util.test.ts
+++ b/apps/server/test/query.util.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMeta,
+  parseOrderBy,
+  parsePagination,
+  parseSelect,
+} from "../src/utils/query.js";
+
+const ALLOWED = ["id", "name", "createdAt", "v", "thumbnail"] as const;
+
+describe("parsePagination", () => {
+  it("defaults to page 1 and limit 20", () => {
+    expect(parsePagination()).toEqual({
+      page: 1,
+      limit: 20,
+      skip: 0,
+      take: 20,
+    });
+    expect(parsePagination({})).toEqual({
+      page: 1,
+      limit: 20,
+      skip: 0,
+      take: 20,
+    });
+  });
+
+  it("derives skip from page and limit", () => {
+    expect(parsePagination({ page: 3, limit: 10 })).toEqual({
+      page: 3,
+      limit: 10,
+      skip: 20,
+      take: 10,
+    });
+  });
+
+  it("falls back to the defaults for values that are not positive numbers", () => {
+    expect(parsePagination({ page: "abc", limit: "" })).toEqual({
+      page: 1,
+      limit: 20,
+      skip: 0,
+      take: 20,
+    });
+    expect(parsePagination({ page: 0, limit: 0 })).toEqual({
+      page: 1,
+      limit: 20,
+      skip: 0,
+      take: 20,
+    });
+  });
+
+  it("coerces numeric strings", () => {
+    expect(parsePagination({ page: "2", limit: "5" })).toEqual({
+      page: 2,
+      limit: 5,
+      skip: 5,
+      take: 5,
+    });
+  });
+});
+
+describe("buildMeta", () => {
+  it("reports the page window over the total", () => {
+    expect(buildMeta({ page: 2, limit: 10, total: 25 })).toEqual({
+      page: 2,
+      limit: 10,
+      total: 25,
+      totalPages: 3,
+      hasNext: true,
+      hasPrev: true,
+    });
+  });
+
+  it("has no next or previous page on a single-page result", () => {
+    expect(buildMeta({ page: 1, limit: 20, total: 3 })).toEqual({
+      page: 1,
+      limit: 20,
+      total: 3,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    });
+  });
+
+  it("reports zero pages for an empty result", () => {
+    expect(buildMeta({ page: 1, limit: 20, total: 0 })).toMatchObject({
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    });
+  });
+});
+
+describe("parseSelect", () => {
+  it("returns undefined when no fields are requested", () => {
+    expect(parseSelect(undefined, ALLOWED)).toBeUndefined();
+    expect(parseSelect("", ALLOWED)).toBeUndefined();
+    expect(parseSelect(42, ALLOWED)).toBeUndefined();
+  });
+
+  it("keeps only allowed fields", () => {
+    expect(parseSelect("id,name,secret", ALLOWED)).toEqual({
+      id: true,
+      name: true,
+    });
+  });
+
+  it("returns undefined when nothing survives the whitelist", () => {
+    expect(parseSelect("secret,password", ALLOWED)).toBeUndefined();
+  });
+});
+
+describe("parseOrderBy", () => {
+  it("defaults to descending id", () => {
+    expect(parseOrderBy(undefined, ALLOWED)).toEqual([{ id: "desc" }]);
+    expect(parseOrderBy("", ALLOWED)).toEqual([{ id: "desc" }]);
+  });
+
+  it("reads a leading minus as descending", () => {
+    expect(parseOrderBy("-name", ALLOWED)).toEqual([{ name: "desc" }]);
+  });
+
+  it("keeps the order of a comma-separated list", () => {
+    expect(parseOrderBy("name,-createdAt", ALLOWED)).toEqual([
+      { name: "asc" },
+      { createdAt: "desc" },
+    ]);
+  });
+
+  it("drops fields outside the whitelist", () => {
+    expect(parseOrderBy("name,hax", ALLOWED)).toEqual([{ name: "asc" }]);
+    expect(parseOrderBy("-hax,createdAt", ALLOWED)).toEqual([
+      { createdAt: "asc" },
+    ]);
+  });
+
+  it("falls back to the default order when nothing survives", () => {
+    expect(parseOrderBy("hax", ALLOWED)).toEqual([{ id: "desc" }]);
+    expect(parseOrderBy("-hax,-alsoHax", ALLOWED)).toEqual([{ id: "desc" }]);
+  });
+});


### PR DESCRIPTION
Four services each carried their own copy of the field-selection and sort parsers plus the same pagination arithmetic, and none of the sort parsers whitelisted field names, so `?sort=anything` reached Prisma and surfaced as a client-controlled 400.

Add `utils/query.ts` with `parsePagination`, `buildMeta`, `parseSelect` and `parseOrderBy`. `parseOrderBy` whitelists against the same allowed-field list `parseSelect` uses and falls back to the default `id desc` order when nothing survives. Category, product, user and config services now use it and keep only their entity-specific where-builder; the base CRUD service's `getAll` derives pagination and meta from the shared helpers. The dead `parseSelect` methods in the user and config services are gone.

Closes #101