### PR TITLE
refactor: type list query params through the CRUD service generic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Even then: one short line. No rationale paragraphs, no restating what the code a
 | `*WhereInput` | filter params |
 | `*Select` | field selection |
 | `ExtendedQueryParams` | pagination/sorting |
+| `*QueryParams` | one entity's list query: `ExtendedQueryParams<{ filters }>` |
 
 All exports flow through `packages/domain/src/index.ts`.
 

--- a/apps/server/src/services/abstract-crud.service.ts
+++ b/apps/server/src/services/abstract-crud.service.ts
@@ -1,4 +1,4 @@
-import { AppError, ErrorCode } from "@repo/domain";
+import { AppError, ErrorCode, type baseQueryParams } from "@repo/domain";
 import { buildMeta, parsePagination, type Pagination } from "../utils/query.js";
 
 /**
@@ -8,6 +8,7 @@ import { buildMeta, parsePagination, type Pagination } from "../utils/query.js";
  * @template CreateInput - The input type for creating new entities
  * @template UpdateInput - The input type for updating existing entities
  * @template DTO - The Data Transfer Object type returned to clients
+ * @template Query - The validated list query params this service accepts
  *
  * @abstract
  *
@@ -29,17 +30,18 @@ import { buildMeta, parsePagination, type Pagination } from "../utils/query.js";
  *   Product,
  *   ProductCreateInput,
  *   ProductUpdateInput,
- *   ProductDTO
+ *   ProductDTO,
+ *   ProductQueryParams
  * > {
  *   protected toDTO(entity: Product): ProductDTO {
  *     return { id: entity.id, name: entity.name };
  *   }
  *
  *   // All query logic lives here
- *   protected async persistFindMany(params) {
- *     const { skip, take, filters, sort, fields } = params;
+ *   protected async persistFindMany(params: Pagination & ProductQueryParams) {
+ *     const { skip, take, name, sort, fields } = params;
  *
- *     const where = this.buildProductWhere(filters);
+ *     const where = this.buildProductWhere(name);
  *     const select = parseSelect(fields, PRODUCT_QUERY_FIELDS);
  *     const orderBy = parseOrderBy(sort, PRODUCT_QUERY_FIELDS);
  *
@@ -52,13 +54,13 @@ import { buildMeta, parsePagination, type Pagination } from "../utils/query.js";
  *   }
  *
  *   // Only the entity-specific where-builder stays private to the service
- *   private buildProductWhere(filters?: any) { ... }
+ *   private buildProductWhere(name?: string) { ... }
  * }
  * ```
  *
  * @remarks
  * - Services implement only what they need
- * - Minimal type complexity: 4 generic params instead of 7
+ * - Minimal type complexity: 5 generic params instead of 7
  * - All error handling and pagination handled by base class
  * - Optional filterUpdateInput hook for input validation
  */
@@ -67,6 +69,7 @@ export abstract class AbstractCrudService<
   CreateInput,
   UpdateInput,
   DTO,
+  Query extends baseQueryParams = baseQueryParams,
 > {
   /**
    * Transform entity to DTO for client response
@@ -81,9 +84,7 @@ export abstract class AbstractCrudService<
    * @returns Array of entities and total count
    */
   protected abstract persistFindMany(
-    params: Pagination & {
-      [key: string]: any; // Allow services to pass any custom query params
-    }
+    params: Pagination & Query
   ): Promise<{ data: Entity[]; total: number }>;
 
   protected abstract persistFindById(id: string): Promise<Entity | null>;
@@ -96,12 +97,11 @@ export abstract class AbstractCrudService<
 
   // ***** Public CRUD Methods *****
 
-  async getAll(query: any) {
+  async getAll(query: Query) {
     const pagination = parsePagination(query);
 
-    // Pass all query params to persistFindMany - service decides what to do with them
     const { data, total } = await this.persistFindMany({
-      ...query, // filters, sort, fields, etc.
+      ...query,
       ...pagination,
     });
 

--- a/apps/server/src/services/category.service.ts
+++ b/apps/server/src/services/category.service.ts
@@ -3,11 +3,11 @@ import type {
   Category,
   CategoryCreateInput,
   CategoryDTO,
+  CategoryQueryParams,
   CategorySelect,
   CategoryUpdateInput,
   NAME,
 } from "@repo/domain";
-import { NAME as NAME_ENUM } from "@repo/domain";
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
 
@@ -23,14 +23,15 @@ export class CategoryService extends AbstractCrudService<
   Category,
   CategoryCreateInput,
   CategoryUpdateInput,
-  CategoryDTO
+  CategoryDTO,
+  CategoryQueryParams
 > {
   protected toDTO(entity: Category): CategoryDTO {
     return entity;
   }
 
   protected async persistFindMany(
-    params: Pagination & { [key: string]: any }
+    params: Pagination & CategoryQueryParams
   ): Promise<{ data: Category[]; total: number }> {
     const { skip, take, name, sort, fields } = params;
 
@@ -89,19 +90,8 @@ export class CategoryService extends AbstractCrudService<
 
   // ===== Private Query Builders =====
 
-  private buildCategoryWhere(name?: string) {
-    if (!name || typeof name !== "string") {
-      return {};
-    }
-
-    // Validate that the name is a valid NAME enum value
-    if (!Object.values(NAME_ENUM).includes(name as NAME)) {
-      return {};
-    }
-
-    return {
-      name: name as NAME,
-    };
+  private buildCategoryWhere(name?: NAME) {
+    return name ? { name } : {};
   }
 }
 

--- a/apps/server/src/services/config.service.ts
+++ b/apps/server/src/services/config.service.ts
@@ -3,6 +3,7 @@ import type {
   Config,
   ConfigCreateInput,
   ConfigDTO,
+  ConfigQueryParams,
   ConfigSelect,
   ConfigUpdateInput,
 } from "@repo/domain";
@@ -20,7 +21,8 @@ export class ConfigService extends AbstractCrudService<
   Config,
   ConfigCreateInput,
   ConfigUpdateInput,
-  ConfigDTO
+  ConfigDTO,
+  ConfigQueryParams
 > {
   protected toDTO(entity: Config): ConfigDTO {
     return entity;
@@ -29,7 +31,7 @@ export class ConfigService extends AbstractCrudService<
   // ***** Persistence Layer Methods *****
 
   protected async persistFindMany(
-    params: Pagination & { [key: string]: any }
+    params: Pagination & ConfigQueryParams
   ): Promise<{ data: Config[]; total: number }> {
     const { skip, take, sort, fields } = params;
 

--- a/apps/server/src/services/product.service.ts
+++ b/apps/server/src/services/product.service.ts
@@ -2,7 +2,6 @@ import { NAME, prisma } from "@repo/database";
 import {
   AppError,
   ErrorCode,
-  ExtendedQueryParams,
   Meta,
   Product,
   ProductCreateInput,
@@ -10,6 +9,7 @@ import {
   ProductFeaturedProductsDTO,
   ProductRelatedProductsDTO,
   ProductsByCategoryNameDTO,
+  ProductQueryParams,
   ProductSelect,
   ProductShowCaseProductsDTO,
   ProductUpdateInput,
@@ -40,7 +40,8 @@ export class ProductService extends AbstractCrudService<
   Product,
   ProductCreateInput,
   ProductUpdateInput,
-  ProductDTO
+  ProductDTO,
+  ProductQueryParams
 > {
   protected toDTO(entity: Product): ProductDTO {
     return entity;
@@ -48,35 +49,24 @@ export class ProductService extends AbstractCrudService<
 
   // ===== Private Query Builders =====
 
-  private buildProductWhere(name?: string, price?: number): ProductWhereInput {
-    if (!name || typeof name !== "string") {
+  private buildProductWhere(name?: string): ProductWhereInput {
+    if (!name) {
       return {};
-    }
-    if (price === undefined || typeof price !== "number") {
-      return {
-        name: {
-          equals: name,
-          mode: "insensitive" as const,
-        },
-      };
     }
     return {
       name: {
         equals: name,
         mode: "insensitive" as const,
       },
-      price: {
-        equals: price,
-      },
     };
   }
 
   protected async persistFindMany(
-    params: Pagination & ExtendedQueryParams<{ name: string; price: number }>
+    params: Pagination & ProductQueryParams
   ): Promise<{ data: Product[]; total: number }> {
-    const { skip, take, sort, fields, name, price } = params;
+    const { skip, take, sort, fields, name } = params;
 
-    const where = this.buildProductWhere(name, price);
+    const where = this.buildProductWhere(name);
     const select = parseSelect(fields, PRODUCT_QUERY_FIELDS);
     const orderBy = parseOrderBy(sort, PRODUCT_QUERY_FIELDS);
 

--- a/apps/server/src/services/user.service.ts
+++ b/apps/server/src/services/user.service.ts
@@ -4,6 +4,7 @@ import type {
   UserCreateInput,
   UserDTO,
   UserPublicInfo,
+  UserQueryParams,
   UserSelect,
   UserUpdateInput,
 } from "@repo/domain";
@@ -25,7 +26,8 @@ export class UserService extends AbstractCrudService<
   UserPublicInfo,
   UserCreateInput,
   UserUpdateInput,
-  UserDTO
+  UserDTO,
+  UserQueryParams
 > {
   protected toDTO(entity: UserPublicInfo): UserDTO {
     const dto = {
@@ -44,7 +46,7 @@ export class UserService extends AbstractCrudService<
   // ***** Persistence Layer Methods *****
 
   protected async persistFindMany(
-    params: Pagination & { [key: string]: any }
+    params: Pagination & UserQueryParams
   ): Promise<{ data: UserPublicInfo[]; total: number }> {
     const { skip, take, role, sort, fields } = params;
 
@@ -116,12 +118,12 @@ export class UserService extends AbstractCrudService<
 
   // ===== Private Query Builders =====
 
-  private buildUserWhere(role?: string) {
-    if (!role || typeof role !== "string") {
+  private buildUserWhere(role?: ROLE) {
+    if (!role) {
       return {};
     }
     return {
-      role: { equals: role as ROLE },
+      role: { equals: role },
     };
   }
 }

--- a/apps/server/test/service-query.test-d.ts
+++ b/apps/server/test/service-query.test-d.ts
@@ -1,0 +1,53 @@
+import type {
+  CategoryQueryParams,
+  CategoryQueryParamsSchema,
+  ProductQueryParams,
+  ProductQueryParamsSchema,
+  UserQueryParams,
+  UserQueryParamsSchema,
+} from "@repo/domain";
+import { describe, expectTypeOf, it } from "vitest";
+import type { z } from "zod";
+import { categoryService } from "../src/services/category.service.js";
+import { productService } from "../src/services/product.service.js";
+import { userService } from "../src/services/user.service.js";
+
+describe("list query params", () => {
+  it("declares the same keys the route's schema parses", () => {
+    expectTypeOf<
+      keyof z.infer<typeof CategoryQueryParamsSchema>
+    >().toEqualTypeOf<keyof CategoryQueryParams>();
+    expectTypeOf<
+      keyof z.infer<typeof ProductQueryParamsSchema>
+    >().toEqualTypeOf<keyof ProductQueryParams>();
+    expectTypeOf<keyof z.infer<typeof UserQueryParamsSchema>>().toEqualTypeOf<
+      keyof UserQueryParams
+    >();
+  });
+
+  it("accepts the filters the entity's route validates", () => {
+    expectTypeOf(categoryService.getAll).toBeCallableWith({
+      name: "Headphones",
+      sort: "-createdAt",
+      page: 2,
+    });
+    expectTypeOf(productService.getAll).toBeCallableWith({ name: "zx9" });
+    expectTypeOf(userService.getAll).toBeCallableWith({ role: "ADMIN" });
+  });
+
+  it("rejects a filter the entity does not have", () => {
+    // @ts-expect-error categories have no `role` filter
+    categoryService.getAll({ role: "ADMIN" });
+    // @ts-expect-error products have no `colour` filter
+    productService.getAll({ colour: "red" });
+    // @ts-expect-error users have no `name` filter
+    userService.getAll({ name: "ada" });
+  });
+
+  it("rejects a filter value outside the validated enum", () => {
+    // @ts-expect-error `name` is a category enum member
+    categoryService.getAll({ name: "Turntables" });
+    // @ts-expect-error `role` is a role enum member
+    userService.getAll({ role: "SUPERUSER" });
+  });
+});

--- a/apps/server/tsconfig.typecheck.json
+++ b/apps/server/tsconfig.typecheck.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "composite": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.test-d.ts"]
+}

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
+    typecheck: {
+      enabled: true,
+      tsconfig: "./tsconfig.typecheck.json",
+    },
     // `src/utils/env.ts` validates process.env at import time, and `app.ts`
     // imports it, so every value the schema requires has to be present before
     // the first test file loads. These are placeholders: no test connects to

--- a/packages/domain/src/category.ts
+++ b/packages/domain/src/category.ts
@@ -6,10 +6,12 @@ import type {
 import { z } from "zod";
 import type {
   EmptyResponse,
+  ExtendedQueryParams,
   ListResponse,
   SingleItemResponse,
 } from "./common.js";
 import {
+  BaseQueryParamsSchema,
   createRequestSchema,
   EmptyResponseSchema,
   ListResponseSchema,
@@ -44,16 +46,14 @@ export const CategoryThumbnailSchema = z.object({
 // * ===== RequestSchemas =====
 
 // LIST - Get all categories (pagination + filtering)
+export type CategoryQueryParams = ExtendedQueryParams<{ name?: NAME }>;
+
+export const CategoryQueryParamsSchema = BaseQueryParamsSchema.extend({
+  name: z.enum(NAME).optional(),
+}) satisfies z.ZodType<CategoryQueryParams>;
+
 export const CategoryGetAllRequestSchema = createRequestSchema({
-  query: z
-    .object({
-      sort: z.string().optional(),
-      name: z.enum(NAME).optional(),
-      fields: z.string().optional(),
-      page: z.coerce.number().int().positive().optional(),
-      limit: z.coerce.number().int().positive().optional(),
-    })
-    .optional(),
+  query: CategoryQueryParamsSchema.optional(),
 });
 
 // GET - Get single category by ID

--- a/packages/domain/src/common.ts
+++ b/packages/domain/src/common.ts
@@ -271,4 +271,11 @@ export interface baseQueryParams {
   fields?: string;
 }
 
+export const BaseQueryParamsSchema = z.object({
+  sort: z.string().optional(),
+  fields: z.string().optional(),
+  page: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().positive().optional(),
+}) satisfies z.ZodType<baseQueryParams>;
+
 export type ExtendedQueryParams<T> = baseQueryParams & T;

--- a/packages/domain/src/config.ts
+++ b/packages/domain/src/config.ts
@@ -1,6 +1,7 @@
 import type { Prisma, Config as PrismaConfig } from "@repo/database";
 import { string, z } from "zod";
 import type {
+  baseQueryParams,
   EmptyResponse,
   ListResponse,
   SingleItemResponse,
@@ -25,6 +26,8 @@ export type ConfigScalarFieldEnum = Prisma.ConfigScalarFieldEnum;
 // *  ===== Entity Specific Types =====
 
 export type ConfigDTO = Config;
+
+export type ConfigQueryParams = baseQueryParams;
 
 // * =====  Common Schemas =====
 

--- a/packages/domain/src/product.ts
+++ b/packages/domain/src/product.ts
@@ -5,7 +5,9 @@ import type {
 } from "@repo/database";
 import { z } from "zod";
 import { NAME } from "./category.js";
+import type { ExtendedQueryParams } from "./common.js";
 import {
+  BaseQueryParamsSchema,
   createRequestSchema,
   EmptyResponse,
   EmptyResponseSchema,
@@ -97,16 +99,14 @@ const ProductPropertiesSchema = z
 // * ===== RequestSchemas =====
 
 // LIST - Get all Products (pagination + filtering)
+export type ProductQueryParams = ExtendedQueryParams<{ name?: string }>;
+
+export const ProductQueryParamsSchema = BaseQueryParamsSchema.extend({
+  name: z.string().optional(),
+}) satisfies z.ZodType<ProductQueryParams>;
+
 export const ProductGetAllRequestSchema = createRequestSchema({
-  query: z
-    .object({
-      sort: z.string().optional(),
-      fields: z.string().optional(),
-      page: z.coerce.number().int().positive().optional(),
-      limit: z.coerce.number().int().positive().optional(),
-      name: z.string().optional(),
-    })
-    .optional(),
+  query: ProductQueryParamsSchema.optional(),
 });
 
 // GET - Get single Product by ID

--- a/packages/domain/src/user.ts
+++ b/packages/domain/src/user.ts
@@ -1,6 +1,8 @@
 import type { Prisma, User as PrismaUser } from "@repo/database";
 import { z } from "zod";
+import type { ExtendedQueryParams } from "./common.js";
 import {
+  BaseQueryParamsSchema,
   createRequestSchema,
   EmptyResponse,
   EmptyResponseSchema,
@@ -67,16 +69,14 @@ export const UserDeleteMeRequestSchema = createRequestSchema({
 
 // LIST - Get all Users (pagination + filtering) - admin only
 
+export type UserQueryParams = ExtendedQueryParams<{ role?: ROLE }>;
+
+export const UserQueryParamsSchema = BaseQueryParamsSchema.extend({
+  role: z.enum(ROLE).optional(),
+}) satisfies z.ZodType<UserQueryParams>;
+
 export const UserGetAllRequestSchema = createRequestSchema({
-  query: z
-    .object({
-      sort: z.string().optional(),
-      fields: z.string().optional(),
-      page: z.coerce.number().int().positive().optional(),
-      limit: z.coerce.number().int().positive().optional(),
-      role: z.enum(ROLE).optional(),
-    })
-    .optional(),
+  query: UserQueryParamsSchema.optional(),
 });
 
 // CREATE - Create new user - admin only


### PR DESCRIPTION
Closes #102

## What changed

`AbstractCrudService.getAll` took `any` and `persistFindMany` was declared with an open index signature, so every service destructured untyped params. A fifth generic — `Query extends baseQueryParams = baseQueryParams` — now threads through both. The default keeps the cart and order services (neither has a `getAll` caller) compiling untouched.

Each list route's query schema gained a named type in `packages/domain`: `CategoryQueryParams`, `ProductQueryParams`, `UserQueryParams`, `ConfigQueryParams`. The schemas are built by extending a shared `BaseQueryParamsSchema` instead of repeating `page`/`limit`/`sort`/`fields` four times, and the category, product, user and config services declare their type through the generic.

The where-builders drop the runtime type guards and `as` casts the route schemas already make impossible.

## Behaviour

None intended, and none found. Two removals deserve the scrutiny:

- **`buildProductWhere`'s price branch** — unreachable. `price` was never a key of `ProductGetAllRequestSchema`, and the non-strict Zod object strips unknown keys, so it could never arrive at `persistFindMany`.
- **The category/user `typeof` guards** — unreachable. Both routes run `validateSchema` with `z.enum(NAME)` / `z.enum(ROLE)`, so only valid enum members get through.

## Verification

`vitest` now runs typecheck tests for the server (`tsconfig.typecheck.json`), so acceptance criterion 3 — an unknown filter key on `getAll` is a compile error — is enforced rather than asserted. `apps/server/test/service-query.test-d.ts` also pins each schema's key set to its declared type, so schema and type cannot drift apart.

Both guards were verified by deliberately breaking them: dropping a `@ts-expect-error` fails with `'colour' does not exist in type 'ProductQueryParams'`, and adding a schema-only key fails the key-set assertion.

`pnpm test` 48 passed / no type errors; `pnpm build` and `pnpm lint` clean.

## Out of scope, ticketed

- `app.ts` types `verified?: Record<string, any>`, so `service.getAll(req.verified?.query)` still passes `any` at the controller boundary — the generic binds the implementations, not the request path. That's #103.
- The query schemas are the last non-`.strict()` input schemas in the repo. Making them strict changes runtime behaviour (unknown keys become 400s), so it's #124 rather than part of a typing refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)