### PR TITLE
refactor: type req.verified from domain request schemas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Route → validateSchema middleware → Controller → Service → Prisma
 
 - **`catchAsync`** — wrap every async route handler; centralized error middleware handles the rest
 - **`validateSchema(ZodSchema)`** — validates `params`, `body`, `query`; validated data lands in `req.verified`
+- **`catchAsync<ValidatedRequest<typeof XRequestSchema>>`** — types `req.verified` from the route's schema; use it in every handler that reads validated input
 - **`AppError`** — throw with error codes from `@repo/domain/error-codes`; never throw raw errors
 - **Zod errors** — auto-converted to `AppError(422, VALIDATION_ERROR)` by error middleware
 - **Logging** — `pino` + `pino-http`; inside a request use `req.log` (it carries `requestId`), never the bare `logger`. Errors are logged once, at the boundary: the error middleware puts 5xx on `res.err` and pino-http emits the single line for that request. Layers in between throw, they don't log.

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,4 +1,4 @@
-import { AppError, ErrorCode, UserPublicInfo } from "@repo/domain";
+import { AppError, ErrorCode } from "@repo/domain";
 import cookieParser from "cookie-parser";
 import cors from "cors";
 import express, { Express } from "express";
@@ -8,15 +8,6 @@ import indexRoute from "./routes/index.js";
 import { env } from "./utils/env.js";
 import { httpLogger } from "./utils/logger.js";
 import { apiLimiter } from "./utils/rateLimiters.js";
-
-declare global {
-  namespace Express {
-    export interface Request {
-      user?: UserPublicInfo;
-      verified?: Record<string, any>;
-    }
-  }
-}
 
 const app: Express = express();
 app.set("query parser", "extended");

--- a/apps/server/src/controllers/auth.controller.ts
+++ b/apps/server/src/controllers/auth.controller.ts
@@ -1,5 +1,8 @@
 import {
   AppError,
+  AuthLoginRequestSchema,
+  AuthSignUpRequestSchema,
+  AuthUpdatePasswordRequestSchema,
   createEmptyResponse,
   createSingleItemResponse,
   ErrorCode,
@@ -7,6 +10,7 @@ import {
 } from "@repo/domain";
 import { Request, RequestHandler, Response } from "express";
 import { authService } from "../services/auth.service.js";
+import { ValidatedRequest } from "../types/validated-request.js";
 import catchAsync from "../utils/catchAsync.js";
 import { env } from "../utils/env.js";
 import { getTokenFromRequest } from "../middlewares/auth.middleware.js";
@@ -62,8 +66,10 @@ const createAndSendAuthCookie = (
  * Sign up a new user
  * Parses request, delegates to service, sends response
  */
-export const signup: RequestHandler = catchAsync(async (req, res, next) => {
-  const { token, user } = await authService.signup(req.verified?.body);
+export const signup: RequestHandler = catchAsync<
+  ValidatedRequest<typeof AuthSignUpRequestSchema>
+>(async (req, res) => {
+  const { token, user } = await authService.signup(req.verified.body);
   createAndSendAuthCookie(user, token, 201, req, res);
 });
 
@@ -71,8 +77,10 @@ export const signup: RequestHandler = catchAsync(async (req, res, next) => {
  * Log in a user
  * Validates credentials via service, sends response with token
  */
-export const login: RequestHandler = catchAsync(async (req, res, next) => {
-  const { email, password } = req.verified?.body;
+export const login: RequestHandler = catchAsync<
+  ValidatedRequest<typeof AuthLoginRequestSchema>
+>(async (req, res) => {
+  const { email, password } = req.verified.body;
   const { user, token } = await authService.login({ email, password });
   createAndSendAuthCookie(user, token, 200, req, res);
 });
@@ -97,27 +105,27 @@ export const logout = (req: Request, res: Response) => {
  * Update user password
  * Gets user ID from request(after authentication), delegates to service, sends response with new token
  */
-export const updatePassword: RequestHandler = catchAsync(
-  async (req, res, next) => {
-    // passwordConfirm and currentPassword validation handled in zod schema
-    const { currentPassword, password } = req.verified?.body;
-    const userId = req.user?.id!;
+export const updatePassword: RequestHandler = catchAsync<
+  ValidatedRequest<typeof AuthUpdatePasswordRequestSchema>
+>(async (req, res, next) => {
+  // passwordConfirm and currentPassword validation handled in zod schema
+  const { currentPassword, password } = req.verified.body;
+  const userId = req.user?.id;
 
-    if (!userId) {
-      return next(
-        new AppError("User ID not found in request", ErrorCode.UNAUTHORIZED),
-      );
-    }
-
-    const userData = await authService.updatePassword(
-      userId,
-      currentPassword,
-      password,
+  if (!userId) {
+    return next(
+      new AppError("User ID not found in request", ErrorCode.UNAUTHORIZED),
     );
-    const { token, user } = userData;
-    createAndSendAuthCookie(user, token, 200, req, res);
-  },
-);
+  }
+
+  const userData = await authService.updatePassword(
+    userId,
+    currentPassword,
+    password,
+  );
+  const { token, user } = userData;
+  createAndSendAuthCookie(user, token, 200, req, res);
+});
 
 export const getUserAuthStatus: RequestHandler = catchAsync(
   async (req, res, _next) => {

--- a/apps/server/src/controllers/cart.controller.ts
+++ b/apps/server/src/controllers/cart.controller.ts
@@ -1,9 +1,14 @@
 import {
+  AddToCartRequestSchema,
   createEmptyResponse,
   createSingleItemResponse,
+  RemoveFromCartRequestSchema,
+  SyncCartRequestSchema,
+  UpdateCartItemRequestSchema,
 } from "@repo/domain";
 import { RequestHandler } from "express";
 import { cartService } from "../services/cart.service.js";
+import { ValidatedRequest } from "../types/validated-request.js";
 import catchAsync from "../utils/catchAsync.js";
 
 /**
@@ -18,10 +23,12 @@ export const getCart: RequestHandler = catchAsync(async (req, res) => {
 /**
  * Add item to cart
  */
-export const addToCart: RequestHandler = catchAsync(async (req, res) => {
+export const addToCart: RequestHandler = catchAsync<
+  ValidatedRequest<typeof AddToCartRequestSchema>
+>(async (req, res) => {
   const userId = req.user!.id;
-  const { productId, quantity } = req.verified?.body;
-  
+  const { productId, quantity } = req.verified.body;
+
   const dto = await cartService.addToCart(userId, productId, quantity);
   res.status(200).json(createSingleItemResponse(dto));
 });
@@ -29,10 +36,12 @@ export const addToCart: RequestHandler = catchAsync(async (req, res) => {
 /**
  * Sync local cart with server cart
  */
-export const syncCart: RequestHandler = catchAsync(async (req, res) => {
+export const syncCart: RequestHandler = catchAsync<
+  ValidatedRequest<typeof SyncCartRequestSchema>
+>(async (req, res) => {
   const userId = req.user!.id;
-  const { items } = req.verified?.body;
-  
+  const { items } = req.verified.body;
+
   const dto = await cartService.syncCart(userId, { items });
   res.status(200).json(createSingleItemResponse(dto));
 });
@@ -40,11 +49,13 @@ export const syncCart: RequestHandler = catchAsync(async (req, res) => {
 /**
  * Update cart item quantity
  */
-export const updateCartItem: RequestHandler = catchAsync(async (req, res) => {
+export const updateCartItem: RequestHandler = catchAsync<
+  ValidatedRequest<typeof UpdateCartItemRequestSchema>
+>(async (req, res) => {
   const userId = req.user!.id;
-  const { cartItemId } = req.verified?.params;
-  const { quantity } = req.verified?.body;
-  
+  const { cartItemId } = req.verified.params;
+  const { quantity } = req.verified.body;
+
   const dto = await cartService.updateCartItem(userId, cartItemId, quantity);
   res.status(200).json(createSingleItemResponse(dto));
 });
@@ -52,10 +63,12 @@ export const updateCartItem: RequestHandler = catchAsync(async (req, res) => {
 /**
  * Remove item from cart
  */
-export const removeFromCart: RequestHandler = catchAsync(async (req, res) => {
+export const removeFromCart: RequestHandler = catchAsync<
+  ValidatedRequest<typeof RemoveFromCartRequestSchema>
+>(async (req, res) => {
   const userId = req.user!.id;
-  const { cartItemId } = req.verified?.params;
-  
+  const { cartItemId } = req.verified.params;
+
   const dto = await cartService.removeFromCart(userId, cartItemId);
   res.status(200).json(createSingleItemResponse(dto));
 });
@@ -65,7 +78,7 @@ export const removeFromCart: RequestHandler = catchAsync(async (req, res) => {
  */
 export const clearCart: RequestHandler = catchAsync(async (req, res) => {
   const userId = req.user!.id;
-  
+
   await cartService.clearCart(userId);
   res.status(200).json(createEmptyResponse());
 });

--- a/apps/server/src/controllers/category.controller.ts
+++ b/apps/server/src/controllers/category.controller.ts
@@ -1,38 +1,54 @@
 import {
+  CategoryCreateRequestSchema,
+  CategoryDeleteByIdRequestSchema,
+  CategoryGetAllRequestSchema,
+  CategoryGetByIdRequestSchema,
+  CategoryUpdateByIdRequestSchema,
   createEmptyResponse,
   createListResponse,
   createSingleItemResponse,
 } from "@repo/domain";
 import { RequestHandler } from "express";
 import { categoryService } from "../services/category.service.js";
+import { ValidatedRequest } from "../types/validated-request.js";
 import catchAsync from "../utils/catchAsync.js";
 
-export const getAllCategories: RequestHandler = catchAsync(async (req, res) => {
-  const result = await categoryService.getAll(req.verified?.query);
+export const getAllCategories: RequestHandler = catchAsync<
+  ValidatedRequest<typeof CategoryGetAllRequestSchema>
+>(async (req, res) => {
+  const result = await categoryService.getAll(req.verified.query);
   res.status(200).json(createListResponse(result.data, result.meta));
 });
 
-export const getCategoryById: RequestHandler = catchAsync(async (req, res) => {
-  const dto = await categoryService.get(req.verified?.params.id);
+export const getCategoryById: RequestHandler = catchAsync<
+  ValidatedRequest<typeof CategoryGetByIdRequestSchema>
+>(async (req, res) => {
+  const dto = await categoryService.get(req.verified.params.id);
   res.status(200).json(createSingleItemResponse(dto));
 });
 
 // * ADMIN CONTROLLERS
 
-export const createCategory: RequestHandler = catchAsync(async (req, res) => {
-  const dto = await categoryService.create(req.verified?.body);
+export const createCategory: RequestHandler = catchAsync<
+  ValidatedRequest<typeof CategoryCreateRequestSchema>
+>(async (req, res) => {
+  const dto = await categoryService.create(req.verified.body);
   res.status(201).json(createSingleItemResponse(dto));
 });
 
-export const updateCategory: RequestHandler = catchAsync(async (req, res) => {
+export const updateCategory: RequestHandler = catchAsync<
+  ValidatedRequest<typeof CategoryUpdateByIdRequestSchema>
+>(async (req, res) => {
   const dto = await categoryService.update(
-    req.verified?.params.id,
-    req.verified?.body
+    req.verified.params.id,
+    req.verified.body
   );
   res.status(200).json(createSingleItemResponse(dto));
 });
 
-export const deleteCategory: RequestHandler = catchAsync(async (req, res) => {
-  await categoryService.delete(req.verified?.params.id);
+export const deleteCategory: RequestHandler = catchAsync<
+  ValidatedRequest<typeof CategoryDeleteByIdRequestSchema>
+>(async (req, res) => {
+  await categoryService.delete(req.verified.params.id);
   res.status(200).json(createEmptyResponse());
 });

--- a/apps/server/src/controllers/config.controller.ts
+++ b/apps/server/src/controllers/config.controller.ts
@@ -1,29 +1,42 @@
-import { createEmptyResponse, createSingleItemResponse } from "@repo/domain";
+import {
+  ConfigCreateRequestSchema,
+  ConfigDeleteByIdRequestSchema,
+  ConfigUpdateByIdRequestSchema,
+  createEmptyResponse,
+  createSingleItemResponse,
+} from "@repo/domain";
 import { RequestHandler } from "express";
 import { configService } from "../services/config.service.js";
+import { ValidatedRequest } from "../types/validated-request.js";
 import catchAsync from "../utils/catchAsync.js";
 
-export const getConfig: RequestHandler = catchAsync(async (req, res) => {
+export const getConfig: RequestHandler = catchAsync(async (_req, res) => {
   const result = await configService.getUniqueConfig();
   res.status(200).json(createSingleItemResponse(result));
 });
 
 // * ADMIN CONTROLLERS
 
-export const createConfig: RequestHandler = catchAsync(async (req, res) => {
-  const dto = await configService.create(req.verified?.body);
+export const createConfig: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ConfigCreateRequestSchema>
+>(async (req, res) => {
+  const dto = await configService.create(req.verified.body);
   res.status(201).json(createSingleItemResponse(dto));
 });
 
-export const updateConfig: RequestHandler = catchAsync(async (req, res) => {
+export const updateConfig: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ConfigUpdateByIdRequestSchema>
+>(async (req, res) => {
   const dto = await configService.update(
-    req.verified?.params.id,
-    req.verified?.body
+    req.verified.params.id,
+    req.verified.body
   );
   res.status(200).json(createSingleItemResponse(dto));
 });
 
-export const deleteConfig: RequestHandler = catchAsync(async (req, res) => {
-  await configService.delete(req.verified?.params.id);
+export const deleteConfig: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ConfigDeleteByIdRequestSchema>
+>(async (req, res) => {
+  await configService.delete(req.verified.params.id);
   res.status(200).json(createEmptyResponse());
 });

--- a/apps/server/src/controllers/order.controller.ts
+++ b/apps/server/src/controllers/order.controller.ts
@@ -1,18 +1,25 @@
 import {
   createListResponse,
   createSingleItemResponse,
+  CreateOrderRequestSchema,
+  GetOrderRequestSchema,
+  ListOrdersRequestSchema,
+  UpdateOrderStatusRequestSchema,
 } from "@repo/domain";
 import { RequestHandler } from "express";
 import { orderService } from "../services/order.service.js";
+import { ValidatedRequest } from "../types/validated-request.js";
 import catchAsync from "../utils/catchAsync.js";
 
 /**
  * Create order from cart
  */
-export const createOrder: RequestHandler = catchAsync(async (req, res) => {
+export const createOrder: RequestHandler = catchAsync<
+  ValidatedRequest<typeof CreateOrderRequestSchema>
+>(async (req, res) => {
   const userId = req.user!.id; // User is set by auth middleware
-  const orderInput = req.verified?.body;
-  
+  const orderInput = req.verified.body;
+
   const dto = await orderService.createOrder(userId, orderInput);
   res.status(201).json(createSingleItemResponse(dto));
 });
@@ -20,10 +27,12 @@ export const createOrder: RequestHandler = catchAsync(async (req, res) => {
 /**
  * Get order by ID
  */
-export const getOrder: RequestHandler = catchAsync(async (req, res) => {
+export const getOrder: RequestHandler = catchAsync<
+  ValidatedRequest<typeof GetOrderRequestSchema>
+>(async (req, res) => {
   const userId = req.user!.id;
-  const { orderId } = req.verified?.params;
-  
+  const { orderId } = req.verified.params;
+
   const dto = await orderService.getOrderById(userId, orderId);
   res.status(200).json(createSingleItemResponse(dto));
 });
@@ -31,10 +40,12 @@ export const getOrder: RequestHandler = catchAsync(async (req, res) => {
 /**
  * List user's orders
  */
-export const listOrders: RequestHandler = catchAsync(async (req, res) => {
+export const listOrders: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ListOrdersRequestSchema>
+>(async (req, res) => {
   const userId = req.user!.id;
-  const query = req.verified?.query;
-  
+  const query = req.verified.query;
+
   const result = await orderService.listUserOrders(userId, query);
   res.status(200).json(createListResponse(result.data, result.meta));
 });
@@ -42,10 +53,12 @@ export const listOrders: RequestHandler = catchAsync(async (req, res) => {
 /**
  * Update order status (admin only)
  */
-export const updateOrderStatus: RequestHandler = catchAsync(async (req, res) => {
-  const { orderId } = req.verified?.params;
-  const { status } = req.verified?.body;
-  
+export const updateOrderStatus: RequestHandler = catchAsync<
+  ValidatedRequest<typeof UpdateOrderStatusRequestSchema>
+>(async (req, res) => {
+  const { orderId } = req.verified.params;
+  const { status } = req.verified.body;
+
   const dto = await orderService.updateOrderStatus(orderId, status);
   res.status(200).json(createSingleItemResponse(dto));
 });

--- a/apps/server/src/controllers/product.controller.ts
+++ b/apps/server/src/controllers/product.controller.ts
@@ -2,43 +2,56 @@ import {
   createEmptyResponse,
   createListResponse,
   createSingleItemResponse,
+  ProductCreateRequestSchema,
+  ProductDeleteByIdRequestSchema,
+  ProductGetAllRequestSchema,
+  ProductGetByCategorySchema,
+  ProductGetByIdRequestSchema,
+  ProductGetBySlugSchema,
+  ProductGetRelatedByIdRequestSchema,
+  ProductUpdateByIdRequestSchema,
 } from "@repo/domain";
 import { RequestHandler } from "express";
 import { productService } from "../services/product.service.js";
+import { ValidatedRequest } from "../types/validated-request.js";
 import catchAsync from "../utils/catchAsync.js";
 
-export const getAllProducts: RequestHandler = catchAsync(async (req, res) => {
-  const result = await productService.getAll(req.verified?.query);
+export const getAllProducts: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ProductGetAllRequestSchema>
+>(async (req, res) => {
+  const result = await productService.getAll(req.verified.query);
   res.status(200).json(createListResponse(result.data, result.meta));
 });
 
-export const getProductById: RequestHandler = catchAsync(async (req, res) => {
-  const dto = await productService.get(req.verified?.params.id);
+export const getProductById: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ProductGetByIdRequestSchema>
+>(async (req, res) => {
+  const dto = await productService.get(req.verified.params.id);
   res.status(200).json(createSingleItemResponse(dto));
 });
 
-export const getProductBySlug: RequestHandler = catchAsync(async (req, res) => {
-  const dto = await productService.getProductBySlug(req.verified?.params.slug);
+export const getProductBySlug: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ProductGetBySlugSchema>
+>(async (req, res) => {
+  const dto = await productService.getProductBySlug(req.verified.params.slug);
   res.status(200).json(createSingleItemResponse(dto));
 });
 
-export const getRelatedProducts: RequestHandler = catchAsync(
-  async (req, res) => {
-    const result = await productService.getRelatedProducts(
-      req.verified?.params.id
-    );
-    res.status(200).json(createListResponse(result.data, result.meta));
-  }
-);
+export const getRelatedProducts: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ProductGetRelatedByIdRequestSchema>
+>(async (req, res) => {
+  const result = await productService.getRelatedProducts(req.verified.params.id);
+  res.status(200).json(createListResponse(result.data, result.meta));
+});
 
-export const getProductsByCategoryName: RequestHandler = catchAsync(
-  async (req, res) => {
-    const result = await productService.getProductsByCategoryName(
-      req.verified?.params.category
-    );
-    res.status(200).json(createListResponse(result.data, result.meta));
-  }
-);
+export const getProductsByCategoryName: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ProductGetByCategorySchema>
+>(async (req, res) => {
+  const result = await productService.getProductsByCategoryName(
+    req.verified.params.category
+  );
+  res.status(200).json(createListResponse(result.data, result.meta));
+});
 
 // not exactly SingleItemResponse response but ok for now
 export const getShowCaseProducts: RequestHandler = catchAsync(
@@ -57,20 +70,26 @@ export const getFeaturedProduct: RequestHandler = catchAsync(
 
 // * ADMIN CONTROLLERS
 
-export const createProduct: RequestHandler = catchAsync(async (req, res) => {
-  const dto = await productService.create(req.verified?.body);
+export const createProduct: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ProductCreateRequestSchema>
+>(async (req, res) => {
+  const dto = await productService.create(req.verified.body);
   res.status(201).json(createSingleItemResponse(dto));
 });
 
-export const updateProduct: RequestHandler = catchAsync(async (req, res) => {
+export const updateProduct: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ProductUpdateByIdRequestSchema>
+>(async (req, res) => {
   const dto = await productService.update(
-    req.verified?.params.id,
-    req.verified?.body
+    req.verified.params.id,
+    req.verified.body
   );
   res.status(200).json(createSingleItemResponse(dto));
 });
 
-export const deleteProduct: RequestHandler = catchAsync(async (req, res) => {
-  await productService.delete(req.verified?.params.id);
+export const deleteProduct: RequestHandler = catchAsync<
+  ValidatedRequest<typeof ProductDeleteByIdRequestSchema>
+>(async (req, res) => {
+  await productService.delete(req.verified.params.id);
   res.status(200).json(createEmptyResponse());
 });

--- a/apps/server/src/controllers/user.controller.ts
+++ b/apps/server/src/controllers/user.controller.ts
@@ -2,9 +2,16 @@ import {
   createEmptyResponse,
   createListResponse,
   createSingleItemResponse,
+  UserCreateRequestSchema,
+  UserDeleteByIdRequestSchema,
+  UserGetAllRequestSchema,
+  UserGetByIdRequestSchema,
+  UserUpdateByIdRequestSchema,
+  UserUpdateMeRequestSchema,
 } from "@repo/domain";
 import { RequestHandler } from "express";
 import { userService } from "../services/user.service.js";
+import { ValidatedRequest } from "../types/validated-request.js";
 import catchAsync from "../utils/catchAsync.js";
 
 // Get the authenticated user's own record
@@ -14,8 +21,10 @@ export const getMe: RequestHandler = catchAsync(async (req, res, _next) => {
 });
 
 // Get a single user
-export const getUser: RequestHandler = catchAsync(async (req, res, _next) => {
-  const dto = await userService.get(req.verified?.params.id);
+export const getUser: RequestHandler = catchAsync<
+  ValidatedRequest<typeof UserGetByIdRequestSchema>
+>(async (req, res, _next) => {
+  const dto = await userService.get(req.verified.params.id);
   res.status(200).json(createSingleItemResponse(dto));
 });
 
@@ -25,40 +34,42 @@ export const deleteMe: RequestHandler = catchAsync(async (req, res, _next) => {
 });
 
 // Get all Users
-export const getAllUsers: RequestHandler = catchAsync(
-  async (req, res, _next) => {
-    const result = await userService.getAll(req.verified?.query);
-    res.status(200).json(createListResponse(result.data, result.meta));
-  }
-);
+export const getAllUsers: RequestHandler = catchAsync<
+  ValidatedRequest<typeof UserGetAllRequestSchema>
+>(async (req, res, _next) => {
+  const result = await userService.getAll(req.verified.query);
+  res.status(200).json(createListResponse(result.data, result.meta));
+});
 
 // deleting a user
-export const deleteUser: RequestHandler = catchAsync(
-  async (req, res, _next) => {
-    await userService.delete(req.verified?.params.id);
-    res.status(200).json(createEmptyResponse());
-  }
-);
+export const deleteUser: RequestHandler = catchAsync<
+  ValidatedRequest<typeof UserDeleteByIdRequestSchema>
+>(async (req, res, _next) => {
+  await userService.delete(req.verified.params.id);
+  res.status(200).json(createEmptyResponse());
+});
 
 // updating a single user
-export const updateUser: RequestHandler = catchAsync(
-  async (req, res, _next) => {
-    const dto = await userService.update(
-      req.verified?.params.id,
-      req.verified?.body
-    );
-    res.status(200).json(createSingleItemResponse(dto));
-  }
-);
-
-export const updateMe: RequestHandler = catchAsync(async (req, res, _next) => {
-  const dto = await userService.update(req.user!.id, req.verified?.body);
+export const updateUser: RequestHandler = catchAsync<
+  ValidatedRequest<typeof UserUpdateByIdRequestSchema>
+>(async (req, res, _next) => {
+  const dto = await userService.update(
+    req.verified.params.id,
+    req.verified.body
+  );
   res.status(200).json(createSingleItemResponse(dto));
 });
 
-export const createUser: RequestHandler = catchAsync(
-  async (req, res, _next) => {
-    const dto = await userService.create(req.verified?.body);
-    res.status(201).json(createSingleItemResponse(dto));
-  }
-);
+export const updateMe: RequestHandler = catchAsync<
+  ValidatedRequest<typeof UserUpdateMeRequestSchema>
+>(async (req, res, _next) => {
+  const dto = await userService.update(req.user!.id, req.verified.body);
+  res.status(200).json(createSingleItemResponse(dto));
+});
+
+export const createUser: RequestHandler = catchAsync<
+  ValidatedRequest<typeof UserCreateRequestSchema>
+>(async (req, res, _next) => {
+  const dto = await userService.create(req.verified.body);
+  res.status(201).json(createSingleItemResponse(dto));
+});

--- a/apps/server/src/middlewares/validation.middleware.ts
+++ b/apps/server/src/middlewares/validation.middleware.ts
@@ -29,11 +29,7 @@ export const validateSchema = (schema: ZodType<any>): RequestHandler =>
       );
     }
 
-    req.verified = {
-      params: parsedRequest.data.params,
-      body: parsedRequest.data.body,
-      query: parsedRequest.data.query,
-    };
+    req.verified = parsedRequest.data;
 
     return next();
   });

--- a/apps/server/src/types/express.d.ts
+++ b/apps/server/src/types/express.d.ts
@@ -1,0 +1,8 @@
+// `verified` is `unknown` so that intersecting it in `ValidatedRequest` collapses
+// to the request schema's inferred type instead of widening it.
+declare namespace Express {
+  interface Request {
+    user?: import("@repo/domain").UserPublicInfo;
+    verified?: unknown;
+  }
+}

--- a/apps/server/src/types/validated-request.ts
+++ b/apps/server/src/types/validated-request.ts
@@ -1,0 +1,7 @@
+import { Request } from "express";
+import { ZodType, z } from "zod";
+
+// Narrows `req.verified` to the type inferred from the route's request schema.
+export type ValidatedRequest<S extends ZodType> = Request & {
+  verified: z.infer<S>;
+};

--- a/apps/server/src/utils/catchAsync.ts
+++ b/apps/server/src/utils/catchAsync.ts
@@ -1,8 +1,8 @@
-import { NextFunction, Request, Response } from "express";
+import { NextFunction, Request, RequestHandler, Response } from "express";
 
 export default <TRequest extends Request = Request>(
-    fn: (req: TRequest, res: Response, next: NextFunction) => Promise<any>
-  ) =>
-  (req: TRequest, res: Response, next: NextFunction) => {
-    fn(req, res, next).catch((err: Error) => next(err));
+    fn: (req: TRequest, res: Response, next: NextFunction) => Promise<unknown>
+  ): RequestHandler =>
+  (req, res, next) => {
+    fn(req as TRequest, res, next).catch((err: Error) => next(err));
   };

--- a/apps/server/test/validated-request.test-d.ts
+++ b/apps/server/test/validated-request.test-d.ts
@@ -1,0 +1,49 @@
+import type {
+  GetOrderRequestSchema,
+  ProductGetAllRequestSchema,
+  UpdateOrderStatusRequestSchema,
+} from "@repo/domain";
+import type { RequestHandler } from "express";
+import { describe, expectTypeOf, it } from "vitest";
+import type { ValidatedRequest } from "../src/types/validated-request.js";
+import catchAsync from "../src/utils/catchAsync.js";
+
+describe("ValidatedRequest", () => {
+  it("narrows req.verified to the schema's inferred type", () => {
+    catchAsync<ValidatedRequest<typeof UpdateOrderStatusRequestSchema>>(
+      async (req) => {
+        expectTypeOf(req.verified.params).toEqualTypeOf<{ orderId: string }>();
+        expectTypeOf(req.verified.body.status).toEqualTypeOf<
+          "PENDING" | "PROCESSING" | "SHIPPED" | "DELIVERED" | "CANCELLED"
+        >();
+      }
+    );
+
+    catchAsync<ValidatedRequest<typeof ProductGetAllRequestSchema>>(
+      async (req) => {
+        expectTypeOf(req.verified.query.name).toEqualTypeOf<
+          string | undefined
+        >();
+      }
+    );
+  });
+
+  it("rejects a field the schema does not declare", () => {
+    catchAsync<ValidatedRequest<typeof GetOrderRequestSchema>>(async (req) => {
+      // @ts-expect-error the schema declares `orderId`, not `id`
+      expectTypeOf(req.verified.params.id);
+      // @ts-expect-error this route validates no body
+      expectTypeOf(req.verified.body.status);
+    });
+  });
+
+  it("stays assignable to RequestHandler so routers need no cast", () => {
+    const handler = catchAsync<ValidatedRequest<typeof GetOrderRequestSchema>>(
+      async (req, res) => {
+        res.json({ orderId: req.verified.params.orderId });
+      }
+    );
+
+    expectTypeOf(handler).toExtend<RequestHandler>();
+  });
+});

--- a/packages/domain/src/category.ts
+++ b/packages/domain/src/category.ts
@@ -53,7 +53,7 @@ export const CategoryQueryParamsSchema = BaseQueryParamsSchema.extend({
 }) satisfies z.ZodType<CategoryQueryParams>;
 
 export const CategoryGetAllRequestSchema = createRequestSchema({
-  query: CategoryQueryParamsSchema.optional(),
+  query: CategoryQueryParamsSchema,
 });
 
 // GET - Get single category by ID

--- a/packages/domain/src/common.ts
+++ b/packages/domain/src/common.ts
@@ -234,35 +234,28 @@ export const ApiResponseSchema = <T extends z.ZodTypeAny>(item: T) =>
 
 // ===== Request Schema Helper =====
 
+const EmptyParamsSchema = z.object({}).strict();
+const EmptyBodySchema = z.undefined();
+const EmptyQuerySchema = z.object({});
+
 /**
  * Create a typed request schema that validates params, body, and query
  * All fields are required to be present but may have empty/default objects
  */
 export const createRequestSchema = <
-  P extends z.ZodTypeAny,
-  B extends z.ZodTypeAny,
-  Q extends z.ZodTypeAny,
+  P extends z.ZodTypeAny = typeof EmptyParamsSchema,
+  B extends z.ZodTypeAny = typeof EmptyBodySchema,
+  Q extends z.ZodTypeAny = typeof EmptyQuerySchema,
 >(options?: {
   params?: P;
   body?: B;
   query?: Q;
-}): z.ZodType<RequestSchema> => {
-  return z.object({
-    params: options?.params || z.object({}).strict(),
-    body: options?.body || z.undefined(),
-    query: options?.query || z.object({}),
-  }) as any;
-};
-
-export type RequestSchema<
-  P = Record<string, any>,
-  B = Record<string, any>,
-  Q = Record<string, any>,
-> = {
-  params: P;
-  body: B;
-  query: Q;
-};
+}) =>
+  z.object({
+    params: options?.params ?? EmptyParamsSchema,
+    body: options?.body ?? EmptyBodySchema,
+    query: options?.query ?? EmptyQuerySchema,
+  } as { params: P; body: B; query: Q });
 
 export interface baseQueryParams {
   page?: number;

--- a/packages/domain/src/product.ts
+++ b/packages/domain/src/product.ts
@@ -106,7 +106,7 @@ export const ProductQueryParamsSchema = BaseQueryParamsSchema.extend({
 }) satisfies z.ZodType<ProductQueryParams>;
 
 export const ProductGetAllRequestSchema = createRequestSchema({
-  query: ProductQueryParamsSchema.optional(),
+  query: ProductQueryParamsSchema,
 });
 
 // GET - Get single Product by ID

--- a/packages/domain/src/user.ts
+++ b/packages/domain/src/user.ts
@@ -76,7 +76,7 @@ export const UserQueryParamsSchema = BaseQueryParamsSchema.extend({
 }) satisfies z.ZodType<UserQueryParams>;
 
 export const UserGetAllRequestSchema = createRequestSchema({
-  query: UserQueryParamsSchema.optional(),
+  query: UserQueryParamsSchema,
 });
 
 // CREATE - Create new user - admin only


### PR DESCRIPTION
Closes #103

## What changed

Request schemas were defined in `@repo/domain` but their types never reached controllers.
`createRequestSchema` widened its return to `z.ZodType<RequestSchema>` with `as any`, and the Express
augmentation typed `req.verified` as `Record<string, any>`, so every controller access was `any`
behind optional chaining. Renaming a schema field compiled and failed at runtime.

- **`createRequestSchema`** preserves the inferred `{ params, body, query }` shape via generic
  defaults that carry the empty-schema fallbacks. The now-dead `RequestSchema` type export is
  removed (zero references anywhere).
- **`src/types/express.d.ts`** — the global augmentation moves out of `app.ts` and declares
  `verified?: unknown`, so intersecting it collapses to the schema type instead of widening it.
- **`src/types/validated-request.ts`** — `ValidatedRequest<S>` narrows `req.verified` to `z.infer<S>`.
- **`catchAsync`** takes a narrowed request type and returns `RequestHandler`, so routers accept the
  handlers without casts.
- **All seven controllers** type their handlers from the schema their route validates and drop the
  `?.` / `!` dance — including `req.user?.id!` in `updatePassword`, whose assertion defeated the
  guard on the very next line (flagged in the #103 discussion).

Two mismatches the compiler surfaced once the `any` was gone:

- The three list-query schemas dropped `.optional()`. Express always supplies a query object and
  every `BaseQueryParamsSchema` field is optional, so `{}` still parses — no runtime change.
- `validateSchema` assigns `parsedRequest.data` directly instead of re-picking its three keys.
  Equivalent, since every schema comes from `createRequestSchema` and Zod's `$strip` already
  discards extras.

## Tests

New `test/validated-request.test-d.ts` in the existing `.test-d.ts` harness covers the narrowing,
rejection of undeclared fields, and `RequestHandler` assignability.

Acceptance criterion 1 was also checked empirically: renaming `orderId` to `orderIdentifier` in
`GetOrderRequestSchema` produces two errors in `order.controller.ts`.

`pnpm test` 51 passed (9 files, incl. both type-test suites) · `pnpm lint` 40 warnings vs. the 61
cap · `pnpm build` clean · server, domain and client type-checks clean.

## Follow-up

The schema is still named twice — once in the route, once in the controller — and `catchAsync`'s
`req as TRequest` is unchecked, so the two could drift with a green type-check. #127 tracks binding
them together so the drift is not expressible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)