### PR TITLE
test: route tests per resource against the Express app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,11 @@ pnpm types:watch       # watch mode across all TS projects
 # Quality
 pnpm lint
 pnpm format
-pnpm test          # domain + server vitest suites via Turbo (no database needed)
+pnpm test          # domain + server vitest suites via Turbo (no network database needed)
 ```
 
 ### Running a single workspace
+
 ```bash
 pnpm --filter server run dev
 pnpm --filter client run dev
@@ -72,6 +73,16 @@ All query building (where, select, orderBy) belongs inside `persistFindMany` via
 
 Skip the service layer for simple pass-through CRUD; go controller → Prisma directly.
 
+### Tests
+
+Server route tests run against the real Express `app` through supertest. A vitest `globalSetup`
+boots an in-memory MongoDB replica set (Prisma requires one), pushes the schema for its indexes,
+and hands the URL to `test/helpers/setup.ts`, which sets `DATABASE_URL` before `app` is imported.
+Seed with the fixture builders in `test/helpers/database.ts` and call `resetDatabase` around each
+test; protected routes take a real signed JWT via `authCookie(userId)`. Files share one database,
+so `fileParallelism` is off. The mongod binary is fetched once by `pnpm install` and cached
+globally; `global-setup.ts` pins the version it runs.
+
 ### Validation rules
 
 - Use `.strict()` on all Zod input schemas (rejects unknown fields)
@@ -83,6 +94,7 @@ Skip the service layer for simple pass-through CRUD; go controller → Prisma di
 Default to no comments — names and structure should carry the meaning; rationale belongs in docs/CONTEXT.md, not inline.
 
 Add one only when:
+
 - an existing convention already comments every item in a section (e.g. the numbered middleware steps in `app.ts` — match the existing one-line style), or
 - a genuinely non-obvious constraint needs flagging (a hidden invariant, a workaround, something a reader would get wrong without it).
 
@@ -90,14 +102,14 @@ Even then: one short line. No rationale paragraphs, no restating what the code a
 
 ### Domain package naming
 
-| Suffix | Purpose |
-|--------|---------|
-| `*CreateInput` / `*UpdateInput` | write operations |
-| `*DTO` | read responses |
-| `*WhereInput` | filter params |
-| `*Select` | field selection |
-| `ExtendedQueryParams` | pagination/sorting |
-| `*QueryParams` | one entity's list query: `ExtendedQueryParams<{ filters }>` |
+| Suffix                          | Purpose                                                     |
+| ------------------------------- | ----------------------------------------------------------- |
+| `*CreateInput` / `*UpdateInput` | write operations                                            |
+| `*DTO`                          | read responses                                              |
+| `*WhereInput`                   | filter params                                               |
+| `*Select`                       | field selection                                             |
+| `ExtendedQueryParams`           | pagination/sorting                                          |
+| `*QueryParams`                  | one entity's list query: `ExtendedQueryParams<{ filters }>` |
 
 All exports flow through `packages/domain/src/index.ts`.
 
@@ -136,11 +148,13 @@ Used for cross-cutting concerns (auth, logging, timing). Middleware chain runs p
 ## Environment Variables
 
 **`packages/database/.env`**
+
 ```
 DATABASE_URL=mongodb+srv://...
 ```
 
 **`apps/server/.env`**
+
 ```
 DATABASE_URL=mongodb+srv://...
 NODE_ENV=development

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -41,6 +41,7 @@
     "@types/node": "^24.1.0",
     "@types/supertest": "^7.2.1",
     "eslint": "^9.39.2",
+    "mongodb-memory-server": "^11.2.0",
     "nodemon": "^3.1.10",
     "pino-pretty": "^13.1.3",
     "supertest": "^7.2.2",

--- a/apps/server/src/utils/env.ts
+++ b/apps/server/src/utils/env.ts
@@ -8,11 +8,19 @@ const msDurationStringCheck = z.custom<ms.StringValue>((val) => {
   return ms(val as ms.StringValue) && typeof val === "string";
 }, "Invalid ms duration format");
 
-type ConnectionString =
+type SrvConnectionString =
   `mongodb+srv://${string}:${string}@${string}/${string}?retryWrites=true&w=majority&appName=${string}`;
 
-const connectionStringRegex =
+// A directly addressed host, which is how the in-memory replica set the route
+// tests run against advertises itself.
+type DirectConnectionString = `mongodb://${string}`;
+
+type ConnectionString = SrvConnectionString | DirectConnectionString;
+
+const srvConnectionStringRegex =
   /^mongodb\+srv:\/\/([^:]+):([^@]+)@([^/]+)\/([^?]+)\?retryWrites=true&w=majority&appName=([^&]+)$/;
+
+const directConnectionStringRegex = /^mongodb:\/\/[^/]+\/[^?]+(\?.*)?$/;
 
 const NodeEnvSchema = z.enum(["development", "production", "test"]);
 
@@ -42,8 +50,10 @@ const createEnv = () => {
   const EnvSchema = z.object({
     NODE_ENV: NodeEnvSchema,
     PORT: z.coerce.number().int().min(1000).max(65535),
-    DATABASE_URL: z.custom<ConnectionString>((val) =>
-      connectionStringRegex.test(val as string),
+    DATABASE_URL: z.custom<ConnectionString>(
+      (val) =>
+        srvConnectionStringRegex.test(val as string) ||
+        directConnectionStringRegex.test(val as string),
     ),
     JWT_SECRET: z
       .string()
@@ -55,7 +65,15 @@ const createEnv = () => {
     VITE_APP_PORT: z.coerce.number().int().min(1000).max(65535).optional(),
   });
 
-  const parsedEnv = EnvSchema.safeParse(process.env);
+  const parsedEnv = EnvSchema.refine(
+    (env) =>
+      env.NODE_ENV !== "production" ||
+      srvConnectionStringRegex.test(env.DATABASE_URL),
+    {
+      path: ["DATABASE_URL"],
+      message: "production requires a mongodb+srv connection string",
+    },
+  ).safeParse(process.env);
 
   if (!parsedEnv.success) {
     throw new Error(

--- a/apps/server/test/auth.route.test.ts
+++ b/apps/server/test/auth.route.test.ts
@@ -1,0 +1,133 @@
+import { ErrorCode } from "@repo/domain";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import app from "../src/app.js";
+import {
+  authCookie,
+  createUser,
+  resetDatabase,
+  TEST_PASSWORD,
+} from "./helpers/database.js";
+
+const signupBody = {
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  password: TEST_PASSWORD,
+  passwordConfirm: TEST_PASSWORD,
+};
+
+beforeEach(resetDatabase);
+
+describe("POST /api/v1/auth/signup", () => {
+  it("creates the user and sets a jwt cookie", async () => {
+    const res = await request(app).post("/api/v1/auth/signup").send(signupBody);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      name: signupBody.name,
+      email: signupBody.email,
+      role: "USER",
+    });
+    expect(res.body.data.password).toBeUndefined();
+    expect(res.headers["set-cookie"]?.[0]).toMatch(/^jwt=.+HttpOnly/i);
+  });
+
+  // The unique index this leans on only exists because the global setup pushes
+  // the schema; without it Prisma never raises P2002 and the 409 never happens.
+  it("rejects an email that is already taken", async () => {
+    await createUser({ email: signupBody.email });
+
+    const res = await request(app).post("/api/v1/auth/signup").send(signupBody);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe(ErrorCode.DUPLICATE_ENTRY);
+  });
+
+  it("rejects a passwordConfirm that does not match", async () => {
+    const res = await request(app)
+      .post("/api/v1/auth/signup")
+      .send({ ...signupBody, passwordConfirm: "something-else" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ path: ["body", "passwordConfirm"] }],
+    });
+  });
+});
+
+describe("POST /api/v1/auth/login", () => {
+  it("returns the user for correct credentials", async () => {
+    const user = await createUser({ email: "grace@example.com" });
+
+    const res = await request(app)
+      .post("/api/v1/auth/login")
+      .send({ email: user.email, password: TEST_PASSWORD });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({ id: user.id, email: user.email });
+  });
+
+  it("rejects a wrong password without saying which field was wrong", async () => {
+    const user = await createUser({ email: "hopper@example.com" });
+
+    const res = await request(app)
+      .post("/api/v1/auth/login")
+      .send({ email: user.email, password: "wrong-password" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.INVALID_CREDENTIALS,
+      message: "Incorrect email or password",
+    });
+  });
+});
+
+describe("PATCH /api/v1/auth/updateMyPassword", () => {
+  it("re-issues a cookie for an authenticated user", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .patch("/api/v1/auth/updateMyPassword")
+      .set("Cookie", authCookie(user.id))
+      .send({
+        currentPassword: TEST_PASSWORD,
+        password: "new-password-1",
+        passwordConfirm: "new-password-1",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["set-cookie"]?.[0]).toMatch(/^jwt=/);
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    const res = await request(app).patch("/api/v1/auth/updateMyPassword").send({
+      currentPassword: TEST_PASSWORD,
+      password: "new-password-1",
+      passwordConfirm: "new-password-1",
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe(ErrorCode.UNAUTHORIZED);
+  });
+});
+
+describe("GET /api/v1/auth/status", () => {
+  it("reports a signed-in user as authenticated", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/auth/status")
+      .set("Cookie", authCookie(user.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ isAuthenticated: true });
+  });
+
+  it("reports an anonymous caller as not authenticated", async () => {
+    const res = await request(app).get("/api/v1/auth/status");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ isAuthenticated: false });
+  });
+});

--- a/apps/server/test/cart.route.test.ts
+++ b/apps/server/test/cart.route.test.ts
@@ -1,0 +1,146 @@
+import { ErrorCode } from "@repo/domain";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import app from "../src/app.js";
+import {
+  ABSENT_ID,
+  authCookie,
+  createProduct,
+  createUser,
+  resetDatabase,
+} from "./helpers/database.js";
+
+beforeEach(resetDatabase);
+
+describe("GET /api/v1/cart", () => {
+  it("creates an empty cart on first read", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/cart")
+      .set("Cookie", authCookie(user.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      userId: user.id,
+      items: [],
+      itemCount: 0,
+      subtotal: 0,
+    });
+  });
+
+  it("rejects an anonymous caller", async () => {
+    const res = await request(app).get("/api/v1/cart");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe(ErrorCode.UNAUTHORIZED);
+  });
+});
+
+describe("POST /api/v1/cart", () => {
+  it("adds a product and reports the running subtotal", async () => {
+    const user = await createUser();
+    const product = await createProduct({ price: 300 });
+
+    const res = await request(app)
+      .post("/api/v1/cart")
+      .set("Cookie", authCookie(user.id))
+      .send({ productId: product.id, quantity: 2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({ itemCount: 2, subtotal: 600 });
+    expect(res.body.data.items[0]).toMatchObject({
+      productId: product.id,
+      productPrice: 300,
+      quantity: 2,
+    });
+  });
+
+  it("rejects a malformed product id", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .post("/api/v1/cart")
+      .set("Cookie", authCookie(user.id))
+      .send({ productId: "not-an-id", quantity: 1 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ path: ["body", "productId"] }],
+    });
+  });
+
+  it("returns NOT_FOUND for a product that does not exist", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .post("/api/v1/cart")
+      .set("Cookie", authCookie(user.id))
+      .send({ productId: ABSENT_ID, quantity: 1 });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe(ErrorCode.NOT_FOUND);
+  });
+});
+
+describe("PATCH /api/v1/cart/items/:cartItemId", () => {
+  it("updates the quantity of an item the caller owns", async () => {
+    const user = await createUser();
+    const product = await createProduct({ price: 100 });
+    const cookie = authCookie(user.id);
+
+    const added = await request(app)
+      .post("/api/v1/cart")
+      .set("Cookie", cookie)
+      .send({ productId: product.id, quantity: 1 });
+
+    const res = await request(app)
+      .patch(`/api/v1/cart/items/${added.body.data.items[0].id}`)
+      .set("Cookie", cookie)
+      .send({ quantity: 5 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({ itemCount: 5, subtotal: 500 });
+  });
+
+  // Pins today's 401; an authenticated non-owner arguably deserves 403 (#135).
+  it("refuses to touch another user's cart item", async () => {
+    const owner = await createUser();
+    const intruder = await createUser();
+    const product = await createProduct();
+
+    const added = await request(app)
+      .post("/api/v1/cart")
+      .set("Cookie", authCookie(owner.id))
+      .send({ productId: product.id, quantity: 1 });
+
+    const res = await request(app)
+      .patch(`/api/v1/cart/items/${added.body.data.items[0].id}`)
+      .set("Cookie", authCookie(intruder.id))
+      .send({ quantity: 2 });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe(ErrorCode.UNAUTHORIZED);
+  });
+});
+
+describe("DELETE /api/v1/cart", () => {
+  it("clears every item", async () => {
+    const user = await createUser();
+    const product = await createProduct();
+    const cookie = authCookie(user.id);
+
+    await request(app)
+      .post("/api/v1/cart")
+      .set("Cookie", cookie)
+      .send({ productId: product.id, quantity: 3 });
+
+    const res = await request(app).delete("/api/v1/cart").set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+
+    const after = await request(app).get("/api/v1/cart").set("Cookie", cookie);
+    expect(after.body.data.items).toEqual([]);
+  });
+});

--- a/apps/server/test/category.route.test.ts
+++ b/apps/server/test/category.route.test.ts
@@ -1,0 +1,121 @@
+import { ErrorCode } from "@repo/domain";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import app from "../src/app.js";
+import {
+  authCookie,
+  createAdmin,
+  createCategory,
+  createProduct,
+  createUser,
+  resetDatabase,
+} from "./helpers/database.js";
+
+const thumbnail = {
+  altText: "Speakers",
+  ariaLabel: "Speakers",
+  src: "https://cdn.example.com/speakers.jpg",
+};
+
+beforeEach(resetDatabase);
+
+describe("GET /api/v1/categories", () => {
+  it("lists the seeded categories", async () => {
+    const category = await createCategory("Earphones");
+
+    const res = await request(app).get("/api/v1/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).toMatchObject({
+      id: category.id,
+      name: "Earphones",
+    });
+  });
+});
+
+describe("GET /api/v1/categories/:id", () => {
+  it("returns one category", async () => {
+    const category = await createCategory();
+
+    const res = await request(app).get(`/api/v1/categories/${category.id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: category.id,
+      thumbnail: category.thumbnail,
+    });
+  });
+
+  it("returns VALIDATION_ERROR for a malformed id", async () => {
+    const res = await request(app).get("/api/v1/categories/not-an-id");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ path: ["params", "id"] }],
+    });
+  });
+});
+
+describe("GET /api/v1/categories/:category/products", () => {
+  it("returns the products in that category", async () => {
+    const category = await createCategory("Speakers");
+    const product = await createProduct({ categoryId: category.id });
+
+    const res = await request(app).get("/api/v1/categories/Speakers/products");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe(product.id);
+  });
+
+  it("rejects a category name outside the enum", async () => {
+    const res = await request(app).get(
+      "/api/v1/categories/Turntables/products",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe(ErrorCode.VALIDATION_ERROR);
+  });
+});
+
+describe("POST /api/v1/categories", () => {
+  it("creates a category for an admin", async () => {
+    const admin = await createAdmin();
+
+    const res = await request(app)
+      .post("/api/v1/categories")
+      .set("Cookie", authCookie(admin.id))
+      .send({ name: "Speakers", thumbnail });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({ name: "Speakers", thumbnail });
+  });
+
+  it("refuses a non-admin", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .post("/api/v1/categories")
+      .set("Cookie", authCookie(user.id))
+      .send({ name: "Speakers", thumbnail });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe(ErrorCode.FORBIDDEN);
+  });
+});
+
+describe("DELETE /api/v1/categories/:id", () => {
+  it("deletes a category for an admin", async () => {
+    const admin = await createAdmin();
+    const category = await createCategory();
+
+    const res = await request(app)
+      .delete(`/api/v1/categories/${category.id}`)
+      .set("Cookie", authCookie(admin.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeNull();
+  });
+});

--- a/apps/server/test/config.route.test.ts
+++ b/apps/server/test/config.route.test.ts
@@ -1,0 +1,112 @@
+import { ErrorCode } from "@repo/domain";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import app from "../src/app.js";
+import {
+  ABSENT_ID,
+  authCookie,
+  createAdmin,
+  createConfig,
+  createProduct,
+  createUser,
+  resetDatabase,
+} from "./helpers/database.js";
+
+beforeEach(resetDatabase);
+
+describe("GET /api/v1/config", () => {
+  it("returns the singleton config", async () => {
+    const config = await createConfig();
+
+    const res = await request(app).get("/api/v1/config");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: config.id,
+      featuredProductId: config.featuredProductId,
+    });
+  });
+
+  it("returns null when no config has been seeded", async () => {
+    const res = await request(app).get("/api/v1/config");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeNull();
+  });
+});
+
+describe("POST /api/v1/config", () => {
+  it("creates a config for an admin", async () => {
+    const admin = await createAdmin();
+    const [featured, cover, grid, wide] = await Promise.all([
+      createProduct(),
+      createProduct(),
+      createProduct(),
+      createProduct(),
+    ]);
+
+    const res = await request(app)
+      .post("/api/v1/config")
+      .set("Cookie", authCookie(admin.id))
+      .send({
+        name: "primary",
+        featuredProductId: featured.id,
+        showCaseCoverId: cover.id,
+        showCaseGridId: grid.id,
+        showCaseWideId: wide.id,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      name: "primary",
+      featuredProductId: featured.id,
+    });
+  });
+
+  it("rejects a malformed featured product id", async () => {
+    const admin = await createAdmin();
+
+    const res = await request(app)
+      .post("/api/v1/config")
+      .set("Cookie", authCookie(admin.id))
+      .send({
+        name: "primary",
+        featuredProductId: "not-an-id",
+        showCaseCoverId: ABSENT_ID,
+        showCaseGridId: ABSENT_ID,
+        showCaseWideId: ABSENT_ID,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ path: ["body", "featuredProductId"] }],
+    });
+  });
+
+  it("refuses a non-admin", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .post("/api/v1/config")
+      .set("Cookie", authCookie(user.id))
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe(ErrorCode.FORBIDDEN);
+  });
+});
+
+describe("DELETE /api/v1/config/:id", () => {
+  it("deletes the config for an admin", async () => {
+    const admin = await createAdmin();
+    const config = await createConfig();
+
+    const res = await request(app)
+      .delete(`/api/v1/config/${config.id}`)
+      .set("Cookie", authCookie(admin.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeNull();
+  });
+});

--- a/apps/server/test/helpers/database.ts
+++ b/apps/server/test/helpers/database.ts
@@ -1,0 +1,137 @@
+import { prisma, type NAME } from "@repo/database";
+import jwt from "jsonwebtoken";
+import { env } from "../../src/utils/env.js";
+
+/**
+ * Fixture builders for the in-memory database. Every test seeds only what it
+ * needs and `resetDatabase` truncates between tests, so nothing carries over.
+ */
+
+let sequence = 0;
+const unique = (prefix: string) => `${prefix}-${++sequence}`;
+
+// Category names come from a three-value enum with a unique index, so products
+// share one category unless a test asks for its own. Memoising the promise (not
+// the row) keeps concurrent `createProduct` calls from racing to create it.
+let sharedCategory: Promise<{ id: string }> | null = null;
+
+const sharedCategoryId = async () => {
+  sharedCategory ??= createCategory();
+  return (await sharedCategory).id;
+};
+
+// Children first: MongoDB has no cascading delete on the server side.
+export const resetDatabase = async () => {
+  sharedCategory = null;
+  await prisma.orderItem.deleteMany();
+  await prisma.order.deleteMany();
+  await prisma.cartItem.deleteMany();
+  await prisma.cart.deleteMany();
+  await prisma.config.deleteMany();
+  await prisma.product.deleteMany();
+  await prisma.category.deleteMany();
+  await prisma.user.deleteMany();
+};
+
+export const TEST_PASSWORD = "password1234";
+
+/** A well-formed ObjectId that no fixture ever creates. */
+export const ABSENT_ID = "0123456789abcdef01234567";
+
+export const createUser = async (
+  overrides: { name?: string; email?: string; role?: "ADMIN" | "USER" } = {},
+) => {
+  const name = overrides.name ?? unique("user");
+  return prisma.user.create({
+    data: {
+      name,
+      email: overrides.email ?? `${name}@example.com`,
+      role: overrides.role ?? "USER",
+      password: TEST_PASSWORD,
+      passwordConfirm: TEST_PASSWORD,
+    },
+  });
+};
+
+export const createAdmin = (
+  overrides: { name?: string; email?: string } = {},
+) => createUser({ ...overrides, role: "ADMIN" });
+
+/** The cookie header a signed-in client sends, using a genuinely signed JWT. */
+export const authCookie = (userId: string) => {
+  const token = jwt.sign({ id: userId }, env.JWT_SECRET, {
+    expiresIn: env.JWT_EXPIRES_IN,
+  });
+  return `jwt=${token}`;
+};
+
+const image = (label: string) => ({
+  altText: `${label} alt`,
+  ariaLabel: `${label} aria`,
+  desktopSrc: `https://cdn.example.com/${label}-desktop.jpg`,
+  mobileSrc: `https://cdn.example.com/${label}-mobile.jpg`,
+  tabletSrc: `https://cdn.example.com/${label}-tablet.jpg`,
+});
+
+const thumbnail = (label: string) => ({
+  altText: `${label} alt`,
+  ariaLabel: `${label} aria`,
+  src: `https://cdn.example.com/${label}-thumb.jpg`,
+});
+
+export const createCategory = (name: NAME = "Headphones") =>
+  prisma.category.create({
+    data: { name, thumbnail: thumbnail(name.toLowerCase()) },
+  });
+
+export const createProduct = async (
+  overrides: { categoryId?: string; price?: number; slug?: string } = {},
+) => {
+  const categoryId = overrides.categoryId ?? (await sharedCategoryId());
+  const label = unique("product");
+
+  return prisma.product.create({
+    data: {
+      categoryId,
+      cartLabel: label,
+      name: label,
+      shortLabel: label,
+      slug: overrides.slug ?? label,
+      description: `${label} description`,
+      price: overrides.price ?? 1000,
+      fullLabel: [label],
+      featuresText: [`${label} feature`],
+      featuredImageText: null,
+      showCaseImageText: null,
+      includedItems: [{ item: "Cable", quantity: 1 }],
+      images: {
+        galleryImages: [image(`${label}-gallery`)],
+        introImage: image(`${label}-intro`),
+        primaryImage: image(`${label}-primary`),
+        relatedProductImage: image(`${label}-related`),
+        thumbnail: thumbnail(label),
+      },
+    },
+  });
+};
+
+/** The singleton config row, with a distinct product behind each slot. */
+export const createConfig = async () => {
+  const categoryId = await sharedCategoryId();
+  const [featured, cover, grid, wide] = await Promise.all([
+    createProduct({ categoryId }),
+    createProduct({ categoryId }),
+    createProduct({ categoryId }),
+    createProduct({ categoryId }),
+  ]);
+
+  return prisma.config.create({
+    data: {
+      name: unique("config"),
+      featuredProductId: featured.id,
+      showCaseCoverId: cover.id,
+      showCaseGridId: grid.id,
+      showCaseWideId: wide.id,
+    },
+  });
+};

--- a/apps/server/test/helpers/global-setup.ts
+++ b/apps/server/test/helpers/global-setup.ts
@@ -1,0 +1,64 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { MongoMemoryReplSet } from "mongodb-memory-server";
+import type { TestProject } from "vitest/node";
+
+const run = promisify(execFile);
+
+// Pinned so a run does not silently change engine version; the binary is
+// downloaded once at install time and cached globally after that.
+const MONGODB_VERSION = "8.2.6";
+
+declare module "vitest" {
+  interface ProvidedContext {
+    databaseUrl: string;
+  }
+}
+
+// Prisma refuses to talk to a standalone mongod, so the in-memory server has to
+// be a replica set even though a single node is all the suite needs.
+const startDatabase = () =>
+  MongoMemoryReplSet.create({
+    binary: { version: MONGODB_VERSION },
+    replSet: { count: 1, storageEngine: "wiredTiger" },
+  });
+
+// MongoDB creates collections on first write, but the unique indexes only exist
+// once the schema is pushed - and tests assert on the 409 they raise.
+const pushSchema = (databaseUrl: string) =>
+  run(
+    "pnpm",
+    [
+      "--filter",
+      "@repo/database",
+      "exec",
+      "prisma",
+      "db",
+      "push",
+      "--skip-generate",
+    ],
+    {
+      cwd: fileURLToPath(new URL("../../../..", import.meta.url)),
+      // `prisma.config.ts` loads dotenv, and the package's own `.env` points at
+      // the real cluster. Pointing dotenv at nothing keeps it out of reach
+      // rather than trusting it not to override.
+      env: {
+        ...process.env,
+        DATABASE_URL: databaseUrl,
+        DOTENV_CONFIG_PATH: "/dev/null",
+      },
+    },
+  );
+
+export default async function setup({ provide }: TestProject) {
+  const replSet = await startDatabase();
+  const databaseUrl = replSet.getUri("audiophile-test");
+
+  await pushSchema(databaseUrl);
+  provide("databaseUrl", databaseUrl);
+
+  return async () => {
+    await replSet.stop();
+  };
+}

--- a/apps/server/test/helpers/setup.ts
+++ b/apps/server/test/helpers/setup.ts
@@ -1,0 +1,6 @@
+import { inject } from "vitest";
+
+// `src/utils/env.ts` and the Prisma client both read DATABASE_URL at import
+// time, so the in-memory server's address has to land here, before the first
+// test file pulls in the app.
+process.env.DATABASE_URL = inject("databaseUrl");

--- a/apps/server/test/order.route.test.ts
+++ b/apps/server/test/order.route.test.ts
@@ -1,0 +1,181 @@
+import { ErrorCode } from "@repo/domain";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import app from "../src/app.js";
+import {
+  authCookie,
+  createAdmin,
+  createProduct,
+  createUser,
+  resetDatabase,
+} from "./helpers/database.js";
+
+const checkout = {
+  shippingAddress: {
+    fullName: "Ada Lovelace",
+    email: "ada@example.com",
+    phone: "555-0100",
+    address: "1 Analytical Way",
+    city: "London",
+    state: "London",
+    zipCode: "E1 6AN",
+    country: "UK",
+  },
+  billingAddress: {
+    fullName: "Ada Lovelace",
+    address: "1 Analytical Way",
+    city: "London",
+    state: "London",
+    zipCode: "E1 6AN",
+    country: "UK",
+  },
+  paymentMethod: "e-Money",
+};
+
+const orderFromCart = async (userId: string, price: number) => {
+  const product = await createProduct({ price });
+  const cookie = authCookie(userId);
+
+  await request(app)
+    .post("/api/v1/cart")
+    .set("Cookie", cookie)
+    .send({ productId: product.id, quantity: 1 });
+
+  const res = await request(app)
+    .post("/api/v1/orders")
+    .set("Cookie", cookie)
+    .send(checkout);
+
+  return { cookie, res };
+};
+
+beforeEach(resetDatabase);
+
+describe("POST /api/v1/orders", () => {
+  it("turns the cart into an order and empties it", async () => {
+    const user = await createUser();
+    const { cookie, res } = await orderFromCart(user.id, 1000);
+
+    expect(res.status).toBe(201);
+    // 1000 subtotal + 50 flat shipping + 20% tax
+    expect(res.body.data).toMatchObject({
+      userId: user.id,
+      status: "PENDING",
+      paymentStatus: "PENDING",
+      subtotal: 1000,
+      shippingCost: 50,
+      tax: 200,
+      total: 1250,
+    });
+    expect(res.body.data.items).toHaveLength(1);
+
+    const cart = await request(app).get("/api/v1/cart").set("Cookie", cookie);
+    expect(cart.body.data.items).toEqual([]);
+  });
+
+  it("refuses to order from an empty cart", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .post("/api/v1/orders")
+      .set("Cookie", authCookie(user.id))
+      .send(checkout);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe(ErrorCode.CART_EMPTY);
+  });
+
+  it("rejects a checkout missing a shipping field", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .post("/api/v1/orders")
+      .set("Cookie", authCookie(user.id))
+      .send({
+        ...checkout,
+        shippingAddress: { ...checkout.shippingAddress, city: "" },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ path: ["body", "shippingAddress", "city"] }],
+    });
+  });
+});
+
+describe("GET /api/v1/orders", () => {
+  it("lists only the caller's orders", async () => {
+    const user = await createUser();
+    const { cookie } = await orderFromCart(user.id, 500);
+
+    const res = await request(app).get("/api/v1/orders").set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.meta).toMatchObject({ page: 1, limit: 10, total: 1 });
+
+    const other = await createUser();
+    const otherRes = await request(app)
+      .get("/api/v1/orders")
+      .set("Cookie", authCookie(other.id));
+    expect(otherRes.body.data).toEqual([]);
+  });
+});
+
+describe("GET /api/v1/orders/:orderId", () => {
+  it("returns the caller's own order", async () => {
+    const user = await createUser();
+    const { cookie, res: created } = await orderFromCart(user.id, 800);
+
+    const res = await request(app)
+      .get(`/api/v1/orders/${created.body.data.id}`)
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(created.body.data.id);
+  });
+
+  it("returns VALIDATION_ERROR for a malformed order id", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/orders/not-an-id")
+      .set("Cookie", authCookie(user.id));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ path: ["params", "orderId"] }],
+    });
+  });
+});
+
+describe("PATCH /api/v1/orders/:orderId/status", () => {
+  it("moves the order on for an admin", async () => {
+    const user = await createUser();
+    const admin = await createAdmin();
+    const { res: created } = await orderFromCart(user.id, 400);
+
+    const res = await request(app)
+      .patch(`/api/v1/orders/${created.body.data.id}/status`)
+      .set("Cookie", authCookie(admin.id))
+      .send({ status: "SHIPPED" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("SHIPPED");
+  });
+
+  it("refuses a non-admin", async () => {
+    const user = await createUser();
+    const { cookie, res: created } = await orderFromCart(user.id, 400);
+
+    const res = await request(app)
+      .patch(`/api/v1/orders/${created.body.data.id}/status`)
+      .set("Cookie", cookie)
+      .send({ status: "SHIPPED" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe(ErrorCode.FORBIDDEN);
+  });
+});

--- a/apps/server/test/product.route.test.ts
+++ b/apps/server/test/product.route.test.ts
@@ -1,14 +1,47 @@
 import { ErrorCode } from "@repo/domain";
 import request from "supertest";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import app from "../src/app.js";
+import {
+  ABSENT_ID,
+  authCookie,
+  createAdmin,
+  createProduct,
+  resetDatabase,
+} from "./helpers/database.js";
 
-// Exercises the real Express app end to end without a database: the malformed
-// id is rejected by `validateSchema` before any controller runs, and the
-// resulting AppError is shaped by the global error middleware. The status is
-// whatever `getStatusCode(VALIDATION_ERROR)` maps to (400 today).
+beforeEach(resetDatabase);
+
+describe("GET /api/v1/products", () => {
+  it("lists the seeded products", async () => {
+    const product = await createProduct();
+
+    const res = await request(app).get("/api/v1/products");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe(product.id);
+    expect(res.body.meta).toMatchObject({ page: 1, total: 1 });
+  });
+});
 
 describe("GET /api/v1/products/:id", () => {
+  it("returns one product", async () => {
+    const product = await createProduct({ price: 1499 });
+
+    const res = await request(app).get(`/api/v1/products/${product.id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: product.id,
+      slug: product.slug,
+      price: 1499,
+    });
+  });
+
+  // Exercises the real Express app end to end: the malformed id is rejected by
+  // `validateSchema` before any controller runs, and the resulting AppError is
+  // shaped by the global error middleware.
   it("returns VALIDATION_ERROR for a malformed id", async () => {
     const res = await request(app).get("/api/v1/products/not-an-id");
 
@@ -22,5 +55,49 @@ describe("GET /api/v1/products/:id", () => {
         details: [{ path: ["params", "id"] }],
       },
     });
+  });
+
+  it("returns NOT_FOUND for a well-formed id that matches nothing", async () => {
+    const res = await request(app).get(`/api/v1/products/${ABSENT_ID}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe(ErrorCode.NOT_FOUND);
+  });
+});
+
+describe("GET /api/v1/products/slug/:slug", () => {
+  it("returns the product with that slug", async () => {
+    const product = await createProduct({ slug: "xx99-mark-two" });
+
+    const res = await request(app).get("/api/v1/products/slug/xx99-mark-two");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(product.id);
+  });
+});
+
+describe("DELETE /api/v1/products/:id", () => {
+  it("deletes a product for an admin", async () => {
+    const admin = await createAdmin();
+    const product = await createProduct();
+
+    const res = await request(app)
+      .delete(`/api/v1/products/${product.id}`)
+      .set("Cookie", authCookie(admin.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeNull();
+
+    const after = await request(app).get(`/api/v1/products/${product.id}`);
+    expect(after.status).toBe(404);
+  });
+
+  it("rejects an anonymous caller", async () => {
+    const product = await createProduct();
+
+    const res = await request(app).delete(`/api/v1/products/${product.id}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe(ErrorCode.UNAUTHORIZED);
   });
 });

--- a/apps/server/test/user.route.test.ts
+++ b/apps/server/test/user.route.test.ts
@@ -1,0 +1,104 @@
+import { ErrorCode } from "@repo/domain";
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import app from "../src/app.js";
+import {
+  authCookie,
+  createAdmin,
+  createUser,
+  resetDatabase,
+} from "./helpers/database.js";
+
+beforeEach(resetDatabase);
+
+describe("GET /api/v1/users/me", () => {
+  it("returns the signed-in user", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/users/me")
+      .set("Cookie", authCookie(user.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      id: user.id,
+      email: user.email,
+      role: "USER",
+    });
+  });
+
+  it("rejects an anonymous caller", async () => {
+    const res = await request(app).get("/api/v1/users/me");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe(ErrorCode.UNAUTHORIZED);
+  });
+});
+
+describe("PATCH /api/v1/users/updateMe", () => {
+  it("updates the name", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .patch("/api/v1/users/updateMe")
+      .set("Cookie", authCookie(user.id))
+      .send({ name: "Renamed" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe("Renamed");
+  });
+
+  it("rejects an unknown field", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .patch("/api/v1/users/updateMe")
+      .set("Cookie", authCookie(user.id))
+      .send({ role: "ADMIN" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe(ErrorCode.VALIDATION_ERROR);
+  });
+});
+
+describe("GET /api/v1/users", () => {
+  it("lists users for an admin", async () => {
+    const admin = await createAdmin();
+    await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/users")
+      .set("Cookie", authCookie(admin.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.meta).toMatchObject({ page: 1, total: 2 });
+  });
+
+  it("refuses a non-admin", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/users")
+      .set("Cookie", authCookie(user.id));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe(ErrorCode.FORBIDDEN);
+  });
+});
+
+describe("GET /api/v1/users/:id", () => {
+  it("returns VALIDATION_ERROR for a malformed id", async () => {
+    const admin = await createAdmin();
+
+    const res = await request(app)
+      .get("/api/v1/users/not-an-id")
+      .set("Cookie", authCookie(admin.id));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ path: ["params", "id"] }],
+    });
+  });
+});

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -3,20 +3,24 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
+    globalSetup: ["./test/helpers/global-setup.ts"],
+    setupFiles: ["./test/helpers/setup.ts"],
+    // Every file talks to the same in-memory database and truncates it between
+    // tests, so they cannot run side by side.
+    fileParallelism: false,
     typecheck: {
       enabled: true,
       tsconfig: "./tsconfig.typecheck.json",
     },
     // `src/utils/env.ts` validates process.env at import time, and `app.ts`
     // imports it, so every value the schema requires has to be present before
-    // the first test file loads. These are placeholders: no test connects to
-    // the database or signs a token, and dotenv never overrides an existing
-    // variable, so a local `.env` cannot leak into a test run.
+    // the first test file loads. DATABASE_URL is the exception: the global
+    // setup boots an in-memory replica set and `test/helpers/setup.ts` injects
+    // its address. dotenv never overrides an existing variable, so a local
+    // `.env` cannot leak into a test run.
     env: {
       NODE_ENV: "test",
       PORT: "8000",
-      DATABASE_URL:
-        "mongodb+srv://user:pass@cluster.example.net/test?retryWrites=true&w=majority&appName=test",
       JWT_SECRET: "test-secret-that-is-at-least-32-characters",
       JWT_EXPIRES_IN: "90d",
       JWT_COOKIE_EXPIRES_IN: "1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
+      mongodb-memory-server:
+        specifier: ^11.2.0
+        version: 11.2.0
       nodemon:
         specifier: ^3.1.10
         version: 3.1.11
@@ -870,6 +873,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mongodb-js/saslprep@1.5.0':
+    resolution: {integrity: sha512-Hk1SKJCMcCos38+vqDnZzlIo4XRj9yCGzYkjB4LcqpeXRIYfia1UWTz+VrueLxoU+uSRJzgkufxoRZg8gi52YA==}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -1796,6 +1802,12 @@ packages:
   '@types/supertest@7.2.1':
     resolution: {integrity: sha512-4CbBvoYVLHL7+yhbYrZET0vsvuyXTC05aRe7dNQkwMzm56auceoy6Yu3K50uZmwfHna1os3CMSgM/3QVkUtPTw==}
 
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
   '@typescript-eslint/eslint-plugin@8.49.0':
     resolution: {integrity: sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1904,6 +1916,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1944,6 +1960,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -1954,8 +1973,53 @@ packages:
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bare-events@2.9.2:
+    resolution: {integrity: sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.8.1:
+    resolution: {integrity: sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==}
+    engines: {bare: '>=1.28.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.2:
+    resolution: {integrity: sha512-ZyKbsuuqK6Ag0K8pX6V5Txq6XeJRvY+wXucnFGRjiyVYP9YWDpIQugk/b+enRYrEYBJaqLzghRQpXPMR7341Nw==}
+
+  bare-stream@2.13.4:
+    resolution: {integrity: sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.5.4:
+    resolution: {integrity: sha512-Gxa7UVWBr0/edU1b+TJhn/AZvMQUj9OGspvYsaTYQrAbZA4BOTZGL3LiZxvD+CeMlDH4juwD84+eTAp/bLYW5g==}
 
   baseline-browser-mapping@2.9.7:
     resolution: {integrity: sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==}
@@ -1987,6 +2051,10 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bson@7.3.2:
+    resolution: {integrity: sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==}
+    engines: {node: '>=20.19.0'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -2079,6 +2147,9 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
@@ -2381,6 +2452,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -2407,6 +2481,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -2443,6 +2520,14 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-cache-dir@3.3.2:
+    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2459,6 +2544,15 @@ packages:
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -2581,6 +2675,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.7.1:
     resolution: {integrity: sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==}
@@ -2787,6 +2885,10 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2832,6 +2934,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2839,6 +2945,9 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -2886,6 +2995,45 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
+  mongodb-connection-string-url@7.0.2:
+    resolution: {integrity: sha512-ZoS07RoFqpKYQwAk59qmrx8+jJHNHU30UjlU96QktiGn1ltvDr+vCznLX5DiUBLEpMAHatHNWV1nM/74ul66kA==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb-memory-server-core@11.2.0:
+    resolution: {integrity: sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb-memory-server@11.2.0:
+    resolution: {integrity: sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb@7.6.0:
+    resolution: {integrity: sha512-WbZ6OCjYw2c53LOjfkQa+reXr7kIiOVpXXglnASFuiMtif0BvsMwHe3ClJHLm1/r7wJFwaasfFtD6iYIktB01g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: ^7.2.0
+      snappy: ^7.3.2
+      socks: ^2.8.6
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2903,6 +3051,10 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  new-find-package-json@2.0.0:
+    resolution: {integrity: sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==}
+    engines: {node: '>=12.22.0'}
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
@@ -2965,13 +3117,25 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -3010,6 +3174,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -3044,6 +3211,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -3407,6 +3578,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -3420,6 +3594,9 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  streamx@2.28.1:
+    resolution: {integrity: sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3484,6 +3661,15 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-stream@3.2.1:
+    resolution: {integrity: sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -3524,6 +3710,10 @@ packages:
   touch@3.1.1:
     resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
     hasBin: true
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3788,6 +3978,14 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3815,6 +4013,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4198,6 +4400,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mongodb-js/saslprep@1.5.0':
+    dependencies:
+      sparse-bitfield: 3.0.3
 
   '@noble/hashes@1.8.0': {}
 
@@ -5054,6 +5260,12 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.11
 
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -5248,6 +5460,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5282,6 +5496,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
+
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
@@ -5294,7 +5512,38 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
+
+  bare-events@2.9.2: {}
+
+  bare-fs@4.8.1:
+    dependencies:
+      bare-events: 2.9.2
+      bare-path: 3.1.2
+      bare-stream: 2.13.4(bare-events@2.9.2)
+      bare-url: 2.5.4
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.2: {}
+
+  bare-stream@2.13.4(bare-events@2.9.2):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.1
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.5.4:
+    dependencies:
+      bare-path: 3.1.2
 
   baseline-browser-mapping@2.9.7: {}
 
@@ -5339,6 +5588,8 @@ snapshots:
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.2(browserslist@4.28.1)
+
+  bson@7.3.2: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -5430,6 +5681,8 @@ snapshots:
   commander@14.0.2: {}
 
   commander@4.1.1: {}
+
+  commondir@1.0.1: {}
 
   component-emitter@1.3.1: {}
 
@@ -5751,6 +6004,12 @@ snapshots:
 
   etag@1.8.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   expect-type@1.4.0: {}
 
   express-rate-limit@8.2.1(express@5.2.1):
@@ -5801,6 +6060,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -5834,6 +6095,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-cache-dir@3.3.2:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -5853,6 +6125,10 @@ snapshots:
   flatted@3.3.3: {}
 
   follow-redirects@1.15.11: {}
+
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@5.5.0)
 
   foreground-child@3.3.1:
     dependencies:
@@ -5971,6 +6247,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.7.1:
     dependencies:
@@ -6131,6 +6414,10 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -6169,9 +6456,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
+
+  memory-pager@1.5.0: {}
 
   merge-descriptors@2.0.0: {}
 
@@ -6210,6 +6503,61 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  mongodb-connection-string-url@7.0.2:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb-memory-server-core@11.2.0:
+    dependencies:
+      async-mutex: 0.5.0
+      camelcase: 6.3.0
+      debug: 4.4.3(supports-color@5.5.0)
+      find-cache-dir: 3.3.2
+      follow-redirects: 1.16.0(debug@4.4.3)
+      https-proxy-agent: 7.0.6
+      mongodb: 7.6.0
+      new-find-package-json: 2.0.0
+      semver: 7.7.3
+      tar-stream: 3.2.1
+      tslib: 2.8.1
+      yauzl: 3.4.0
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
+  mongodb-memory-server@11.2.0:
+    dependencies:
+      mongodb-memory-server-core: 11.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - bare-abort-controller
+      - bare-buffer
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - react-native-b4a
+      - snappy
+      - socks
+      - supports-color
+
+  mongodb@7.6.0:
+    dependencies:
+      '@mongodb-js/saslprep': 1.5.0
+      bson: 7.3.2
+      mongodb-connection-string-url: 7.0.2
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -6223,6 +6571,12 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  new-find-package-json@2.0.0:
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
 
   no-case@3.0.4:
     dependencies:
@@ -6287,13 +6641,23 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -6324,6 +6688,8 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pend@1.2.0: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -6377,6 +6743,10 @@ snapshots:
       thread-stream: 4.2.0
 
   pirates@4.0.7: {}
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
 
   pkg-types@1.3.1:
     dependencies:
@@ -6693,6 +7063,10 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
+
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
@@ -6700,6 +7074,15 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@4.2.0: {}
+
+  streamx@2.28.1:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   string-width@4.2.3:
     dependencies:
@@ -6777,6 +7160,30 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-stream@3.2.1:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -6809,6 +7216,10 @@ snapshots:
   toidentifier@1.0.1: {}
 
   touch@3.1.1: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -7029,6 +7440,13 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -7055,6 +7473,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   yallist@3.1.1: {}
+
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,9 @@ packages:
   - packages/*
 
 onlyBuiltDependencies:
-  - '@prisma/client'
-  - '@prisma/engines'
+  - "@prisma/client"
+  - "@prisma/engines"
   - bcrypt
   - esbuild
+  - mongodb-memory-server
   - prisma


### PR DESCRIPTION
Every resource (auth, users, products, categories, cart, orders, config) now has a supertest file
that drives the real Express app through the full chain — validation middleware, controller,
service, Prisma, error middleware — covering at least one happy path and one validation failure
each. 103 tests, ~18s, no network database.

## How the database works

A vitest `globalSetup` boots an in-memory MongoDB replica set (Prisma refuses a standalone mongod)
and pushes the schema, so the unique indexes tests rely on exist. `test/helpers/setup.ts` puts its
URL in `DATABASE_URL` before `app` — and the Prisma client — are imported.

`test/helpers/database.ts` holds the fixture builders, `resetDatabase`, and `authCookie(userId)`,
which signs a genuine JWT so protected routes are exercised *through* `authenticate` rather than
around it.

## Two production-facing changes

- **`env.ts` accepts a directly addressed `mongodb://` URL, but only outside production.** A
  refinement keeps the Atlas `mongodb+srv://` contract intact where it matters. Verified across all
  three `NODE_ENV` values: the direct form passes in development and test, is rejected in
  production, and `mongodb+srv://` still passes in production.
- **`mongodb-memory-server` added to `onlyBuiltDependencies`**, so the mongod binary is fetched at
  install time rather than on the first test run.

## From code review

- The schema push runs with `DOTENV_CONFIG_PATH` pointed at nothing. `prisma.config.ts` loads
  dotenv and `packages/database/.env` holds the real Atlas string — it worked only because dotenv
  does not override an existing variable. Now the real cluster is out of reach rather than merely
  unlikely to be hit.
- mongod version pinned, so a run cannot silently change engine version.
- A duplicate-email signup test makes the index push load-bearing rather than decorative.
- `fileParallelism` off: every file shares the one database and truncates it.

## Verification

`turbo run test --force` with nothing cached and every package rebuilt: 15 files, 103 tests, no
type errors, ~20s including builds. `pnpm lint` clean.

## Follow-ups filed, not fixed here

- #135 — cart and order ownership failures return 401 where 403 fits better. That is a product bug,
  not a test bug, so the tests pin current behaviour and cross-reference the ticket.
- #136 — whether to allow running against an external MongoDB instead of the in-memory one. Filed
  as a decision, with the trade-off and the conditions that would make it worth doing.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)