### PR TITLE
chore: fix root prettier, add format:check and .prettierignore

### DIFF
--- a/.claude/skills/batch-tickets/SKILL.md
+++ b/.claude/skills/batch-tickets/SKILL.md
@@ -16,47 +16,55 @@ conflicts are impossible.
    - a range (`105-130`) → `gh issue list --state open --json number,title` filtered to that range.
      A range regularly contains closed or non-existent numbers; only work open ones and say which you dropped.
    - bare numbers → use them as given.
-   Order the list ascending unless the user gave an order. Do not ask for approval of the list —
-   print it and proceed.
+     Order the list ascending unless the user gave an order. Do not ask for approval of the list —
+     print it and proceed.
 2. **Check the tree is clean and `main` is current**: `git switch main && git pull`. Abort the whole
    batch if the tree is dirty; that is the user's uncommitted work.
 3. **Announce the gate**: this repo has no PR CI, so `pnpm build && pnpm lint && pnpm test` run
-   locally *is* the merge gate.
+   locally _is_ the merge gate.
 
 ## Per-ticket loop
 
 For each issue number `N`, in order:
 
 ### 1. Read
+
 `gh issue view N --comments`. Extract the ask, the acceptance criteria, and any decisions made in
 comments. Pick the conventional-commit `<type>` matching the bulk of the change.
 
 ### 2. Branch
+
 ```bash
 git switch main && git pull
 git switch -c <type>/N-<slug>
 ```
+
 `<slug>` is 2–5 kebab-case words from the title. Convention lives in `docs/agents/issue-tracker.md`.
 
 ### 3. Delegate
+
 Spawn **one** subagent (`general-purpose`, `run_in_background: false` — the batch is sequential and
 nothing else can proceed until it returns). Give it:
+
 - the full issue body and relevant comments, pasted in — it cannot see this conversation
 - the branch it is already on, and that it must **not** commit, push, merge, or switch branches
 - the repo conventions it must follow (point it at `CLAUDE.md`)
 - an instruction to report what it changed and anything it deliberately left out
 
 ### 4. Verify
+
 ```bash
 pnpm build && pnpm lint && pnpm test
 ```
+
 All three must pass. There is no working root type-check script (see #134); `pnpm build` is what
 type-checks the packages. Skip `pnpm format` — it is broken at the root (see #131).
 
 **On failure**: make one focused attempt to fix it yourself. If it still fails, this ticket is a
-**miss** — go to *Handling a miss* below and move on to the next ticket. Never merge red.
+**miss** — go to _Handling a miss_ below and move on to the next ticket. Never merge red.
 
 ### 5. Land
+
 ```bash
 git add <the paths the subagent reported>   # never `git add -A` — unrelated untracked files exist
 git commit   # conventional-commit subject; body ends with "Closes #N"
@@ -66,15 +74,18 @@ gh pr merge <pr> --squash --delete-branch
 git switch main && git pull && git branch -d <branch>
 git fetch --prune   # gh deletes the remote branch; this clears the stale tracking ref
 ```
+
 Commit messages end with the `Co-Authored-By` trailer from the session's attribution rules; PR bodies
 end with the generated-with line.
 
 ### 6. Record
+
 Append one row to the running report: ticket, title, outcome, PR link, one-line summary of the change.
 
 ## Handling a miss
 
 Do not stop the batch. For the failed ticket:
+
 - leave the branch pushed and the PR open (create it if you had not yet), titled with a `[WIP]` prefix
 - `gh issue comment N` with what failed and the verification output
 - `git switch main && git pull` so the next ticket starts clean
@@ -87,6 +98,7 @@ pull cleanly, or three tickets in a row fail verification (something systemic is
 
 Print a markdown table — ticket, title, outcome (shipped / failed / skipped), PR link, note — followed
 by:
+
 - what landed on `main`, as a short list of squashed commits
 - every failed ticket with its open PR link and what a human needs to do
 - any ticket whose scope you narrowed, and what you left out

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+build/
+generated/
+coverage/
+.turbo/
+pnpm-lock.yaml

--- a/apps/client/.prettierrc
+++ b/apps/client/.prettierrc
@@ -1,6 +1,5 @@
 {
   "plugins": ["prettier-plugin-tailwindcss"],
-  "pluginSearchDirs": false,
   "tailwindAttributes": [
     "classes",
     "className",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -54,8 +54,6 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
-    "prettier": "^3.6.2",
-    "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^4.1.11",
     "tw-animate-css": "^1.3.6",
     "typescript": "~5.8.3",

--- a/apps/client/src/app/routes/auth/login.tsx
+++ b/apps/client/src/app/routes/auth/login.tsx
@@ -4,7 +4,7 @@ import { Metadata } from "@/components/seo/metadata";
 
 export default function LoginPage() {
   return (
-    <Section classes="tracking-200 max-w-md min-w-xs">
+    <Section classes="tracking-200 min-w-xs max-w-md">
       <Metadata title="Login" noIndex />
       <LoginForm />
     </Section>

--- a/apps/client/src/app/routes/auth/signup.tsx
+++ b/apps/client/src/app/routes/auth/signup.tsx
@@ -4,7 +4,7 @@ import { Metadata } from "@/components/seo/metadata";
 
 export default function SignupPage() {
   return (
-    <Section classes="tracking-200 max-w-md min-w-xs">
+    <Section classes="tracking-200 min-w-xs max-w-md">
       <Metadata title="Create Account" noIndex />
       <SignupForm />
     </Section>

--- a/apps/client/src/app/routes/category/index.tsx
+++ b/apps/client/src/app/routes/category/index.tsx
@@ -34,7 +34,7 @@ const Category = () => {
           {activeCategory}
         </h1>
       </header>
-      <main className="mt-16 md:mt-30 lg:mt-40">
+      <main className="md:mt-30 mt-16 lg:mt-40">
         <ProductsList products={ProductsResponse.data} />
 
         <Section>

--- a/apps/client/src/app/routes/home/index.tsx
+++ b/apps/client/src/app/routes/home/index.tsx
@@ -19,7 +19,7 @@ const Home = () => {
         description="Explore premium headphones, earphones, and speakers from Audiophile."
       />
       <main>
-        <Section classes="mb-10 h-[calc(100vh-(var(--nav-bar-height)))] w-full bg-neutral-900 md:mb-24 lg:mb-30">
+        <Section classes="lg:mb-30 mb-10 h-[calc(100vh-(var(--nav-bar-height)))] w-full bg-neutral-900 md:mb-24">
           <Container classes="grid h-full grid-cols-1 bg-neutral-600">
             <SafeRenderWithErrorBlock
               title="Error loading featured product"
@@ -30,7 +30,7 @@ const Home = () => {
           </Container>
         </Section>
 
-        <Section classes="md:mb-24 lg:mb-42">
+        <Section classes="lg:mb-42 md:mb-24">
           <SafeRenderWithErrorBlock
             title="Error loading categories"
             containerClasses="mb-30"
@@ -41,12 +41,12 @@ const Home = () => {
           </SafeRenderWithErrorBlock>
         </Section>
 
-        <Section classes="space-y-6 md:mb-24 md:space-y-8 lg:mb-53 lg:space-y-12">
+        <Section classes="lg:mb-53 space-y-6 md:mb-24 md:space-y-8 lg:space-y-12">
           <SafeRenderWithErrorBlock title="Error loading showcase products">
             <ShowCaseProductsSection />
           </SafeRenderWithErrorBlock>
         </Section>
-        <Section classes="md:mb-24 lg:mb-47">
+        <Section classes="lg:mb-47 md:mb-24">
           <BestGearSection />
         </Section>
       </main>

--- a/apps/client/src/app/routes/product/index.tsx
+++ b/apps/client/src/app/routes/product/index.tsx
@@ -43,7 +43,7 @@ const Product = () => {
         image={product.images.primaryImage.desktopSrc}
         type="product"
       />
-      <Container classes="mt-4 mb-6 md:mt-8 md:mb-8 lg:mt-19 lg:mb-14">
+      <Container classes="lg:mt-19 mb-6 mt-4 md:mb-8 md:mt-8 lg:mb-14">
         <Button
           onClick={() => navigate(-1)}
           aria-label="Go back to previous page"
@@ -57,7 +57,7 @@ const Product = () => {
 
       <main className="text-neutral-900" key={productSlug}>
         <Section classes="max-sm:mb-22">
-          <Container classes="flex flex-col gap-y-8 md:flex-row md:gap-x-17 lg:gap-x-31">
+          <Container classes="md:gap-x-17 lg:gap-x-31 flex flex-col gap-y-8 md:flex-row">
             <ResponsivePicture
               mobileSrc={product.images.primaryImage.mobileSrc}
               tabletSrc={product.images.primaryImage.tabletSrc}
@@ -91,7 +91,7 @@ const Product = () => {
         </Section>
 
         <Section classes="mb-22 md:mb-38 lg:mb-40">
-          <Container classes="flex flex-col gap-22 md:gap-30 lg:flex-row lg:gap-31">
+          <Container classes="gap-22 md:gap-30 lg:gap-31 flex flex-col lg:flex-row">
             <div>
               <h2 className="tracking-300 mb-6 text-xl font-bold uppercase md:mb-8 md:text-[32px]">
                 features
@@ -113,7 +113,7 @@ const Product = () => {
                     <span className="text-primary-700 mr-5 font-bold md:mr-6">
                       {inc.quantity}x
                     </span>
-                    <span className="text-neutral-600 capitalize">
+                    <span className="capitalize text-neutral-600">
                       {inc.item}
                     </span>
                   </li>

--- a/apps/client/src/components/errors/error-block.tsx
+++ b/apps/client/src/components/errors/error-block.tsx
@@ -22,7 +22,7 @@ const ErrorBlock = ({
       classes={cn("flex items-center justify-center", containerClasses)}
     >
       <div className="bg-primary-500 flex gap-4 rounded p-4 text-left max-sm:flex-col max-sm:items-center max-sm:gap-2">
-        <div className="bg-primary-700 flex h-12 w-12 items-center justify-center rounded-4xl text-3xl">
+        <div className="bg-primary-700 rounded-4xl flex h-12 w-12 items-center justify-center text-3xl">
           !
         </div>
         <div className="clr-primary-700 fw-bold flow">

--- a/apps/client/src/components/layouts/auth-layout.tsx
+++ b/apps/client/src/components/layouts/auth-layout.tsx
@@ -11,7 +11,7 @@ import { Container } from "../ui/container";
 const AuthLayout = () => {
   useQuery(getAuthStatusQueryOptions());
   return (
-    <main className="bg-muted flex min-h-svh flex-col items-center gap-6 px-6 pt-10 md:pt-26">
+    <main className="bg-muted md:pt-26 flex min-h-svh flex-col items-center gap-6 px-6 pt-10">
       <Container classes="w-full max-w-md">
         <Button variant="link" asChild className="mb-4 gap-2 px-0">
           <Link to={paths.home.getHref()}>

--- a/apps/client/src/components/layouts/content-layout/footer.tsx
+++ b/apps/client/src/components/layouts/content-layout/footer.tsx
@@ -11,7 +11,7 @@ import { NavLinks } from "./nav-bar/nav-links";
 export const Footer = () => {
   return (
     <footer className="relative mt-auto bg-neutral-900 text-center">
-      <Container classes="before:bg-primary-500 grid gap-y-12 pt-14 pb-10 before:absolute before:top-px before:h-1 before:w-28 before:justify-self-center before:content-[''] md:grid-cols-2 md:gap-y-8 md:text-left md:before:justify-self-start">
+      <Container classes="before:bg-primary-500 grid gap-y-12 pb-10 pt-14 before:absolute before:top-px before:h-1 before:w-28 before:justify-self-center before:content-[''] md:grid-cols-2 md:gap-y-8 md:text-left md:before:justify-self-start">
         <Link
           className="hover:*:*:fill-primary-500 focus-visible:*:*:fill-primary-500 max-md:mx-auto md:col-span-2 lg:col-span-1"
           to={paths.home.path}
@@ -21,7 +21,7 @@ export const Footer = () => {
         <SafeRenderWithErrorBlock title="Error loading categories navigation">
           <NavLinks />
         </SafeRenderWithErrorBlock>
-        <p className="opacity-50 max-md:max-w-96 max-md:place-self-center md:col-span-2 md:max-lg:max-w-170 lg:col-span-1">
+        <p className="md:max-lg:max-w-170 opacity-50 max-md:max-w-96 max-md:place-self-center md:col-span-2 lg:col-span-1">
           Audiophile is an all in one stop to fulfill your audio needs. We're a
           small team of music lovers and sound specialists who are devoted to
           helping you get the most out of personal audio. Come and visit our

--- a/apps/client/src/components/layouts/content-layout/nav-bar/index.tsx
+++ b/apps/client/src/components/layouts/content-layout/nav-bar/index.tsx
@@ -24,7 +24,7 @@ export const Navbar = () => {
     <>
       <nav className="bg-neutral-900 max-md:border-b max-md:border-neutral-100/20">
         <Container>
-          <div className="flex h-(--nav-bar-height) items-center justify-between md:border-b md:border-neutral-100/20">
+          <div className="h-(--nav-bar-height) flex items-center justify-between md:border-b md:border-neutral-100/20">
             {!isLarge && <NavBarDialog />}
             {isSmall ? (
               <Link
@@ -56,12 +56,12 @@ export const Navbar = () => {
               </SafeRenderWithErrorBlock>
               <button
                 onClick={() => setCartOpen(true)}
-                className="relative hover:*:fill-primary-500 focus-visible:*:fill-primary-500 cursor-pointer"
+                className="hover:*:fill-primary-500 focus-visible:*:fill-primary-500 relative cursor-pointer"
                 aria-label="Open cart"
               >
                 <CartIcon title="cart icon" />
                 {cart?.data.itemCount && cart.data.itemCount > 0 ? (
-                  <span className="absolute -top-2 -right-2 bg-primary-500 text-white text-xs font-bold rounded-full h-5 w-5 flex items-center justify-center">
+                  <span className="bg-primary-500 absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full text-xs font-bold text-white">
                     {cart.data.itemCount}
                   </span>
                 ) : null}

--- a/apps/client/src/components/layouts/content-layout/nav-bar/nav-bar-dialog.tsx
+++ b/apps/client/src/components/layouts/content-layout/nav-bar/nav-bar-dialog.tsx
@@ -25,7 +25,7 @@ export default function NavBarDialog() {
       <DialogContent
         aria-describedby="main-menu"
         showCloseButton={false}
-        className="fixed inset-0 top-(--nav-bar-height) w-full max-w-full translate-x-0 translate-y-0 rounded-t-none max-sm:overflow-scroll sm:max-w-full md:bottom-auto"
+        className="top-(--nav-bar-height) fixed inset-0 w-full max-w-full translate-x-0 translate-y-0 rounded-t-none max-sm:overflow-scroll sm:max-w-full md:bottom-auto"
       >
         <DialogTitle className="sr-only">Main menu</DialogTitle>
         <DialogDescription className="sr-only">

--- a/apps/client/src/components/layouts/root-layout.tsx
+++ b/apps/client/src/components/layouts/root-layout.tsx
@@ -31,7 +31,7 @@ export function RootLayout() {
     <div className="flex min-h-dvh flex-col">
       <Metadata />
       {isLoading && (
-        <div className="absolute top-0 left-0 z-50 w-full bg-black/10">
+        <div className="absolute left-0 top-0 z-50 w-full bg-black/10">
           <div className="flex h-screen w-full items-center justify-center">
             <LoadingSpinner size="xl" />
           </div>

--- a/apps/client/src/components/seo/metadata.tsx
+++ b/apps/client/src/components/seo/metadata.tsx
@@ -51,9 +51,7 @@ export const Metadata = ({
       />
       <meta name="twitter:title" content={resolvedTitle} />
       <meta name="twitter:description" content={resolvedDescription} />
-      {resolvedImage && (
-        <meta name="twitter:image" content={resolvedImage} />
-      )}
+      {resolvedImage && <meta name="twitter:image" content={resolvedImage} />}
       {noIndex && <meta name="robots" content="noindex, nofollow" />}
     </>
   );

--- a/apps/client/src/components/ui/button.tsx
+++ b/apps/client/src/components/ui/button.tsx
@@ -36,7 +36,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }

--- a/apps/client/src/components/ui/card.tsx
+++ b/apps/client/src/components/ui/card.tsx
@@ -10,7 +10,7 @@ const Card = React.forwardRef<
     ref={ref}
     className={cn(
       "rounded-xl border border-neutral-200 bg-white text-neutral-950 shadow-sm dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
-      className
+      className,
     )}
     {...props}
   />

--- a/apps/client/src/components/ui/dialog.tsx
+++ b/apps/client/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 top-(--nav-bar-height) z-50 bg-neutral-300/40",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 top-(--nav-bar-height) fixed inset-0 z-50 bg-neutral-300/40",
         className,
       )}
       {...props}
@@ -58,7 +58,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
         {...props}
@@ -67,7 +67,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground rounded-xs focus:outline-hidden absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -108,7 +108,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn("text-lg font-semibold leading-none", className)}
       {...props}
     />
   );

--- a/apps/client/src/components/ui/drawer.tsx
+++ b/apps/client/src/components/ui/drawer.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Drawer as DrawerPrimitive } from "vaul"
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
 
-import { cn } from "@/lib/cn"
+import { cn } from "@/lib/cn";
 
 const Drawer = ({
   shouldScaleBackground = true,
@@ -11,14 +11,14 @@ const Drawer = ({
     shouldScaleBackground={shouldScaleBackground}
     {...props}
   />
-)
-Drawer.displayName = "Drawer"
+);
+Drawer.displayName = "Drawer";
 
-const DrawerTrigger = DrawerPrimitive.Trigger
+const DrawerTrigger = DrawerPrimitive.Trigger;
 
-const DrawerPortal = DrawerPrimitive.Portal
+const DrawerPortal = DrawerPrimitive.Portal;
 
-const DrawerClose = DrawerPrimitive.Close
+const DrawerClose = DrawerPrimitive.Close;
 
 const DrawerOverlay = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Overlay>,
@@ -29,8 +29,8 @@ const DrawerOverlay = React.forwardRef<
     className={cn("fixed inset-0 z-50 bg-black/80", className)}
     {...props}
   />
-))
-DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 
 const DrawerContent = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Content>,
@@ -42,7 +42,7 @@ const DrawerContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950",
-        className
+        className,
       )}
       {...props}
     >
@@ -50,8 +50,8 @@ const DrawerContent = React.forwardRef<
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>
-))
-DrawerContent.displayName = "DrawerContent"
+));
+DrawerContent.displayName = "DrawerContent";
 
 const DrawerHeader = ({
   className,
@@ -61,8 +61,8 @@ const DrawerHeader = ({
     className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
     {...props}
   />
-)
-DrawerHeader.displayName = "DrawerHeader"
+);
+DrawerHeader.displayName = "DrawerHeader";
 
 const DrawerFooter = ({
   className,
@@ -72,8 +72,8 @@ const DrawerFooter = ({
     className={cn("mt-auto flex flex-col gap-2 p-4", className)}
     {...props}
   />
-)
-DrawerFooter.displayName = "DrawerFooter"
+);
+DrawerFooter.displayName = "DrawerFooter";
 
 const DrawerTitle = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Title>,
@@ -83,12 +83,12 @@ const DrawerTitle = React.forwardRef<
     ref={ref}
     className={cn(
       "text-lg font-semibold leading-none tracking-tight",
-      className
+      className,
     )}
     {...props}
   />
-))
-DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
 
 const DrawerDescription = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Description>,
@@ -99,8 +99,8 @@ const DrawerDescription = React.forwardRef<
     className={cn("text-sm text-neutral-500 dark:text-neutral-400", className)}
     {...props}
   />
-))
-DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
 
 export {
   Drawer,
@@ -113,4 +113,4 @@ export {
   DrawerFooter,
   DrawerTitle,
   DrawerDescription,
-}
+};

--- a/apps/client/src/components/ui/dropdown-menu.tsx
+++ b/apps/client/src/components/ui/dropdown-menu.tsx
@@ -1,13 +1,13 @@
-import * as React from "react"
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
-import { cn } from "@/lib/cn"
+import { cn } from "@/lib/cn";
 
 function DropdownMenu({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
 function DropdownMenuPortal({
@@ -15,7 +15,7 @@ function DropdownMenuPortal({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
   return (
     <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-  )
+  );
 }
 
 function DropdownMenuTrigger({
@@ -26,7 +26,7 @@ function DropdownMenuTrigger({
       data-slot="dropdown-menu-trigger"
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuContent({
@@ -40,13 +40,13 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
-          className
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--radix-dropdown-menu-content-available-height) origin-(--radix-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border p-1 shadow-md",
+          className,
         )}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
-  )
+  );
 }
 
 function DropdownMenuGroup({
@@ -54,7 +54,7 @@ function DropdownMenuGroup({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
   return (
     <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-  )
+  );
 }
 
 function DropdownMenuItem({
@@ -63,8 +63,8 @@ function DropdownMenuItem({
   variant = "default",
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
-  inset?: boolean
-  variant?: "default" | "destructive"
+  inset?: boolean;
+  variant?: "default" | "destructive";
 }) {
   return (
     <DropdownMenuPrimitive.Item
@@ -72,12 +72,12 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuCheckboxItem({
@@ -90,8 +90,8 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
       )}
       checked={checked}
       {...props}
@@ -103,7 +103,7 @@ function DropdownMenuCheckboxItem({
       </span>
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
-  )
+  );
 }
 
 function DropdownMenuRadioGroup({
@@ -114,7 +114,7 @@ function DropdownMenuRadioGroup({
       data-slot="dropdown-menu-radio-group"
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuRadioItem({
@@ -126,8 +126,8 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
       )}
       {...props}
     >
@@ -138,7 +138,7 @@ function DropdownMenuRadioItem({
       </span>
       {children}
     </DropdownMenuPrimitive.RadioItem>
-  )
+  );
 }
 
 function DropdownMenuLabel({
@@ -146,7 +146,7 @@ function DropdownMenuLabel({
   inset,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.Label
@@ -154,11 +154,11 @@ function DropdownMenuLabel({
       data-inset={inset}
       className={cn(
         "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSeparator({
@@ -171,7 +171,7 @@ function DropdownMenuSeparator({
       className={cn("bg-border -mx-1 my-1 h-px", className)}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuShortcut({
@@ -183,17 +183,17 @@ function DropdownMenuShortcut({
       data-slot="dropdown-menu-shortcut"
       className={cn(
         "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSub({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
 }
 
 function DropdownMenuSubTrigger({
@@ -202,22 +202,22 @@ function DropdownMenuSubTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <DropdownMenuPrimitive.SubTrigger
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[inset]:pl-8 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
       )}
       {...props}
     >
       {children}
       <ChevronRightIcon className="ml-auto size-4" />
     </DropdownMenuPrimitive.SubTrigger>
-  )
+  );
 }
 
 function DropdownMenuSubContent({
@@ -228,12 +228,12 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
-        className
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -252,4 +252,4 @@ export {
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
-}
+};

--- a/apps/client/src/components/ui/field.tsx
+++ b/apps/client/src/components/ui/field.tsx
@@ -1,9 +1,9 @@
-import { useMemo } from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { useMemo } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/cn"
-import { Label } from "@/components/ui/label"
-import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/cn";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
 
 function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
   return (
@@ -12,11 +12,11 @@ function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
       className={cn(
         "flex flex-col gap-6",
         "has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function FieldLegend({
@@ -32,11 +32,11 @@ function FieldLegend({
         "mb-3 font-medium",
         "data-[variant=legend]:text-base",
         "data-[variant=label]:text-sm",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
@@ -45,11 +45,11 @@ function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="field-group"
       className={cn(
         "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 const fieldVariants = cva(
@@ -73,8 +73,8 @@ const fieldVariants = cva(
     defaultVariants: {
       orientation: "vertical",
     },
-  }
-)
+  },
+);
 
 function Field({
   className,
@@ -89,7 +89,7 @@ function Field({
       className={cn(fieldVariants({ orientation }), className)}
       {...props}
     />
-  )
+  );
 }
 
 function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -98,11 +98,11 @@ function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="field-content"
       className={cn(
         "group/field-content flex flex-1 flex-col gap-1.5 leading-snug",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function FieldLabel({
@@ -116,11 +116,11 @@ function FieldLabel({
         "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
         "has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -128,12 +128,12 @@ function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="field-label"
       className={cn(
-        "flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50",
-        className
+        "flex w-fit items-center gap-2 text-sm font-medium leading-snug group-data-[disabled=true]/field:opacity-50",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
@@ -141,14 +141,14 @@ function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="field-description"
       className={cn(
-        "text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance",
-        "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
+        "text-muted-foreground text-sm font-normal leading-normal group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "nth-last-2:-mt-1 last:mt-0 [[data-variant=legend]+&]:-mt-1.5",
         "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function FieldSeparator({
@@ -156,7 +156,7 @@ function FieldSeparator({
   className,
   ...props
 }: React.ComponentProps<"div"> & {
-  children?: React.ReactNode
+  children?: React.ReactNode;
 }) {
   return (
     <div
@@ -164,7 +164,7 @@ function FieldSeparator({
       data-content={!!children}
       className={cn(
         "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
-        className
+        className,
       )}
       {...props}
     >
@@ -178,7 +178,7 @@ function FieldSeparator({
         </span>
       )}
     </div>
-  )
+  );
 }
 
 function FieldError({
@@ -187,37 +187,37 @@ function FieldError({
   errors,
   ...props
 }: React.ComponentProps<"div"> & {
-  errors?: Array<{ message?: string } | undefined>
+  errors?: Array<{ message?: string } | undefined>;
 }) {
   const content = useMemo(() => {
     if (children) {
-      return children
+      return children;
     }
 
     if (!errors?.length) {
-      return null
+      return null;
     }
 
     const uniqueErrors = [
       ...new Map(errors.map((error) => [error?.message, error])).values(),
-    ]
+    ];
 
     if (uniqueErrors?.length == 1) {
-      return uniqueErrors[0]?.message
+      return uniqueErrors[0]?.message;
     }
 
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
         {uniqueErrors.map(
           (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>
+            error?.message && <li key={index}>{error.message}</li>,
         )}
       </ul>
-    )
-  }, [children, errors])
+    );
+  }, [children, errors]);
 
   if (!content) {
-    return null
+    return null;
   }
 
   return (
@@ -229,7 +229,7 @@ function FieldError({
     >
       {content}
     </div>
-  )
+  );
 }
 
 export {
@@ -243,4 +243,4 @@ export {
   FieldSet,
   FieldContent,
   FieldTitle,
-}
+};

--- a/apps/client/src/components/ui/input.tsx
+++ b/apps/client/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/cn"
+import { cn } from "@/lib/cn";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -8,14 +8,14 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input shadow-xs h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base outline-none transition-[color,box-shadow] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/apps/client/src/components/ui/label.tsx
+++ b/apps/client/src/components/ui/label.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
 
-import { cn } from "@/lib/cn"
+import { cn } from "@/lib/cn";
 
 function Label({
   className,
@@ -11,12 +11,12 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        "flex select-none items-center gap-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/apps/client/src/components/ui/navigation-menu.tsx
+++ b/apps/client/src/components/ui/navigation-menu.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
-import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
-import { cva } from "class-variance-authority"
-import { ChevronDown } from "lucide-react"
+import * as React from "react";
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { cva } from "class-variance-authority";
+import { ChevronDown } from "lucide-react";
 
-import { cn } from "@/lib/cn"
+import { cn } from "@/lib/cn";
 
 const NavigationMenu = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Root>,
@@ -13,15 +13,15 @@ const NavigationMenu = React.forwardRef<
     ref={ref}
     className={cn(
       "relative z-10 flex max-w-max flex-1 items-center justify-center",
-      className
+      className,
     )}
     {...props}
   >
     {children}
     <NavigationMenuViewport />
   </NavigationMenuPrimitive.Root>
-))
-NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName
+));
+NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName;
 
 const NavigationMenuList = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.List>,
@@ -31,18 +31,18 @@ const NavigationMenuList = React.forwardRef<
     ref={ref}
     className={cn(
       "group flex flex-1 list-none items-center justify-center space-x-1",
-      className
+      className,
     )}
     {...props}
   />
-))
-NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
+));
+NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 
-const NavigationMenuItem = NavigationMenuPrimitive.Item
+const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-white px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-100 hover:text-neutral-900 focus:bg-neutral-100 focus:text-neutral-900 focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-active:bg-neutral-100/50 data-[state=open]:bg-neutral-100/50 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50 dark:focus:bg-neutral-800 dark:focus:text-neutral-50 dark:data-active:bg-neutral-800/50 dark:data-[state=open]:bg-neutral-800/50"
-)
+  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-white px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-100 hover:text-neutral-900 focus:bg-neutral-100 focus:text-neutral-900 focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-active:bg-neutral-100/50 data-[state=open]:bg-neutral-100/50 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50 dark:focus:bg-neutral-800 dark:focus:text-neutral-50 dark:data-active:bg-neutral-800/50 dark:data-[state=open]:bg-neutral-800/50",
+);
 
 const NavigationMenuTrigger = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
@@ -53,14 +53,15 @@ const NavigationMenuTrigger = React.forwardRef<
     className={cn(navigationMenuTriggerStyle(), "group", className)}
     {...props}
   >
-    {children}{""}
+    {children}
+    {""}
     <ChevronDown
       className="relative top-[1px] ml-1 h-3 w-3 transition duration-300 group-data-[state=open]:rotate-180"
       aria-hidden="true"
     />
   </NavigationMenuPrimitive.Trigger>
-))
-NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName
+));
+NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName;
 
 const NavigationMenuContent = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Content>,
@@ -69,15 +70,15 @@ const NavigationMenuContent = React.forwardRef<
   <NavigationMenuPrimitive.Content
     ref={ref}
     className={cn(
-      "left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto",
-      className
+      "data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 left-0 top-0 w-full md:absolute md:w-auto",
+      className,
     )}
     {...props}
   />
-))
-NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName
+));
+NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
 
-const NavigationMenuLink = NavigationMenuPrimitive.Link
+const NavigationMenuLink = NavigationMenuPrimitive.Link;
 
 const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
@@ -86,16 +87,16 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn("absolute left-0 top-full flex justify-center")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border border-neutral-200 bg-white text-neutral-950 shadow-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)] dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
-        className
+        "origin-top-center data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border border-neutral-200 bg-white text-neutral-950 shadow-sm md:w-[var(--radix-navigation-menu-viewport-width)] dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
+        className,
       )}
       ref={ref}
       {...props}
     />
   </div>
-))
+));
 NavigationMenuViewport.displayName =
-  NavigationMenuPrimitive.Viewport.displayName
+  NavigationMenuPrimitive.Viewport.displayName;
 
 const NavigationMenuIndicator = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
@@ -104,16 +105,16 @@ const NavigationMenuIndicator = React.forwardRef<
   <NavigationMenuPrimitive.Indicator
     ref={ref}
     className={cn(
-      "top-full z-1 flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
-      className
+      "z-1 data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full flex h-1.5 items-end justify-center overflow-hidden",
+      className,
     )}
     {...props}
   >
     <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-neutral-200 shadow-md dark:bg-neutral-800" />
   </NavigationMenuPrimitive.Indicator>
-))
+));
 NavigationMenuIndicator.displayName =
-  NavigationMenuPrimitive.Indicator.displayName
+  NavigationMenuPrimitive.Indicator.displayName;
 
 export {
   navigationMenuTriggerStyle,
@@ -125,4 +126,4 @@ export {
   NavigationMenuLink,
   NavigationMenuIndicator,
   NavigationMenuViewport,
-}
+};

--- a/apps/client/src/components/ui/quantity-selector.tsx
+++ b/apps/client/src/components/ui/quantity-selector.tsx
@@ -28,7 +28,7 @@ export function QuantitySelector({
   return (
     <div
       className={cn(
-        "flex h-12 w-30 items-center justify-around bg-neutral-200 text-xs font-bold",
+        "w-30 flex h-12 items-center justify-around bg-neutral-200 text-xs font-bold",
         className,
       )}
     >

--- a/apps/client/src/components/ui/separator.tsx
+++ b/apps/client/src/components/ui/separator.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
 
-import { cn } from "@/lib/cn"
+import { cn } from "@/lib/cn";
 
 function Separator({
   className,
@@ -17,12 +17,12 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
-        className
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/apps/client/src/components/ui/tabs.tsx
+++ b/apps/client/src/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 
-import { cn } from "@/lib/cn"
+import { cn } from "@/lib/cn";
 
 function Tabs({
   className,
@@ -13,7 +13,7 @@ function Tabs({
       className={cn("flex flex-col gap-2", className)}
       {...props}
     />
-  )
+  );
 }
 
 function TabsList({
@@ -25,11 +25,11 @@ function TabsList({
       data-slot="tabs-list"
       className={cn(
         "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TabsTrigger({
@@ -40,12 +40,12 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-sm font-medium transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TabsContent({
@@ -58,7 +58,7 @@ function TabsContent({
       className={cn("flex-1 outline-none", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/apps/client/src/components/ui/toast.tsx
+++ b/apps/client/src/components/ui/toast.tsx
@@ -14,8 +14,8 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-100 flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
-      className
+      "z-100 fixed top-0 flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className,
     )}
     {...props}
   />
@@ -36,7 +36,7 @@ const toastVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
+  },
 );
 
 const Toast = React.forwardRef<
@@ -61,8 +61,8 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-neutral-200 bg-transparent px-3 text-sm font-medium transition-colors hover:bg-neutral-100 focus:outline-hidden focus:ring-1 focus:ring-neutral-950 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-neutral-100/40 hover:group-[.destructive]:border-red-500/30 hover:group-[.destructive]:bg-red-500 hover:group-[.destructive]:text-neutral-50 focus:group-[.destructive]:ring-red-500 dark:border-neutral-800 dark:hover:bg-neutral-800 dark:focus:ring-neutral-300 dark:group-[.destructive]:border-neutral-800/40 dark:hover:group-[.destructive]:border-red-900/30 dark:hover:group-[.destructive]:bg-red-900 dark:hover:group-[.destructive]:text-neutral-50 dark:focus:group-[.destructive]:ring-red-900",
-      className
+      "focus:outline-hidden inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-neutral-200 bg-transparent px-3 text-sm font-medium transition-colors hover:bg-neutral-100 focus:ring-1 focus:ring-neutral-950 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-neutral-100/40 hover:group-[.destructive]:border-red-500/30 hover:group-[.destructive]:bg-red-500 hover:group-[.destructive]:text-neutral-50 focus:group-[.destructive]:ring-red-500 dark:border-neutral-800 dark:hover:bg-neutral-800 dark:focus:ring-neutral-300 dark:group-[.destructive]:border-neutral-800/40 dark:hover:group-[.destructive]:border-red-900/30 dark:hover:group-[.destructive]:bg-red-900 dark:hover:group-[.destructive]:text-neutral-50 dark:focus:group-[.destructive]:ring-red-900",
+      className,
     )}
     {...props}
   />
@@ -76,8 +76,8 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-1 top-1 rounded-md p-1 text-neutral-950/50 opacity-0 transition-opacity hover:text-neutral-950 focus:opacity-100 focus:outline-hidden focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 hover:group-[.destructive]:text-red-50 focus:group-[.destructive]:ring-red-400 focus:group-[.destructive]:ring-offset-red-600 dark:text-neutral-50/50 dark:hover:text-neutral-50",
-      className
+      "focus:outline-hidden absolute right-1 top-1 rounded-md p-1 text-neutral-950/50 opacity-0 transition-opacity hover:text-neutral-950 focus:opacity-100 focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 hover:group-[.destructive]:text-red-50 focus:group-[.destructive]:ring-red-400 focus:group-[.destructive]:ring-offset-red-600 dark:text-neutral-50/50 dark:hover:text-neutral-50",
+      className,
     )}
     toast-close=""
     {...props}

--- a/apps/client/src/components/ui/tooltip.tsx
+++ b/apps/client/src/components/ui/tooltip.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
-import { cn } from "@/lib/cn"
+import { cn } from "@/lib/cn";
 
 function TooltipProvider({
   delayDuration = 0,
@@ -13,7 +13,7 @@ function TooltipProvider({
       delayDuration={delayDuration}
       {...props}
     />
-  )
+  );
 }
 
 function Tooltip({
@@ -23,13 +23,13 @@ function Tooltip({
     <TooltipProvider>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
     </TooltipProvider>
-  )
+  );
 }
 
 function TooltipTrigger({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -44,8 +44,8 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
-          className
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin) z-50 w-fit text-balance rounded-md px-3 py-1.5 text-xs",
+          className,
         )}
         {...props}
       >
@@ -53,7 +53,7 @@ function TooltipContent({
         <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/apps/client/src/features/auth/components/password-visibility-toggle.tsx
+++ b/apps/client/src/features/auth/components/password-visibility-toggle.tsx
@@ -18,7 +18,7 @@ export function PasswordVisibilityToggle({
     <button
       type="button"
       className={cn(
-        "absolute top-1/2 right-2 -translate-y-1/2 cursor-pointer p-1 text-neutral-500/70 hover:text-neutral-700 focus-visible:outline-none",
+        "absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer p-1 text-neutral-500/70 hover:text-neutral-700 focus-visible:outline-none",
         className,
       )}
       onClick={onToggle}

--- a/apps/client/src/features/categories/components/category-nav-list/index.tsx
+++ b/apps/client/src/features/categories/components/category-nav-list/index.tsx
@@ -29,7 +29,7 @@ const CategoryNavList = ({ clickHandler }: { clickHandler?: () => void }) => {
               src={category.thumbnail.src}
               alt={category.thumbnail.altText}
               aria-label={category.thumbnail.ariaLabel}
-              className="z-10 col-start-1 col-end-2 row-start-1 row-end-3 max-w-1/3 md:max-w-2/3 lg:max-w-5/6"
+              className="max-w-1/3 md:max-w-2/3 lg:max-w-5/6 z-10 col-start-1 col-end-2 row-start-1 row-end-3"
             />
             <div className="col-start-1 col-end-2 row-start-2 row-end-4 w-full rounded-md bg-neutral-200"></div>
             <div className="col-start-1 col-end-2 row-start-3 row-end-4 w-full text-center">

--- a/apps/client/src/features/products/components/product-skeleton.tsx
+++ b/apps/client/src/features/products/components/product-skeleton.tsx
@@ -9,10 +9,10 @@ export default function ProductSkeleton({ classes }: { classes?: string }) {
         classes,
       )}
     >
-      <Skeleton className="mb-6 h-5 w-51" />
-      <Skeleton className="mb-8 h-14 w-66" />
-      <Skeleton className="mb-6 h-22 w-68" />
-      <Skeleton className="h-12 w-46 rounded-none" />
+      <Skeleton className="w-51 mb-6 h-5" />
+      <Skeleton className="w-66 mb-8 h-14" />
+      <Skeleton className="h-22 w-68 mb-6" />
+      <Skeleton className="w-46 h-12 rounded-none" />
       <p className="sr-only">Loading product details...</p>
       <span className="sr-only">Loading...</span>
     </article>

--- a/apps/client/src/features/products/components/products-list-skeleton.tsx
+++ b/apps/client/src/features/products/components/products-list-skeleton.tsx
@@ -8,7 +8,7 @@ const ProductsListSkeleton = () => {
     <>
       <Section>
         <Container
-          classes={`flex flex-col gap-8 md:gap-14 lg:flex-row lg:gap-31`}
+          classes={`lg:gap-31 flex flex-col gap-8 md:gap-14 lg:flex-row`}
         >
           <Skeleton className="h-64 w-full rounded-sm" />
           <ProductSkeleton />
@@ -16,7 +16,7 @@ const ProductsListSkeleton = () => {
       </Section>
       <Section>
         <Container
-          classes={`flex flex-col gap-8 md:gap-14 lg:flex-row-reverse lg:gap-31`}
+          classes={`lg:gap-31 flex flex-col gap-8 md:gap-14 lg:flex-row-reverse`}
         >
           <Skeleton className="h-64 w-full rounded-sm" />
           <ProductSkeleton />
@@ -24,7 +24,7 @@ const ProductsListSkeleton = () => {
       </Section>
       <Section>
         <Container
-          classes={`flex flex-col gap-8 md:gap-14 lg:flex-row lg:gap-31`}
+          classes={`lg:gap-31 flex flex-col gap-8 md:gap-14 lg:flex-row`}
         >
           <Skeleton className="h-64 w-full rounded-sm" />
           <ProductSkeleton />

--- a/apps/client/src/features/products/components/products-list.tsx
+++ b/apps/client/src/features/products/components/products-list.tsx
@@ -14,7 +14,7 @@ export default function ProductsList({ products }: TProductListProps) {
       {products.map((product, i) => (
         <Section key={product.id}>
           <Container
-            classes={`flex flex-col gap-8 md:gap-14 lg:flex-row lg:gap-31 ${i % 2 === 1 ? "lg:flex-row-reverse" : ""}`}
+            classes={`lg:gap-31 flex flex-col gap-8 md:gap-14 lg:flex-row ${i % 2 === 1 ? "lg:flex-row-reverse" : ""}`}
           >
             <ResponsivePicture
               mobileSrc={product.images.introImage.mobileSrc}

--- a/apps/client/src/features/products/components/showcase-section/index.tsx
+++ b/apps/client/src/features/products/components/showcase-section/index.tsx
@@ -28,8 +28,8 @@ const ShowCaseProductsSection = () => {
   return (
     <>
       <article>
-        <Container classes="bg-primary-500 flex flex-col items-center gap-8 overflow-hidden rounded-sm pt-24 lg:flex-row lg:items-start lg:justify-center lg:gap-30">
-          <section className="mx-auto w-[60%] max-w-60 lg:mx-0 lg:-mb-2.5 lg:max-w-102.5">
+        <Container classes="bg-primary-500 lg:gap-30 flex flex-col items-center gap-8 overflow-hidden rounded-sm pt-24 lg:flex-row lg:items-start lg:justify-center">
+          <section className="lg:max-w-102.5 mx-auto w-[60%] max-w-60 lg:mx-0 lg:-mb-2.5">
             <ResponsivePicture
               altText={showCaseCover?.images.showCaseImage?.altText || ""}
               ariaLabel={showCaseCover?.images.showCaseImage?.ariaLabel || ""}
@@ -98,7 +98,7 @@ const ShowCaseProductsSection = () => {
           />
           <div className="z-10 col-span-full row-span-full ml-6 self-center md:ml-16 lg:ml-24">
             <header>
-              <h2 className="text-2xl font-bold tracking-[0.07em] text-neutral-900 uppercase">
+              <h2 className="text-2xl font-bold uppercase tracking-[0.07em] text-neutral-900">
                 {showCaseWide?.shortLabel}
               </h2>
             </header>
@@ -146,7 +146,7 @@ const ShowCaseProductsSection = () => {
           <section className="flex items-center overflow-hidden rounded-sm bg-neutral-200">
             <div className="ml-6 md:ml-10 lg:ml-24">
               <header>
-                <h2 className="text-2xl font-bold tracking-[0.07em] text-neutral-900 uppercase">
+                <h2 className="text-2xl font-bold uppercase tracking-[0.07em] text-neutral-900">
                   {showCaseGrid?.shortLabel}
                 </h2>
               </header>

--- a/apps/server/ERROR_FLOW.md
+++ b/apps/server/ERROR_FLOW.md
@@ -159,42 +159,48 @@
 ## Error Types & Status Codes
 
 ### Validation Errors
-| Error Type | Handler | Status | Message Format |
-|------------|---------|--------|----------------|
-| ZodError (middleware) | validateSchema → AppError | 422 | "Unprocessable Content. The following variables are missing or invalid: {details}" |
-| ZodError (global) | handleZodError | 400 | "Unprocessable Content. The following variables are missing or invalid: {details}" |
+
+| Error Type            | Handler                   | Status | Message Format                                                                     |
+| --------------------- | ------------------------- | ------ | ---------------------------------------------------------------------------------- |
+| ZodError (middleware) | validateSchema → AppError | 422    | "Unprocessable Content. The following variables are missing or invalid: {details}" |
+| ZodError (global)     | handleZodError            | 400    | "Unprocessable Content. The following variables are missing or invalid: {details}" |
 
 ### Database Errors (Prisma)
-| Error Code | Handler | Status | Message |
-|------------|---------|--------|---------|
-| P2023 | handleCastErrorDB | 400 | "{err.meta.message}" |
-| P2002 | handleDuplicateFieldsDB | 400 | "Duplicate field value: {target}. Please use another value!" |
-| P2025 | handleMissingDocumentDB | 404 | "No matching {modelName} was found" |
-| PrismaClientValidationError | handleValidationErrorDB | 422 | "Invalid query data. - Unprocessable Content" |
+
+| Error Code                  | Handler                 | Status | Message                                                      |
+| --------------------------- | ----------------------- | ------ | ------------------------------------------------------------ |
+| P2023                       | handleCastErrorDB       | 400    | "{err.meta.message}"                                         |
+| P2002                       | handleDuplicateFieldsDB | 400    | "Duplicate field value: {target}. Please use another value!" |
+| P2025                       | handleMissingDocumentDB | 404    | "No matching {modelName} was found"                          |
+| PrismaClientValidationError | handleValidationErrorDB | 422    | "Invalid query data. - Unprocessable Content"                |
 
 ### Authentication Errors (JWT)
-| Error Name | Handler | Status | Message |
-|------------|---------|--------|---------|
-| JsonWebTokenError | handleJWTError | 401 | "Invalid token. Please log in again!" |
-| TokenExpiredError | handleJWTExpiredError | 401 | "Your token has expired! Please log in again." |
+
+| Error Name        | Handler               | Status | Message                                        |
+| ----------------- | --------------------- | ------ | ---------------------------------------------- |
+| JsonWebTokenError | handleJWTError        | 401    | "Invalid token. Please log in again!"          |
+| TokenExpiredError | handleJWTExpiredError | 401    | "Your token has expired! Please log in again." |
 
 ### Application Errors
-| Type | Status | Operational | Description |
-|------|--------|-------------|-------------|
-| AppError | Custom (400-599) | true | Intentional errors thrown by app logic |
-| Unknown Error | 500 | false | Programming errors, unexpected exceptions |
+
+| Type          | Status           | Operational | Description                               |
+| ------------- | ---------------- | ----------- | ----------------------------------------- |
+| AppError      | Custom (400-599) | true        | Intentional errors thrown by app logic    |
+| Unknown Error | 500              | false       | Programming errors, unexpected exceptions |
 
 ---
 
 ## Key Components
 
 ### 1. catchAsync (utils/catchAsync.ts)
+
 ```typescript
 // Wraps async route handlers to catch Promise rejections
 // Passes errors to next() → error middleware
 ```
 
 ### 2. validateSchema (middlewares/validation.middleware.ts)
+
 ```typescript
 // Validates req.params, req.body, req.query against Zod schema
 // On failure: Creates AppError(422) and calls next(appError)
@@ -202,12 +208,14 @@
 ```
 
 ### 3. Error Middleware (middlewares/error.middleware.ts)
+
 ```typescript
 // Central error handling with 4 parameters: (err, req, res, next)
 // Branches based on NODE_ENV
 ```
 
 ### 4. AppError (utils/appError.ts)
+
 ```typescript
 // Custom error class with:
 // - statusCode (HTTP status)
@@ -267,12 +275,14 @@ bare `logger`.
 ❌ **Production**: Hide implementation details to prevent information leakage
 
 **Operational Errors** (expected, safe to show):
+
 - Validation failures
 - Missing resources (404)
 - Duplicate entries
 - Authentication failures
 
 **Non-Operational Errors** (unexpected, hide details):
+
 - Syntax errors
 - Undefined references
 - Database connection failures

--- a/apps/server/FIELD_WHITELISTING.md
+++ b/apps/server/FIELD_WHITELISTING.md
@@ -69,7 +69,7 @@ import { categoryUpdateSchema } from "@repo/domain";
 
 router.route("/:id").patch(
   validateSchema(categoryUpdateSchema), // ← Validation happens here
-  categoryController.updateCategory
+  categoryController.updateCategory,
 );
 ```
 

--- a/apps/server/SERVICE_LAYER_EXAMPLE.md
+++ b/apps/server/SERVICE_LAYER_EXAMPLE.md
@@ -119,7 +119,7 @@ export class OrderService {
         if (product.inventory < item.quantity) {
           throw new AppError(
             `Insufficient stock for ${product.name}. Available: ${product.inventory}, Requested: ${item.quantity}`,
-            400
+            400,
           );
         }
 
@@ -134,7 +134,7 @@ export class OrderService {
       if (Math.abs(calculatedTotal - orderData.total) > 0.01) {
         throw new AppError(
           `Total mismatch. Expected: ${calculatedTotal}, Received: ${orderData.total}`,
-          400
+          400,
         );
       }
 
@@ -176,8 +176,8 @@ export class OrderService {
           tx.product.update({
             where: { id: update.id },
             data: { inventory: update.quantity },
-          })
-        )
+          }),
+        ),
       );
 
       return order;
@@ -208,7 +208,7 @@ export class OrderService {
       if (!["PENDING", "PROCESSING"].includes(order.status)) {
         throw new AppError(
           `Cannot cancel order with status: ${order.status}`,
-          400
+          400,
         );
       }
 
@@ -225,8 +225,8 @@ export class OrderService {
           tx.product.update({
             where: { id: item.productId },
             data: { inventory: { increment: item.quantity } },
-          })
-        )
+          }),
+        ),
       );
 
       return updatedOrder;
@@ -242,7 +242,7 @@ export class OrderService {
       status?: string;
       page?: number;
       limit?: number;
-    }
+    },
   ) {
     const page = options.page || 1;
     const limit = options.limit || 10;
@@ -434,7 +434,7 @@ export class UserService {
     // Validate password using Prisma extension method
     const isPasswordValid = await prisma.user.validatePassword(
       credentials.password,
-      user.password
+      user.password,
     );
 
     if (!isPasswordValid) {
@@ -456,7 +456,7 @@ export class UserService {
   async updatePassword(
     userId: string,
     currentPassword: string,
-    newPassword: string
+    newPassword: string,
   ) {
     // Get user with password
     const user = await prisma.user.findUnique({
@@ -471,7 +471,7 @@ export class UserService {
     // Verify current password
     const isValid = await prisma.user.validatePassword(
       currentPassword,
-      user.password
+      user.password,
     );
 
     if (!isValid) {
@@ -576,7 +576,7 @@ export class ProductService {
   async createProduct(productData: CreateProductInput) {
     // Upload images to Cloudinary (external service)
     const uploadedImages = await this.uploadImagesToCloudinary(
-      productData.images
+      productData.images,
     );
 
     // Create product with uploaded image URLs
@@ -647,8 +647,8 @@ export class ProductService {
           prisma.product.updateMany({
             where: { sku: item.sku },
             data: { price: item.price },
-          })
-        )
+          }),
+        ),
       );
 
       return {
@@ -671,7 +671,7 @@ export class ProductService {
           url: "https://cloudinary.com/uploaded-image.jpg",
           publicId: "product-images/abc123",
         };
-      })
+      }),
     );
 
     return uploads;
@@ -685,7 +685,7 @@ export class ProductService {
     Promise.all(
       publicIds.map(async (publicId) => {
         // Delete from cloudinary
-      })
+      }),
     ).catch((error) => {
       console.error("Failed to delete images from Cloudinary", error);
     });
@@ -792,7 +792,7 @@ describe("OrderService", () => {
       });
 
       await expect(service.createOrder("user-1", orderData)).rejects.toThrow(
-        "Insufficient stock"
+        "Insufficient stock",
       );
     });
   });

--- a/apps/server/VALIDATION_STRATEGY.md
+++ b/apps/server/VALIDATION_STRATEGY.md
@@ -88,7 +88,7 @@
 // Example: Product route with validation
 router.route("/slug/:slug").get(
   validateSchema(GetProductBySlugSchema), // ← VALIDATE HERE
-  productController.getProductBySlug
+  productController.getProductBySlug,
 );
 ```
 
@@ -122,7 +122,7 @@ export const updateProduct: RequestHandler = catchAsync(async (req, res) => {
   if (product.publishedAt && req.body.price < product.price * 0.5) {
     throw new AppError(
       "Cannot reduce published product price by more than 50%",
-      400
+      400,
     );
   }
 
@@ -499,7 +499,7 @@ export const CreateOrderSchema = z.object({
       (data) => {
         const itemsTotal = data.items.reduce(
           (sum, item) => sum + item.price * item.quantity,
-          0
+          0,
         );
         const discountedTotal = itemsTotal - (data.discount || 0);
         return Math.abs(discountedTotal - data.total) < 0.01;
@@ -507,7 +507,7 @@ export const CreateOrderSchema = z.object({
       {
         message: "Total must match items total minus discount",
         path: ["total"],
-      }
+      },
     ),
 });
 ```
@@ -766,12 +766,12 @@ router.route("/category/:id").get(controller.getCategoryById); // Uses same vali
 ```typescript
 router.route("/:id").get(
   validateSchema(GetProductByIdSchema), // Clear what's validated
-  controller.getById
+  controller.getById,
 );
 
 router.route("/category/:id").get(
   validateSchema(GetCategoryByIdSchema), // Different validation
-  controller.getCategoryById
+  controller.getCategoryById,
 );
 ```
 
@@ -799,7 +799,7 @@ router.route("/category/:id").get(
 router.post(
   "/products",
   validateSchema(CreateProductSchema), // ✅ Right layer
-  controller.createProduct
+  controller.createProduct,
 );
 ```
 

--- a/apps/server/src/controllers/category.controller.ts
+++ b/apps/server/src/controllers/category.controller.ts
@@ -41,7 +41,7 @@ export const updateCategory: RequestHandler = catchAsync<
 >(async (req, res) => {
   const dto = await categoryService.update(
     req.verified.params.id,
-    req.verified.body
+    req.verified.body,
   );
   res.status(200).json(createSingleItemResponse(dto));
 });

--- a/apps/server/src/controllers/config.controller.ts
+++ b/apps/server/src/controllers/config.controller.ts
@@ -29,7 +29,7 @@ export const updateConfig: RequestHandler = catchAsync<
 >(async (req, res) => {
   const dto = await configService.update(
     req.verified.params.id,
-    req.verified.body
+    req.verified.body,
   );
   res.status(200).json(createSingleItemResponse(dto));
 });

--- a/apps/server/src/controllers/product.controller.ts
+++ b/apps/server/src/controllers/product.controller.ts
@@ -40,7 +40,9 @@ export const getProductBySlug: RequestHandler = catchAsync<
 export const getRelatedProducts: RequestHandler = catchAsync<
   ValidatedRequest<typeof ProductGetRelatedByIdRequestSchema>
 >(async (req, res) => {
-  const result = await productService.getRelatedProducts(req.verified.params.id);
+  const result = await productService.getRelatedProducts(
+    req.verified.params.id,
+  );
   res.status(200).json(createListResponse(result.data, result.meta));
 });
 
@@ -48,7 +50,7 @@ export const getProductsByCategoryName: RequestHandler = catchAsync<
   ValidatedRequest<typeof ProductGetByCategorySchema>
 >(async (req, res) => {
   const result = await productService.getProductsByCategoryName(
-    req.verified.params.category
+    req.verified.params.category,
   );
   res.status(200).json(createListResponse(result.data, result.meta));
 });
@@ -58,14 +60,14 @@ export const getShowCaseProducts: RequestHandler = catchAsync(
   async (_req, res) => {
     const dto = await productService.getShowCaseProducts();
     res.status(200).json(createSingleItemResponse(dto));
-  }
+  },
 );
 
 export const getFeaturedProduct: RequestHandler = catchAsync(
   async (_req, res) => {
     const dto = await productService.getFeaturedProduct();
     res.status(200).json(createSingleItemResponse(dto));
-  }
+  },
 );
 
 // * ADMIN CONTROLLERS
@@ -82,7 +84,7 @@ export const updateProduct: RequestHandler = catchAsync<
 >(async (req, res) => {
   const dto = await productService.update(
     req.verified.params.id,
-    req.verified.body
+    req.verified.body,
   );
   res.status(200).json(createSingleItemResponse(dto));
 });

--- a/apps/server/src/controllers/user.controller.ts
+++ b/apps/server/src/controllers/user.controller.ts
@@ -55,7 +55,7 @@ export const updateUser: RequestHandler = catchAsync<
 >(async (req, res, _next) => {
   const dto = await userService.update(
     req.verified.params.id,
-    req.verified.body
+    req.verified.body,
   );
   res.status(200).json(createSingleItemResponse(dto));
 });

--- a/apps/server/src/middlewares/validation.middleware.ts
+++ b/apps/server/src/middlewares/validation.middleware.ts
@@ -25,7 +25,7 @@ export const validateSchema = (schema: ZodType<any>): RequestHandler =>
       }));
 
       return next(
-        new AppError(message, ErrorCode.VALIDATION_ERROR, undefined, details)
+        new AppError(message, ErrorCode.VALIDATION_ERROR, undefined, details),
       );
     }
 

--- a/apps/server/src/routes/cart.route.ts
+++ b/apps/server/src/routes/cart.route.ts
@@ -20,42 +20,42 @@ cartRouter.use(authenticate);
 cartRouter.get(
   "/",
   validateSchema(GetCartRequestSchema),
-  cartController.getCart
+  cartController.getCart,
 );
 
 // Add item to cart
 cartRouter.post(
   "/",
   validateSchema(AddToCartRequestSchema),
-  cartController.addToCart
+  cartController.addToCart,
 );
 
 // Sync local cart with server cart
 cartRouter.post(
   "/sync",
   validateSchema(SyncCartRequestSchema),
-  cartController.syncCart
+  cartController.syncCart,
 );
 
 // Update cart item quantity
 cartRouter.patch(
   "/items/:cartItemId",
   validateSchema(UpdateCartItemRequestSchema),
-  cartController.updateCartItem
+  cartController.updateCartItem,
 );
 
 // Remove item from cart
 cartRouter.delete(
   "/items/:cartItemId",
   validateSchema(RemoveFromCartRequestSchema),
-  cartController.removeFromCart
+  cartController.removeFromCart,
 );
 
 // Clear cart
 cartRouter.delete(
   "/",
   validateSchema(ClearCartRequestSchema),
-  cartController.clearCart
+  cartController.clearCart,
 );
 
 export default cartRouter;

--- a/apps/server/src/routes/category.route.ts
+++ b/apps/server/src/routes/category.route.ts
@@ -17,19 +17,19 @@ const categoryRouter: express.Router = express.Router();
 categoryRouter.get(
   "/",
   validateSchema(CategoryGetAllRequestSchema),
-  categoryController.getAllCategories
+  categoryController.getAllCategories,
 );
 
 categoryRouter.get(
   "/:category/products",
   validateSchema(ProductGetByCategorySchema),
-  productController.getProductsByCategoryName
+  productController.getProductsByCategoryName,
 );
 
 categoryRouter.get(
   "/:id",
   validateSchema(CategoryGetByIdRequestSchema),
-  categoryController.getCategoryById
+  categoryController.getCategoryById,
 );
 
 // * ADMIN ROUTES (restricted to admin roles)
@@ -39,18 +39,18 @@ categoryRouter.use(authenticate, authorize("ADMIN"));
 categoryRouter.post(
   "/",
   validateSchema(CategoryCreateRequestSchema),
-  categoryController.createCategory
+  categoryController.createCategory,
 );
 
 categoryRouter
   .route("/:id")
   .patch(
     validateSchema(CategoryUpdateByIdRequestSchema),
-    categoryController.updateCategory
+    categoryController.updateCategory,
   )
   .delete(
     validateSchema(CategoryDeleteByIdRequestSchema),
-    categoryController.deleteCategory
+    categoryController.deleteCategory,
   );
 
 export default categoryRouter;

--- a/apps/server/src/routes/config.route.ts
+++ b/apps/server/src/routes/config.route.ts
@@ -16,7 +16,7 @@ const configRouter: express.Router = express.Router();
 configRouter.get(
   "/",
   validateSchema(ConfigGetUniqueRequestSchema),
-  configController.getConfig
+  configController.getConfig,
 );
 
 // * ADMIN ROUTES (restricted to admin roles)
@@ -25,19 +25,19 @@ configRouter.use(authenticate, authorize("ADMIN"));
 configRouter.post(
   "/",
   validateSchema(ConfigCreateRequestSchema),
-  configController.createConfig
+  configController.createConfig,
 );
 
 configRouter.patch(
   "/:id",
   validateSchema(ConfigUpdateByIdRequestSchema),
-  configController.updateConfig
+  configController.updateConfig,
 );
 
 configRouter.delete(
   "/:id",
   validateSchema(ConfigDeleteByIdRequestSchema),
-  configController.deleteConfig
+  configController.deleteConfig,
 );
 
 export default configRouter;

--- a/apps/server/src/routes/product.route.ts
+++ b/apps/server/src/routes/product.route.ts
@@ -18,35 +18,35 @@ const productRouter: express.Router = express.Router();
 productRouter.get(
   "/",
   validateSchema(ProductGetAllRequestSchema),
-  productController.getAllProducts
+  productController.getAllProducts,
 );
 productRouter.get(
   "/featured",
   validateSchema(ProductGetByPathSchema),
-  productController.getFeaturedProduct
+  productController.getFeaturedProduct,
 );
 productRouter.get(
   "/show-case",
   validateSchema(ProductGetByPathSchema),
-  productController.getShowCaseProducts
+  productController.getShowCaseProducts,
 );
 
 productRouter.get(
   "/related-products/:id",
   validateSchema(ProductGetRelatedByIdRequestSchema),
-  productController.getRelatedProducts
+  productController.getRelatedProducts,
 );
 
 productRouter.get(
   "/:id",
   validateSchema(ProductGetByIdRequestSchema),
-  productController.getProductById
+  productController.getProductById,
 );
 
 productRouter.get(
   "/slug/:slug",
   validateSchema(ProductGetBySlugSchema),
-  productController.getProductBySlug
+  productController.getProductBySlug,
 );
 
 // * ADMIN ROUTES (restricted to admin roles)
@@ -56,18 +56,18 @@ productRouter.use(authenticate, authorize("ADMIN"));
 productRouter.post(
   "/",
   validateSchema(ProductCreateRequestSchema),
-  productController.createProduct
+  productController.createProduct,
 );
 
 productRouter
   .route("/:id")
   .patch(
     validateSchema(ProductUpdateByIdRequestSchema),
-    productController.updateProduct
+    productController.updateProduct,
   )
   .delete(
     validateSchema(ProductDeleteByIdRequestSchema),
-    productController.deleteProduct
+    productController.deleteProduct,
   );
 
 export default productRouter;

--- a/apps/server/src/routes/user.route.ts
+++ b/apps/server/src/routes/user.route.ts
@@ -22,19 +22,19 @@ userRouter.use(authenticate);
 userRouter.get(
   "/me",
   validateSchema(UserGetMeRequestSchema),
-  userController.getMe
+  userController.getMe,
 );
 
 userRouter.patch(
   "/updateMe",
   validateSchema(UserUpdateMeRequestSchema),
-  userController.updateMe
+  userController.updateMe,
 );
 
 userRouter.delete(
   "/deleteMe",
   validateSchema(UserDeleteMeRequestSchema),
-  userController.deleteMe
+  userController.deleteMe,
 );
 
 // * ADMIN ROUTES (restricted to admin roles)
@@ -44,31 +44,31 @@ userRouter.use(authorize("ADMIN"));
 userRouter.get(
   "/",
   validateSchema(UserGetAllRequestSchema),
-  userController.getAllUsers
+  userController.getAllUsers,
 );
 
 userRouter.post(
   "/",
   validateSchema(UserCreateRequestSchema),
-  userController.createUser
+  userController.createUser,
 );
 
 userRouter.get(
   "/:id",
   validateSchema(UserGetByIdRequestSchema),
-  userController.getUser
+  userController.getUser,
 );
 
 userRouter.patch(
   "/:id",
   validateSchema(UserUpdateByIdRequestSchema),
-  userController.updateUser
+  userController.updateUser,
 );
 
 userRouter.delete(
   "/:id",
   validateSchema(UserDeleteByIdRequestSchema),
-  userController.deleteUser
+  userController.deleteUser,
 );
 
 export default userRouter;

--- a/apps/server/src/services/abstract-crud.service.ts
+++ b/apps/server/src/services/abstract-crud.service.ts
@@ -84,14 +84,14 @@ export abstract class AbstractCrudService<
    * @returns Array of entities and total count
    */
   protected abstract persistFindMany(
-    params: Pagination & Query
+    params: Pagination & Query,
   ): Promise<{ data: Entity[]; total: number }>;
 
   protected abstract persistFindById(id: string): Promise<Entity | null>;
   protected abstract persistCreate(data: CreateInput): Promise<Entity>;
   protected abstract persistUpdate(
     id: string,
-    data: UpdateInput
+    data: UpdateInput,
   ): Promise<Entity | null>;
   protected abstract persistDelete(id: string): Promise<boolean>;
 
@@ -152,7 +152,7 @@ export abstract class AbstractCrudService<
 
   protected pickFieldsByAllowed<T extends Record<string, any>>(
     obj: T,
-    fields: (keyof T)[]
+    fields: (keyof T)[],
   ): Partial<T> {
     return fields.reduce((acc, field) => {
       if (field in obj) {
@@ -164,7 +164,7 @@ export abstract class AbstractCrudService<
 
   protected pickFieldsByNotAllowed<T extends Record<string, any>>(
     obj: T,
-    fields: (keyof T)[]
+    fields: (keyof T)[],
   ): Partial<T> {
     const result: Partial<T> = {};
     for (const key in obj) {

--- a/apps/server/src/services/auth.service.ts
+++ b/apps/server/src/services/auth.service.ts
@@ -57,7 +57,7 @@ export class AuthService {
    * @returns The created user with token
    */
   async signup(
-    data: AuthSignUpRequest
+    data: AuthSignUpRequest,
   ): Promise<{ user: UserDTO; token: string }> {
     // Create user with Prisma (password hashing happens via schema defaults)
     const user = await prisma.user.create({
@@ -96,20 +96,20 @@ export class AuthService {
     if (!user) {
       throw new AppError(
         "Incorrect email or password",
-        ErrorCode.INVALID_CREDENTIALS
+        ErrorCode.INVALID_CREDENTIALS,
       );
     }
 
     // Validate password using Prisma's custom method
     const isPasswordValid = await prisma.user.validatePassword(
       password,
-      user.password
+      user.password,
     );
 
     if (!isPasswordValid) {
       throw new AppError(
         "Incorrect email or password",
-        ErrorCode.INVALID_CREDENTIALS
+        ErrorCode.INVALID_CREDENTIALS,
       );
     }
 
@@ -136,7 +136,7 @@ export class AuthService {
   async updatePassword(
     userId: string,
     currentPassword: string,
-    newPassword: string
+    newPassword: string,
   ): Promise<AuthSessionDTO> {
     // Get user with password field
     const user = await prisma.user.findUnique({
@@ -149,20 +149,20 @@ export class AuthService {
     if (!user) {
       throw new AppError(
         "Your current password is wrong.",
-        ErrorCode.INVALID_CREDENTIALS
+        ErrorCode.INVALID_CREDENTIALS,
       );
     }
 
     // Validate current password
     const isPasswordValid = await prisma.user.validatePassword(
       currentPassword,
-      user.password
+      user.password,
     );
 
     if (!isPasswordValid) {
       throw new AppError(
         "Your current password is wrong.",
-        ErrorCode.INVALID_CREDENTIALS
+        ErrorCode.INVALID_CREDENTIALS,
       );
     }
 
@@ -225,7 +225,7 @@ export class AuthService {
     if (token === null) {
       throw new AppError(
         "You ar not logged in! Please log in to gain access",
-        ErrorCode.UNAUTHORIZED
+        ErrorCode.UNAUTHORIZED,
       );
     }
     const decoded = this.verifyToken(token);
@@ -238,7 +238,7 @@ export class AuthService {
     if (!currentUser) {
       throw new AppError(
         "The user belonging to this token does no longer exists",
-        ErrorCode.UNAUTHORIZED
+        ErrorCode.UNAUTHORIZED,
       );
     }
 
@@ -246,12 +246,12 @@ export class AuthService {
     if (currentUser.passwordChangedAt) {
       const hasPasswordChanged = await prisma.user.isPasswordChangedAfter(
         decoded.iat!,
-        currentUser.passwordChangedAt
+        currentUser.passwordChangedAt,
       );
       if (hasPasswordChanged) {
         throw new AppError(
           "User recently changed password! Please log in to again",
-          ErrorCode.UNAUTHORIZED
+          ErrorCode.UNAUTHORIZED,
         );
       }
     }

--- a/apps/server/src/services/category.service.ts
+++ b/apps/server/src/services/category.service.ts
@@ -31,7 +31,7 @@ export class CategoryService extends AbstractCrudService<
   }
 
   protected async persistFindMany(
-    params: Pagination & CategoryQueryParams
+    params: Pagination & CategoryQueryParams,
   ): Promise<{ data: Category[]; total: number }> {
     const { skip, take, name, sort, fields } = params;
 

--- a/apps/server/src/services/config.service.ts
+++ b/apps/server/src/services/config.service.ts
@@ -31,7 +31,7 @@ export class ConfigService extends AbstractCrudService<
   // ***** Persistence Layer Methods *****
 
   protected async persistFindMany(
-    params: Pagination & ConfigQueryParams
+    params: Pagination & ConfigQueryParams,
   ): Promise<{ data: Config[]; total: number }> {
     const { skip, take, sort, fields } = params;
 

--- a/apps/server/src/services/product.service.ts
+++ b/apps/server/src/services/product.service.ts
@@ -62,7 +62,7 @@ export class ProductService extends AbstractCrudService<
   }
 
   protected async persistFindMany(
-    params: Pagination & ProductQueryParams
+    params: Pagination & ProductQueryParams,
   ): Promise<{ data: Product[]; total: number }> {
     const { skip, take, sort, fields, name } = params;
 
@@ -129,7 +129,7 @@ export class ProductService extends AbstractCrudService<
   }
 
   async getProductsByCategoryName(
-    categoryName: NAME
+    categoryName: NAME,
   ): Promise<{ data: ProductsByCategoryNameDTO[]; meta: Meta }> {
     // Find category by name
     const products = await prisma.product.findMany({
@@ -180,7 +180,7 @@ export class ProductService extends AbstractCrudService<
    */
 
   async getRelatedProducts(
-    productId: string
+    productId: string,
   ): Promise<{ data: ProductRelatedProductsDTO[]; meta: Meta }> {
     // Get base product info
     const product = await prisma.product.findUnique({
@@ -296,7 +296,7 @@ export class ProductService extends AbstractCrudService<
     if (!config) {
       throw new AppError(
         "Site configuration not found",
-        ErrorCode.INTERNAL_ERROR
+        ErrorCode.INTERNAL_ERROR,
       );
     }
 
@@ -308,7 +308,7 @@ export class ProductService extends AbstractCrudService<
     if (!config.showCaseCover || !config.showCaseWide || !config.showCaseGrid) {
       throw new AppError(
         "Incomplete showcase configuration",
-        ErrorCode.INTERNAL_ERROR
+        ErrorCode.INTERNAL_ERROR,
       );
     }
 
@@ -348,7 +348,7 @@ export class ProductService extends AbstractCrudService<
     if (!config) {
       throw new AppError(
         "Site configuration not found",
-        ErrorCode.INTERNAL_ERROR
+        ErrorCode.INTERNAL_ERROR,
       );
     }
 
@@ -360,14 +360,14 @@ export class ProductService extends AbstractCrudService<
     if (!config.featuredProduct.featuredImageText) {
       throw new AppError(
         "Featured product missing featured text",
-        ErrorCode.INTERNAL_ERROR
+        ErrorCode.INTERNAL_ERROR,
       );
     }
 
     if (!config.featuredProduct.images?.featuredImage) {
       throw new AppError(
         "Featured product missing featured image",
-        ErrorCode.INTERNAL_ERROR
+        ErrorCode.INTERNAL_ERROR,
       );
     }
 

--- a/apps/server/src/services/user.service.ts
+++ b/apps/server/src/services/user.service.ts
@@ -46,7 +46,7 @@ export class UserService extends AbstractCrudService<
   // ***** Persistence Layer Methods *****
 
   protected async persistFindMany(
-    params: Pagination & UserQueryParams
+    params: Pagination & UserQueryParams,
   ): Promise<{ data: UserPublicInfo[]; total: number }> {
     const { skip, take, role, sort, fields } = params;
 

--- a/apps/server/src/utils/catchAsync.ts
+++ b/apps/server/src/utils/catchAsync.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, RequestHandler, Response } from "express";
 
 export default <TRequest extends Request = Request>(
-    fn: (req: TRequest, res: Response, next: NextFunction) => Promise<unknown>
+    fn: (req: TRequest, res: Response, next: NextFunction) => Promise<unknown>,
   ): RequestHandler =>
   (req, res, next) => {
     fn(req as TRequest, res, next).catch((err: Error) => next(err));

--- a/apps/server/src/utils/query.ts
+++ b/apps/server/src/utils/query.ts
@@ -51,7 +51,7 @@ export const buildMeta = ({
 
 export const parseSelect = <Field extends string>(
   fields: unknown,
-  allowedFields: readonly Field[]
+  allowedFields: readonly Field[],
 ): Record<Field, true> | undefined => {
   if (typeof fields !== "string" || !fields) return undefined;
 
@@ -67,7 +67,7 @@ export const parseSelect = <Field extends string>(
 
 export const parseOrderBy = <Field extends string>(
   sort: unknown,
-  allowedFields: readonly Field[]
+  allowedFields: readonly Field[],
 ): OrderBy[] => {
   const defaultOrderBy: OrderBy[] = [{ id: "desc" }];
   if (typeof sort !== "string" || !sort) return defaultOrderBy;

--- a/apps/server/test/list-query.route.test.ts
+++ b/apps/server/test/list-query.route.test.ts
@@ -150,7 +150,9 @@ describe("GET /api/v1/products", () => {
   });
 
   it("keeps a valid sort list and whitelisted fields", async () => {
-    const { args } = await listProducts("?sort=-price,name&fields=id,price,hax");
+    const { args } = await listProducts(
+      "?sort=-price,name&fields=id,price,hax",
+    );
 
     expect(args).toMatchObject({
       orderBy: [{ price: "desc" }, { name: "asc" }],
@@ -170,7 +172,9 @@ describe("GET /api/v1/users", () => {
   });
 
   it("keeps a valid sort list and whitelisted fields", async () => {
-    const { args } = await listUsers("?sort=-createdAt,email&fields=id,email,password");
+    const { args } = await listUsers(
+      "?sort=-createdAt,email&fields=id,email,password",
+    );
 
     expect(args).toMatchObject({
       orderBy: [{ createdAt: "desc" }, { email: "asc" }],

--- a/apps/server/test/validated-request.test-d.ts
+++ b/apps/server/test/validated-request.test-d.ts
@@ -16,7 +16,7 @@ describe("ValidatedRequest", () => {
         expectTypeOf(req.verified.body.status).toEqualTypeOf<
           "PENDING" | "PROCESSING" | "SHIPPED" | "DELIVERED" | "CANCELLED"
         >();
-      }
+      },
     );
 
     catchAsync<ValidatedRequest<typeof ProductGetAllRequestSchema>>(
@@ -24,7 +24,7 @@ describe("ValidatedRequest", () => {
         expectTypeOf(req.verified.query.name).toEqualTypeOf<
           string | undefined
         >();
-      }
+      },
     );
   });
 
@@ -41,7 +41,7 @@ describe("ValidatedRequest", () => {
     const handler = catchAsync<ValidatedRequest<typeof GetOrderRequestSchema>>(
       async (req, res) => {
         res.json({ orderId: req.verified.params.orderId });
-      }
+      },
     );
 
     expectTypeOf(handler).toExtend<RequestHandler>();

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -19,11 +19,11 @@ Infer the repo from `git remote -v`; `gh` does this automatically when run insid
 
 Branch name: `<type>/<issue#>-<slug>`
 
-| Part | Rule |
-|---|---|
-| `<type>` | `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, or `perf` — the conventional-commit type matching the bulk of the change |
-| `<issue#>` | the bare GitHub issue number, no `#` |
-| `<slug>` | 2-5 kebab-case words from the issue title |
+| Part       | Rule                                                                                                                         |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `<type>`   | `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, or `perf` — the conventional-commit type matching the bulk of the change |
+| `<issue#>` | the bare GitHub issue number, no `#`                                                                                         |
+| `<slug>`   | 2-5 kebab-case words from the issue title                                                                                    |
 
 ```
 feat/112-order-history-page

--- a/docs/server-fixes-backlog.md
+++ b/docs/server-fixes-backlog.md
@@ -22,7 +22,7 @@ refactor last, since it touches every controller).
 params: z.object({ orderId: IdValidator }),    // ← the factory, not a schema
 ```
 
-Everywhere else in the codebase it's `IdValidator()`. Here the *function* is passed.
+Everywhere else in the codebase it's `IdValidator()`. Here the _function_ is passed.
 
 **Why it matters:** Zod 4 constructs the object fine, then throws
 `Invalid element at key "orderId": expected a Zod schema` **at parse time**. That throw happens
@@ -30,20 +30,24 @@ inside `validateSchema`, so it's a plain `Error` — not a `ZodError` — which 
 passes it through untouched and `sendErrorProd` returns a generic **500 INTERNAL_ERROR**.
 
 Affected routes (`apps/server/src/routes/order.route.ts:35,46`):
+
 - `GET /api/v1/orders/:orderId`
 - `PATCH /api/v1/orders/:orderId/status`
 
 Both are unconditionally broken in production. Verified by probe, not inferred.
 
 **Fix:**
+
 ```ts
 params: z.object({ orderId: IdValidator("Order") }).strict(),
 ```
+
 (Add `.strict()` while you're there — the other entity schemas have it, these two don't.)
 
 **Blast radius:** 2 lines.
 
 **Verify:**
+
 ```bash
 curl -s localhost:8000/api/v1/orders/<valid-24-char-id> -H "Cookie: jwt=<token>" | jq '.success'
 # before: false / 500 INTERNAL_ERROR — after: true
@@ -76,11 +80,11 @@ Also note it reads `process.env.NODE_ENV` directly instead of the validated `env
 const sendErrorProd = (err: unknown, req: Request, res: Response) => {
   if (err instanceof AppError) {
     if (err.code === ErrorCode.INVALID_CREDENTIALS) clearAuthCookie(req, res);
-    if (err.statusCode >= 500) console.error("ERROR 💥", err);   // ← add
+    if (err.statusCode >= 500) console.error("ERROR 💥", err); // ← add
     return res.status(err.statusCode).json(/* … */);
   }
 
-  console.error("ERROR 💥", err);                                 // ← always
+  console.error("ERROR 💥", err); // ← always
   return res.status(500).json(/* generic */);
 };
 ```
@@ -143,7 +147,7 @@ complete" and exit promptly.
 return sort.split(",").map((field) => {
   const isDescending = field.startsWith("-");
   const fieldName = isDescending ? field.substring(1) : field;
-  return { [fieldName]: isDescending ? "desc" : "asc" };   // ← any field name reaches Prisma
+  return { [fieldName]: isDescending ? "desc" : "asc" }; // ← any field name reaches Prisma
 });
 ```
 
@@ -173,6 +177,7 @@ Export conditions are matched **in declaration order**. `"import"` resolves firs
 relies on the map (rather than the top-level `"types"` fallback) never sees the declarations.
 
 **Fix:**
+
 ```json
 "exports": { ".": { "types": "./dist/src/index.d.ts", "import": "./dist/src/index.js" } }
 ```
@@ -204,6 +209,7 @@ Produces `"Product  Id is required"` (double space) in the client-facing error m
 ### 8. `req.verified` is untyped — schemas don't reach controllers
 
 **Where:**
+
 - `packages/domain/src/common.ts:237-251` — `createRequestSchema` casts its return to
   `z.ZodType<RequestSchema>` with `as any`, discarding the inferred `{params, body, query}` types
 - `apps/server/src/app.ts:16` — `verified?: Record<string, any>`
@@ -216,24 +222,34 @@ controller access is `any` with an optional-chain + non-null-assertion dance to 
 **Fix (3 steps):**
 
 1. `common.ts` — stop widening the return type:
+
    ```ts
    export const createRequestSchema = <
      P extends z.ZodTypeAny = z.ZodObject<Record<string, never>>,
      B extends z.ZodTypeAny = z.ZodUndefined,
      Q extends z.ZodTypeAny = z.ZodObject<Record<string, never>>,
-   >(options?: { params?: P; body?: B; query?: Q }) =>
+   >(options?: {
+     params?: P;
+     body?: B;
+     query?: Q;
+   }) =>
      z.object({
        params: (options?.params ?? z.strictObject({})) as P,
        body: (options?.body ?? z.undefined()) as B,
        query: (options?.query ?? z.object({})) as Q,
      });
    ```
+
    (The `RequestSchema` type export becomes dead — remove it.)
 
 2. `validation.middleware.ts` — add the narrowed request type:
+
    ```ts
-   export type ValidatedRequest<S extends ZodType> = Request & { verified: z.infer<S> };
+   export type ValidatedRequest<S extends ZodType> = Request & {
+     verified: z.infer<S>;
+   };
    ```
+
    and change the augmentation in `app.ts` to `verified?: unknown` (intersection then collapses to
    the schema type). Consider moving the augmentation to `src/types/express.d.ts` while you're here.
 
@@ -244,17 +260,20 @@ controller access is `any` with an optional-chain + non-null-assertion dance to 
      <TReq extends Request = Request>(
        fn: (req: TReq, res: Response, next: NextFunction) => Promise<unknown>,
      ): RequestHandler =>
-     (req, res, next) => { fn(req as TReq, res, next).catch(next); };
+     (req, res, next) => {
+       fn(req as TReq, res, next).catch(next);
+     };
    ```
 
 Then controllers become:
+
 ```ts
-export const getCategoryById = catchAsync<ValidatedRequest<typeof CategoryGetByIdRequestSchema>>(
-  async (req, res) => {
-    const dto = await categoryService.get(req.verified.params.id);  // string, checked
-    res.status(200).json(createSingleItemResponse(dto));
-  },
-);
+export const getCategoryById = catchAsync<
+  ValidatedRequest<typeof CategoryGetByIdRequestSchema>
+>(async (req, res) => {
+  const dto = await categoryService.get(req.verified.params.id); // string, checked
+  res.status(200).json(createSingleItemResponse(dto));
+});
 ```
 
 **Blast radius:** largest item on the list — `common.ts`, `validation.middleware.ts`,
@@ -275,6 +294,7 @@ schema and confirm the controller fails to compile.
 destructures untyped params.
 
 **Fix:** add a 5th generic:
+
 ```ts
 export abstract class AbstractCrudService<
   Entity, CreateInput, UpdateInput, DTO,
@@ -287,6 +307,7 @@ export abstract class AbstractCrudService<
   async getAll(query: Query): Promise<{ data: DTO[]; meta: Meta }> { … }
 }
 ```
+
 Then e.g. `CategoryService extends AbstractCrudService<…, ExtendedQueryParams<{ name?: NAME }>>`.
 
 Defaulting the generic means existing subclasses keep compiling until you tighten them one at a
@@ -366,6 +387,7 @@ Today: no logs at all in production, no request ids, no way to correlate a clien
 with a server log line.
 
 **Fix:** add `pino` + `pino-http` (`utils/logger.ts`, full version in blueprint §7) with:
+
 - `genReqId` assigning/propagating `x-request-id`
 - redaction of `authorization`, `cookie`, `set-cookie`, `*.password`, `*.passwordConfirm`
 - `pino-pretty` transport in development only
@@ -400,6 +422,7 @@ warnings on first run.
 ### 15. No tests
 
 There is no test setup at all. Highest value per line of effort:
+
 - one **route test** per resource via `supertest` against `app` — covers validation → controller →
   service → error middleware in one assertion
 - one **service test** per service for the business rules (`filterUpdateInput` whitelists,
@@ -445,24 +468,24 @@ is the only option and `pnpm db:push` is correct here. Nothing to change.
 
 ## Summary
 
-| # | Fix | Priority | Files touched |
-|---|---|---|---|
-| 1 | `IdValidator` uncalled → 2 routes 500 | **P0** | 1 |
-| 2 | Production errors never logged | **P0** | 1 |
-| 3 | Await DB connect before listen | P1 | 1 |
-| 4 | Unified graceful shutdown | P1 | 1 |
-| 5 | Whitelist `?sort=` fields | P1 | 4 (or 1 with #10) |
-| 6 | `exports` condition order | P1 | 1–2 |
-| 7 | Stray space in validator label | P1 | 1 |
-| 8 | Typed `req.verified` | P2 | ~11 |
-| 9 | `getAll` Query generic | P2 | 6 |
-| 10 | Shared `utils/query.ts` | P2 | 6 |
-| 11 | Dead `parseSelect` | P2 | 1 |
-| 12 | `getMe` param mutation | P2 | 2 |
-| 13 | pino structured logging | P3 | 6 |
-| 14 | ESLint flat config | P3 | ~6 |
-| 15 | Tests | P3 | new |
-| 16 | Prisma import patch script | P3 (done) | 7 |
-| 17 | Migrations | N/A (Mongo) | — |
+| #   | Fix                                   | Priority    | Files touched     |
+| --- | ------------------------------------- | ----------- | ----------------- |
+| 1   | `IdValidator` uncalled → 2 routes 500 | **P0**      | 1                 |
+| 2   | Production errors never logged        | **P0**      | 1                 |
+| 3   | Await DB connect before listen        | P1          | 1                 |
+| 4   | Unified graceful shutdown             | P1          | 1                 |
+| 5   | Whitelist `?sort=` fields             | P1          | 4 (or 1 with #10) |
+| 6   | `exports` condition order             | P1          | 1–2               |
+| 7   | Stray space in validator label        | P1          | 1                 |
+| 8   | Typed `req.verified`                  | P2          | ~11               |
+| 9   | `getAll` Query generic                | P2          | 6                 |
+| 10  | Shared `utils/query.ts`               | P2          | 6                 |
+| 11  | Dead `parseSelect`                    | P2          | 1                 |
+| 12  | `getMe` param mutation                | P2          | 2                 |
+| 13  | pino structured logging               | P3          | 6                 |
+| 14  | ESLint flat config                    | P3          | ~6                |
+| 15  | Tests                                 | P3          | new               |
+| 16  | Prisma import patch script            | P3 (done)   | 7                 |
+| 17  | Migrations                            | N/A (Mongo) | —                 |
 
 P0+P1 is roughly an afternoon and fixes two real production bugs. P2 is a weekend. P3 is ongoing.

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
     "db:seed": "turbo run db:seed",
     "db:generate": "turbo run db:generate",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "test": "turbo run test"
   },
   "devDependencies": {
     "prettier": "^3.8.1",
+    "prettier-plugin-tailwindcss": "^0.6.14",
     "turbo": "^2.8.10",
     "typescript": "5.9.3"
   },

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -61,7 +61,7 @@ const fullyExtendedClient = clientWithProductExtensions.$extends({
         // if password and password confirm exist ,iit can only be update password route
         if (args.data.password && args.data.passwordConfirm) {
           const hashedPassword = await hashPassword(
-            args.data.password as string
+            args.data.password as string,
           );
           args.data.password = hashedPassword;
           args.data.passwordConfirm = hashedPassword;
@@ -78,18 +78,18 @@ const fullyExtendedClient = clientWithProductExtensions.$extends({
     user: {
       validatePassword: async function (
         candidatePassword: string,
-        userPassword: string
+        userPassword: string,
       ) {
         return await bcrypt.compare(candidatePassword, userPassword);
       },
       isPasswordChangedAfter: async function (
         JWTTimestamp: number,
-        passwordChangedAt: Date
+        passwordChangedAt: Date,
       ) {
         if (passwordChangedAt) {
           const changedTimestamp = parseInt(
             (passwordChangedAt.getTime() / 1000).toString(),
-            10
+            10,
           );
 
           return JWTTimestamp < changedTimestamp;

--- a/packages/database/src/seed/config.seed.ts
+++ b/packages/database/src/seed/config.seed.ts
@@ -16,7 +16,7 @@ const seedConfigs = async (createdProducts: ProductCreateResult[]) => {
       acc[category.name] = category.id;
       return acc;
     },
-    {} as Record<string, string>
+    {} as Record<string, string>,
   );
 
   const config = await prisma.config.create({

--- a/packages/domain/src/app-error.ts
+++ b/packages/domain/src/app-error.ts
@@ -10,7 +10,7 @@ export class AppError extends Error {
     message: string,
     code: ErrorCode,
     statusCode?: number,
-    details?: ErrorDetail[]
+    details?: ErrorDetail[],
   ) {
     super(message);
 

--- a/packages/domain/src/common.ts
+++ b/packages/domain/src/common.ts
@@ -151,7 +151,7 @@ export function createErrorResponse(options: ErrorObject): ErrorResponse {
  * Check if response is successful
  */
 export function isSuccessResponse<T>(
-  response: ApiResponse<T>
+  response: ApiResponse<T>,
 ): response is SingleItemResponse<T> | ListResponse<T> | EmptyResponse {
   return response.success === true;
 }
@@ -160,7 +160,7 @@ export function isSuccessResponse<T>(
  * Check if response is an error
  */
 export function isErrorResponse<T>(
-  response: ApiResponse<T>
+  response: ApiResponse<T>,
 ): response is ErrorResponse {
   return response.success === false;
 }
@@ -169,7 +169,7 @@ export function isErrorResponse<T>(
  * Check if response is a paginated list
  */
 export function isListResponse<T>(
-  response: ApiResponse<T>
+  response: ApiResponse<T>,
 ): response is ListResponse<T> {
   return response.success === true && "meta" in response;
 }
@@ -178,7 +178,7 @@ export function isListResponse<T>(
  * Check if response is a single item
  */
 export function isSingleItemResponse<T>(
-  response: ApiResponse<T>
+  response: ApiResponse<T>,
 ): response is SingleItemResponse<T> {
   return (
     response.success === true && response.data !== null && !("meta" in response)
@@ -189,7 +189,7 @@ export function isSingleItemResponse<T>(
  * Check if response is empty (DELETE)
  */
 export function isEmptyResponse<T>(
-  response: ApiResponse<T>
+  response: ApiResponse<T>,
 ): response is EmptyResponse {
   return response.success === true && response.data === null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.14
+        version: 0.6.14(prettier@3.8.1)
       turbo:
         specifier: ^2.8.10
         version: 2.8.10
@@ -144,12 +147,6 @@ importers:
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
-      prettier:
-        specifier: ^3.6.2
-        version: 3.7.4
-      prettier-plugin-tailwindcss:
-        specifier: ^0.6.14
-        version: 0.6.14(prettier@3.7.4)
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.18
@@ -3308,11 +3305,6 @@ packages:
         optional: true
       prettier-plugin-svelte:
         optional: true
-
-  prettier@3.7.4:
-    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
@@ -6776,11 +6768,9 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-tailwindcss@0.6.14(prettier@3.7.4):
+  prettier-plugin-tailwindcss@0.6.14(prettier@3.8.1):
     dependencies:
-      prettier: 3.7.4
-
-  prettier@3.7.4: {}
+      prettier: 3.8.1
 
   prettier@3.8.1: {}
 


### PR DESCRIPTION
Root `pnpm format` had been exiting 1 unnoticed: `apps/client/.prettierrc` declares
`prettier-plugin-tailwindcss`, but that package was a devDependency of `apps/client` only, so
prettier invoked from the root could not resolve it and bailed before formatting anything.

**Approach: hoist.** `prettier-plugin-tailwindcss` moves to the root `devDependencies` and
`apps/client` drops its own `prettier` (`^3.6.2`) and plugin pins. Exactly one prettier — `3.8.1` —
now resolves across the workspace, and the root glob can load the plugin. The per-package
`turbo run format:check` alternative was viable but higher-churn and would have left the version
skew to solve separately.

Also in this PR:
- `format:check` script (`prettier --check`), leaving `format` as the fixer — #129's CI step was waiting on this
- `.prettierignore` covering `node_modules/`, `dist/`, `build/`, `generated/`, `coverage/`, `.turbo/` and `pnpm-lock.yaml`, so generated output is excluded deliberately rather than by `.gitignore` coincidence
- removed the dead Prettier 2 `pluginSearchDirs` key from the client config (it was printing an unknown-option warning per client file)

Split into two commits so the config fix stays reviewable: `8cc702d` is the fix, `b72568c` is the
mechanical reformat of the 63 files the broken root script had never reached (tailwind class sorting
on the client, plus prettier 3.8 formatting where the client had been using its own 3.6).

## Verification

- `pnpm format` exits 0 and sorts tailwind classes; running it twice produces no diff
- `pnpm format:check` exits 0 on a clean tree and exits 1 when a client file and a server file are hand-mangled (both flagged by name)
- `prettier --file-info` confirms the new ignore patterns hit `packages/database/generated`, `dist/`, `.turbo/` and the lockfile
- `pnpm build`, `pnpm lint`, `pnpm test` all pass

Out of scope: the glob stays `{ts,tsx,md}` (no `.json`/`.css`/`.js`), and the plugin's
`tailwindStylesheet` option for Tailwind v4 custom-utility sorting is left for its own ticket.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)