### PR TITLE
chore: make type-check cover every TypeScript package

### DIFF
--- a/.claude/skills/batch-tickets/SKILL.md
+++ b/.claude/skills/batch-tickets/SKILL.md
@@ -54,11 +54,11 @@ nothing else can proceed until it returns). Give it:
 ### 4. Verify
 
 ```bash
-pnpm build && pnpm lint && pnpm test
+pnpm build && pnpm lint && pnpm test && pnpm type-check
 ```
 
-All three must pass. There is no working root type-check script (see #134); `pnpm build` is what
-type-checks the packages. Skip `pnpm format` — it is broken at the root (see #131).
+All four must pass. `pnpm type-check` runs `tsc` in every workspace; `pnpm build` also
+type-checks the packages it compiles. Skip `pnpm format` — it is broken at the root (see #131).
 
 **On failure**: make one focused attempt to fix it yourself. If it still fails, this ticket is a
 **miss** — go to _Handling a miss_ below and move on to the next ticket. Never merge red.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ This is a **Turborepo + pnpm workspace** monorepo with:
 - **Build**: `pnpm build` (Turbo builds all packages + apps)
 - **Database**: `pnpm db:generate` → runs `prisma generate`; the generator's `importFileExtension = "js"` emits `.js` extensions on generated imports (required for ESM)
 - **Seed**: `pnpm db:seed` (located at `packages/database/src/seed/`)
-- **Type-check**: `pnpm types:watch` (watch mode for all TS projects)
+- **Type-check**: `pnpm type-check` (every workspace via Turbo) | `pnpm types:watch` (watch mode for all TS projects)
 
 ### Build Order Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ pnpm db:push           # push schema to MongoDB Atlas
 pnpm db:seed           # seed database
 
 # Type-check
+pnpm type-check        # tsc across every workspace via Turbo
 pnpm types:watch       # watch mode across all TS projects
 
 # Quality

--- a/README.md
+++ b/README.md
@@ -968,6 +968,7 @@ pnpm db:push          # Push schema changes to database (dev only)
 # Code Quality
 pnpm lint             # Run ESLint on all packages
 pnpm format           # Format all code with Prettier
+pnpm type-check       # Type check every workspace via Turbo
 pnpm types:watch      # Watch mode type checking for all packages
 
 # Production

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "prod": "vite preview",
     "start": "vite preview",
+    "type-check": "tsc -b",
     "lint": "eslint . --max-warnings 34"
   },
   "dependencies": {

--- a/apps/client/tsconfig.app.json
+++ b/apps/client/tsconfig.app.json
@@ -18,6 +18,7 @@
 
     /* Linting */
     "strict": true,
+    // Stricter than @repo/typescript-config/base.json on unused bindings; see #130.
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon --exec tsx src/index.ts",
     "build": "tsup",
     "build:tsc": "NODE_OPTIONS='--max-old-space-size=8192' tsc -p tsconfig.build.json",
-    "type-check": "tsc --noEmit --skipLibCheck",
+    "type-check": "tsc -p tsconfig.json --noEmit",
     "start": "node dist/index.js",
     "lint": "eslint . --max-warnings 61",
     "test": "vitest run"

--- a/apps/server/tsconfig.build.json
+++ b/apps/server/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
+    "noEmit": false,
     "composite": false,
     "sourceMap": true,
     "noEmitOnError": false,

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -4,8 +4,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "types": ["node"],
-    "skipLibCheck": true,
-    "composite": true
+    "composite": true,
+    "noEmit": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prod:client": "pnpm --filter \"client\" run start",
     "prod:server": "pnpm --filter \"server\" run start",
     "build": "turbo run build",
+    "type-check": "turbo run type-check",
     "types:watch": "tsc -b -w",
     "db:push": "turbo run db:push",
     "db:seed": "turbo run db:seed",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -22,6 +22,7 @@
     "studio": "prisma studio",
     "format": "prisma format",
     "lint": "eslint . --max-warnings 4",
+    "type-check": "tsc -p tsconfig.json --noEmit",
     "build": "pnpm db:generate && tsc -p tsconfig.build.json",
     "build:watch": "tsc -p tsconfig.build.json -w"
   },

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "types": ["node"],
-    "skipLibCheck": true,
     "composite": true,
     "declaration": true,
     "declarationMap": true,

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -14,7 +14,7 @@
     "build": "tsc -p tsconfig.build.json",
     "build:watch": "tsc -p tsconfig.build.json -w",
     "dev": "tsc -p tsconfig.build.json -w",
-    "types:check": "tsc -p tsconfig.json --noEmit",
+    "type-check": "tsc -p tsconfig.json --noEmit",
     "clean": "rimraf dist",
     "lint": "eslint . --max-warnings 7",
     "test": "vitest run"

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -5,7 +5,6 @@
     "rootDir": "src",
     "outDir": "dist/src",
     "declaration": true,
-    "skipLibCheck": true,
     "composite": true,
     "disableSourceOfProjectReferenceRedirect": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "files": [],
   "references": [
     { "path": "packages/database/tsconfig.build.json" },
-    { "path": "packages/domain/tsconfig.build.json" }
+    { "path": "packages/domain/tsconfig.build.json" },
+    { "path": "apps/server/tsconfig.json" },
+    { "path": "apps/client/tsconfig.json" }
   ]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,7 @@
       "persistent": true
     },
     "type-check": {
+      "dependsOn": ["^build", "db:generate"],
       "cache": true,
       "outputs": []
     },


### PR DESCRIPTION
`turbo.json` defined a `type-check` task, so the monorepo looked like it type-checked itself. A dry
run showed **one of six packages** actually ran a command — only `apps/server`. A green
`type-check` was proving nothing about the other five.

## Changes

- **One script name.** `type-check` everywhere: `packages/domain`'s `types:check` is renamed (no alias left; nothing referenced the old spelling), and `apps/client` (`tsc -b` — `tsconfig.app.json` already sets `noEmit`, so build mode is a pure check) and `packages/database` gain a script they never had.
- **Root entry point.** `pnpm type-check` → `turbo run type-check`. The task gains `"dependsOn": ["^build", "db:generate"]`: server/domain/client resolve workspace deps through built `dist` output, and `packages/database`'s tsconfig includes the gitignored `generated/**/*.ts`, which is absent on a clean checkout.
- **`types:watch` now means what it says.** Both apps are added to the root `tsconfig.json` references, so the documented cross-repo watch covers `apps/server` and `apps/client` instead of silently skipping them. This route worked cleanly, so `CLAUDE.md`'s "all TS projects" claim is made true rather than reworded.
- **`skipLibCheck` triplication → one place.** Now only `packages/config-typescript/base.json` (plus the client's `app`/`node` configs, which legitimately don't extend the base). The server's CLI flag and the per-package re-sets are gone.
- **Client strictness divergence documented,** not resolved: one line in `apps/client/tsconfig.app.json` pointing at #130, which owns the `noUnusedLocals`/`noUnusedParameters` decision. Nothing here pre-empts it.

`apps/server/tsconfig.json` becomes `noEmit: true` so root `tsc -b` cannot clobber `apps/server/dist`
with tsc output over the tsup bundle; `tsconfig.build.json` sets `noEmit: false` to keep the `build:tsc`
path emitting. Confirmed: `build:tsc` still emits 70 files, `pnpm build` still emits the 2-file bundle,
and root `tsc -b` leaves `dist` untouched.

## Verification

The point of the ticket, so all four were tested individually with `pnpm type-check --force`
(turbo `--force`, so caching could not mask a pass) and reverted after each:

| package | result |
|---|---|
| `packages/database` | fails, `@repo/database:type-check` TS2322 |
| `packages/domain` | fails, `@repo/domain:type-check` TS2322 |
| `apps/server` | fails, `server:type-check` TS2322 |
| `apps/client` | fails, `client:type-check` TS2322 |

`npx turbo run type-check --dry=json` now shows a real command for all four TS packages; only the two
config-only packages remain `<NONEXISTENT>`.

`pnpm build`, `pnpm lint`, `pnpm test`, `pnpm type-check` and `pnpm format:check` all pass.

Docs updated for the new root script: `CLAUDE.md`, `README.md`, `.github/copilot-instructions.md`, and
the `batch-tickets` skill (which hardcoded "there is no working root type-check script (see #134)" in
its verify step). No CI type-check workflow exists yet — #129 still adds it.

Out of scope: restructuring `apps/client` onto the shared base (optional per the issue; `bundler`
resolution and DOM libs must stay), the unused-binding values themselves (#130), and the server's
three-tsconfig split (sanity-checked — all three are used, left alone).

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)