### PR TITLE
docs: put format:check in the batch-tickets merge gate

### DIFF
--- a/.claude/skills/batch-tickets/SKILL.md
+++ b/.claude/skills/batch-tickets/SKILL.md
@@ -54,11 +54,13 @@ nothing else can proceed until it returns). Give it:
 ### 4. Verify
 
 ```bash
-pnpm build && pnpm lint && pnpm test && pnpm type-check
+pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check
 ```
 
-All four must pass. `pnpm type-check` runs `tsc` in every workspace; `pnpm build` also
-type-checks the packages it compiles. Skip `pnpm format` — it is broken at the root (see #131).
+All five must pass. `pnpm type-check` runs `tsc` in every workspace; `pnpm build` also
+type-checks the packages it compiles. `pnpm format:check` verifies formatting without rewriting —
+use it rather than `pnpm format`, which is the fixer and would hide a formatting miss by silently
+correcting it.
 
 **On failure**: make one focused attempt to fix it yourself. If it still fails, this ticket is a
 **miss** — go to _Handling a miss_ below and move on to the next ticket. Never merge red.


### PR DESCRIPTION
The `batch-tickets` skill's verify step still said *"Skip `pnpm format` — it is broken at the root
(see #131)"*. #131 (#140) fixed the root formatter and added the `--check` counterpart, so that
instruction is stale.

The gate is now `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check`.
The wording calls out **why it must be `format:check` and not `format`**: the latter is the fixer, so
running it in a verify step would silently rewrite a formatting miss instead of failing on it.

Follow-up to #140 and #141; noticed while running the batch that shipped them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)