### PR TITLE
chore: teach ESLint the underscore convention and ratchet warning budgets

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -9,7 +9,7 @@
     "prod": "vite preview",
     "start": "vite preview",
     "type-check": "tsc -b",
-    "lint": "eslint . --max-warnings 34"
+    "lint": "eslint . --max-warnings 23"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",

--- a/apps/client/src/components/layouts/content-layout/nav-bar/user-dropdown/logged-in-user-dropdown.tsx
+++ b/apps/client/src/components/layouts/content-layout/nav-bar/user-dropdown/logged-in-user-dropdown.tsx
@@ -43,7 +43,7 @@ export default function LoggedInUserDropdown() {
         description: "See you soon!",
         duration: 3000,
       });
-    } catch (error) {
+    } catch {
       toast({
         title: "Logout failed",
         description: "Please try again",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "build:tsc": "NODE_OPTIONS='--max-old-space-size=8192' tsc -p tsconfig.build.json",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "start": "node dist/index.js",
-    "lint": "eslint . --max-warnings 61",
+    "lint": "eslint . --max-warnings 28",
     "test": "vitest run"
   },
   "dependencies": {

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -58,7 +58,7 @@ app.use(cookieParser());
 // 7. Routes
 app.use("/api/v1", indexRoute);
 
-app.all(/.*/, (req, res, next) => {
+app.all(/.*/, (req, _res, next) => {
   next(
     new AppError(
       `Can't find ${req.originalUrl} on this server!`,

--- a/apps/server/src/middlewares/error.middleware.ts
+++ b/apps/server/src/middlewares/error.middleware.ts
@@ -22,7 +22,7 @@ const handleMissingDocumentDB = (err: Prisma.PrismaClientKnownRequestError) => {
   return new AppError(message, ErrorCode.NOT_FOUND);
 };
 
-const handleValidationErrorDB = (err: Error) => {
+const handleValidationErrorDB = () => {
   // ** should get caught by zod before this point
   const message = `Invalid query data. -  Unprocessable Content`;
   return new AppError(message, ErrorCode.VALIDATION_ERROR);
@@ -117,7 +117,7 @@ const normalizeError = (err: unknown): AppError | unknown => {
   }
 
   if (isPrismaValidationError(err)) {
-    return handleValidationErrorDB(err);
+    return handleValidationErrorDB();
   }
 
   // JWT errors
@@ -199,11 +199,12 @@ const sendErrorProd = (err: unknown, req: Request, res: Response) => {
   );
 };
 
+// Express only treats a 4-arity handler as error middleware, so `_next` must stay.
 export default (
   err: unknown,
   req: Request,
   res: Response,
-  next: NextFunction,
+  _next: NextFunction,
 ) => {
   // Convert known error types to AppError
   const normalizedError = normalizeError(err);

--- a/apps/server/src/routes/health.route.ts
+++ b/apps/server/src/routes/health.route.ts
@@ -7,7 +7,7 @@ const healthRouter: express.Router = express.Router();
  * @desc    Health check endpoint for load balancers and monitoring
  * @access  Public
  */
-healthRouter.get("/", (req, res) => {
+healthRouter.get("/", (_req, res) => {
   res.status(200).json({
     status: "ok",
     timestamp: new Date().toISOString(),

--- a/packages/config-eslint/README.md
+++ b/packages/config-eslint/README.md
@@ -25,10 +25,19 @@ are nominal and lint would never fail on its own. Enforcement comes from each
 package's budget instead:
 
 ```json
-"lint": "eslint . --max-warnings 61"
+"lint": "eslint . --max-warnings 28"
 ```
 
-The number is that package's warning count at the time of the ESLint 9 flat-config
-migration. It is a **ratchet**: a new warning pushes the count over budget and
-fails the build, while the existing backlog stays visible instead of being
-silenced. Lower the number as warnings are burned off; never raise it.
+The number is that package's **exact** current warning count, so it carries no
+slack: a new warning pushes the count over budget and fails the build, while the
+existing backlog stays visible instead of being silenced. Lower the number as
+warnings are burned off; never raise it.
+
+## Unused bindings
+
+`@typescript-eslint/no-unused-vars` is configured with `^_` ignore patterns for
+arguments, variables and caught errors, matching the codebase convention of
+prefixing an intentionally-unused binding with `_`. `@repo/typescript-config`
+enables `noUnusedLocals` and `noUnusedParameters` so the compiler enforces the
+same thing; note TypeScript honours the `_` prefix for parameters and caught
+errors but not for locals.

--- a/packages/config-eslint/base.js
+++ b/packages/config-eslint/base.js
@@ -49,6 +49,14 @@ export const base = tseslint.config(
         "error",
         { allowList: turboEnvAllowList },
       ],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
     },
   },
 );

--- a/packages/config-typescript/base.json
+++ b/packages/config-typescript/base.json
@@ -13,8 +13,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "preserveWatchOutput": true,
     "skipLibCheck": true,
     "strict": true

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -21,7 +21,7 @@
     "db:reset": "pnpm db:push --force-reset && pnpm db:generate && pnpm db:seed",
     "studio": "prisma studio",
     "format": "prisma format",
-    "lint": "eslint . --max-warnings 4",
+    "lint": "eslint . --max-warnings 3",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "build": "pnpm db:generate && tsc -p tsconfig.build.json",
     "build:watch": "tsc -p tsconfig.build.json -w"

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -16,7 +16,7 @@
     "dev": "tsc -p tsconfig.build.json -w",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "clean": "rimraf dist",
-    "lint": "eslint . --max-warnings 7",
+    "lint": "eslint . --max-warnings 1",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/domain/src/user.ts
+++ b/packages/domain/src/user.ts
@@ -4,8 +4,6 @@ import type { ExtendedQueryParams } from "./common.js";
 import {
   BaseQueryParamsSchema,
   createRequestSchema,
-  EmptyResponse,
-  EmptyResponseSchema,
   ListResponse,
   ListResponseSchema,
   SingleItemResponse,


### PR DESCRIPTION
Closes #130

## What changed

**1. ESLint now reads the `_` convention.** Added to `packages/config-eslint/base.js`:

```js
"@typescript-eslint/no-unused-vars": ["error", {
  argsIgnorePattern: "^_",
  varsIgnorePattern: "^_",
  caughtErrorsIgnorePattern: "^_",
}],
```

21 of the 26 `no-unused-vars` warnings were on identifiers already following the convention. **Zero `no-unused-vars` warnings remain anywhere.**

**2. The genuinely-unused bindings are gone.** The issue's attribution was slightly off — the 5 live in server ×2, client ×1, domain ×2 (not client ×3):

| binding | file | action |
|---|---|---|
| `EmptyResponse`, `EmptyResponseSchema` | `packages/domain/src/user.ts` | deleted from the import (both still defined in `common.ts` and used by five other modules) |
| `catch (error)` | `logged-in-user-dropdown.tsx` | deleted via optional catch binding |
| `err` param | `handleValidationErrorDB` in `error.middleware.ts` | parameter deleted, call site updated |
| `next` param | default error handler in `error.middleware.ts` | **renamed to `_next`, not deleted** — see below |

**One deliberate deviation from the acceptance criteria.** Express identifies error middleware purely by `fn.length === 4`. Deleting `next` would silently demote the default export to an ordinary middleware and take the entire error pipeline offline. Renamed with the `_` prefix instead, with a one-line comment flagging the arity invariant.

**3. Budgets are now exact.** Every `--max-warnings` set to its precise post-fix count:

| package | before | after | old cap | new cap |
|---|---|---|---|---|
| `apps/server` | 40 | 28 | 61 | 28 |
| `apps/client` | 34 | 23 | 34 | 23 |
| `@repo/domain` | 3 | 1 | 7 | 1 |
| `@repo/database` | 4 | 3 | 4 | 3 |
| `@repo/eslint-config` | 0 | 0 | 0 | 0 |
| `@repo/typescript-config` | 0 | 0 | 0 | 0 |

Remaining backlog is `no-explicit-any` (37, → #133), `react-refresh/only-export-components` (14), `no-unused-expressions` (2), `no-empty-object-type` (2) — all left visible, none silenced.

## Decision on `noUnusedLocals` / `noUnusedParameters`: **turned ON**

1. **`apps/client` already enforced both.** Its `tsconfig.app.json` / `tsconfig.node.json` set them `true` and don't extend `@repo/typescript-config` at all — the shared base's `false` was the outlier.
2. **The cost was two renames.** A full `pnpm type-check` with the flags on produced exactly two errors, both leading unused Express params in server, both fixed with the `_` prefix already used everywhere (`app.ts`, `health.route.ts`).
3. **TS catches a class ESLint structurally cannot.** typescript-eslint defaults to `args: "after-used"`, so it will never report a leading unused parameter followed by a used one — precisely those two cases.
4. **Caveat, documented in the config-eslint README:** TypeScript honours `_` for parameters and caught errors but **not** for locals — `const _x = 1` passes ESLint and fails `tsc`. There are zero unused locals today, so nothing breaks, but a future author wanting one will need `void _x`.

## Verification

The ratchet was verified per package, not just on server: a throwaway file with one unused non-underscore `const` was dropped into each of the six packages in turn, and all six exited 1 (server 29>28, client 24>23, database 4>3, domain 2>1, config-eslint 1>0, config-typescript 1>0). Independently re-confirmed each cap is *exact* by re-running lint at `N-1`, which fails, against `N`, which passes.

Full gate green:

```
pnpm build        exit 0   (4/4 tasks)
pnpm lint         exit 0   (6/6 tasks)
pnpm test         exit 0   (domain 6 tests, server 103 tests)
pnpm type-check   exit 0   (7/7 tasks)
pnpm format:check exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)