### PR TITLE
ci: run lint, type-check, tests and format check on every PR

### DIFF
--- a/.claude/skills/batch-tickets/SKILL.md
+++ b/.claude/skills/batch-tickets/SKILL.md
@@ -20,8 +20,8 @@ conflicts are impossible.
      print it and proceed.
 2. **Check the tree is clean and `main` is current**: `git switch main && git pull`. Abort the whole
    batch if the tree is dirty; that is the user's uncommitted work.
-3. **Announce the gate**: this repo has no PR CI, so `pnpm build && pnpm lint && pnpm test` run
-   locally _is_ the merge gate.
+3. **Announce the gate**: `.github/workflows/ci.yml` runs the same checks on every PR, and the
+   local run below is the pre-merge gate that mirrors it.
 
 ## Per-ticket loop
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded PR pushes stop early; pushes to main keep their status.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -18,8 +19,7 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     env:
-      # Nothing here connects to a database, but prisma.config.ts refuses to
-      # load without the variable, so generate/build/type-check need a value.
+      # prisma.config.ts refuses to load without it; nothing here connects.
       DATABASE_URL: mongodb://localhost:27017/audiophile
       MONGOMS_DOWNLOAD_DIR: ${{ github.workspace }}/.cache/mongodb-binaries
 
@@ -42,8 +42,7 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      # mongodb-memory-server downloads its binary from a postinstall hook, so
-      # the cache has to be restored before install, not before the test step.
+      # A postinstall hook downloads the binary, so restore before install.
       - name: Cache MongoDB binary
         uses: actions/cache@v4
         with:
@@ -51,6 +50,7 @@ jobs:
           key: mongodb-binaries-${{ runner.os }}-${{ steps.mongodb.outputs.version }}
 
       - run: pnpm install --frozen-lockfile
+        timeout-minutes: 10
 
       # The Prisma client is generated, not committed.
       - run: pnpm db:generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    env:
+      # Nothing here connects to a database, but prisma.config.ts refuses to
+      # load without the variable, so generate/build/type-check need a value.
+      DATABASE_URL: mongodb://localhost:27017/audiophile
+      MONGOMS_DOWNLOAD_DIR: ${{ github.workspace }}/.cache/mongodb-binaries
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve MongoDB version
+        id: mongodb
+        run: |
+          version=$(sed -n 's/^const MONGODB_VERSION = "\(.*\)";$/\1/p' apps/server/test/helpers/global-setup.ts)
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "MONGOMS_VERSION=$version" >> "$GITHUB_ENV"
+
+      # pnpm's version comes from the root package.json `packageManager` field.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # mongodb-memory-server downloads its binary from a postinstall hook, so
+      # the cache has to be restored before install, not before the test step.
+      - name: Cache MongoDB binary
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.MONGOMS_DOWNLOAD_DIR }}
+          key: mongodb-binaries-${{ runner.os }}-${{ steps.mongodb.outputs.version }}
+
+      - run: pnpm install --frozen-lockfile
+
+      # The Prisma client is generated, not committed.
+      - run: pnpm db:generate
+
+      - run: pnpm build
+
+      - run: pnpm lint
+
+      - run: pnpm type-check
+
+      - run: pnpm test
+        timeout-minutes: 10
+
+      - run: pnpm format:check

--- a/apps/server/test/helpers/global-setup.ts
+++ b/apps/server/test/helpers/global-setup.ts
@@ -8,6 +8,7 @@ const run = promisify(execFile);
 
 // Pinned so a run does not silently change engine version; the binary is
 // downloaded once at install time and cached globally after that.
+// `.github/workflows/ci.yml` parses this line for its binary cache key.
 const MONGODB_VERSION = "8.2.6";
 
 declare module "vitest" {


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` — a single `verify` job on `pull_request` targeting `main` and on `push` to `main`:

install → `db:generate` → `build` → `lint` → `type-check` → `test` → `format:check`

Notes on the two non-obvious bits:

- **`DATABASE_URL` is set to a dummy value.** `packages/database/prisma.config.ts` calls `env("DATABASE_URL")`, which throws at config-load time when the variable is missing — so `prisma generate`, `build` and `type-check` all need one. Nothing in the job connects to a database.
- **The MongoDB binary cache is restored before `pnpm install`, not before the test step.** `mongodb-memory-server` is in `onlyBuiltDependencies`, so its postinstall hook downloads the binary during install. The cache is keyed on the version pinned in `apps/server/test/helpers/global-setup.ts`, extracted into a step output so the key follows the pin.

`concurrency` with `cancel-in-progress` stops superseded pushes. `keep-alive.yml` is untouched.

**Manual follow-up:** branch protection on `main` requiring the `Verify` check is a repo setting rather than a file, so it is not in this PR.

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)