### PR TITLE
fix: return 403 for cart and order ownership failures

### DIFF
--- a/apps/server/src/services/cart.service.ts
+++ b/apps/server/src/services/cart.service.ts
@@ -266,7 +266,7 @@ export class CartService extends AbstractCrudService<
     }
 
     if (cartItem.cart.userId !== userId) {
-      throw new AppError("Unauthorized", ErrorCode.UNAUTHORIZED);
+      throw new AppError("Forbidden", ErrorCode.FORBIDDEN);
     }
 
     // Update quantity
@@ -294,7 +294,7 @@ export class CartService extends AbstractCrudService<
     }
 
     if (cartItem.cart.userId !== userId) {
-      throw new AppError("Unauthorized", ErrorCode.UNAUTHORIZED);
+      throw new AppError("Forbidden", ErrorCode.FORBIDDEN);
     }
 
     // Delete cart item

--- a/apps/server/src/services/order.service.ts
+++ b/apps/server/src/services/order.service.ts
@@ -173,7 +173,7 @@ export class OrderService extends AbstractCrudService<
 
     // Verify ownership
     if (order.userId !== userId) {
-      throw new AppError("Unauthorized", ErrorCode.UNAUTHORIZED);
+      throw new AppError("Forbidden", ErrorCode.FORBIDDEN);
     }
 
     return this.toDTO(order as any);

--- a/apps/server/test/cart.route.test.ts
+++ b/apps/server/test/cart.route.test.ts
@@ -104,7 +104,6 @@ describe("PATCH /api/v1/cart/items/:cartItemId", () => {
     expect(res.body.data).toMatchObject({ itemCount: 5, subtotal: 500 });
   });
 
-  // Pins today's 401; an authenticated non-owner arguably deserves 403 (#135).
   it("refuses to touch another user's cart item", async () => {
     const owner = await createUser();
     const intruder = await createUser();
@@ -120,8 +119,8 @@ describe("PATCH /api/v1/cart/items/:cartItemId", () => {
       .set("Cookie", authCookie(intruder.id))
       .send({ quantity: 2 });
 
-    expect(res.status).toBe(401);
-    expect(res.body.error.code).toBe(ErrorCode.UNAUTHORIZED);
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe(ErrorCode.FORBIDDEN);
   });
 });
 

--- a/apps/server/test/order.route.test.ts
+++ b/apps/server/test/order.route.test.ts
@@ -136,6 +136,19 @@ describe("GET /api/v1/orders/:orderId", () => {
     expect(res.body.data.id).toBe(created.body.data.id);
   });
 
+  it("refuses to read another user's order", async () => {
+    const owner = await createUser();
+    const intruder = await createUser();
+    const { res: created } = await orderFromCart(owner.id, 800);
+
+    const res = await request(app)
+      .get(`/api/v1/orders/${created.body.data.id}`)
+      .set("Cookie", authCookie(intruder.id));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe(ErrorCode.FORBIDDEN);
+  });
+
   it("returns VALIDATION_ERROR for a malformed order id", async () => {
     const user = await createUser();
 

--- a/docs/adr/0001-ownership-failures-return-403.md
+++ b/docs/adr/0001-ownership-failures-return-403.md
@@ -1,0 +1,20 @@
+# Ownership failures return 403, not 401
+
+An authenticated caller reaching for a cart item or order that belongs to someone else now gets
+`ErrorCode.FORBIDDEN` (403) instead of `ErrorCode.UNAUTHORIZED` (401). This keeps 401 meaning
+strictly "you are not authenticated", so the client's Axios interceptor and any future
+refresh-token logic can key off it unambiguously, and it matches what `authorize()` already
+returns for a role mismatch.
+
+## Considered options
+
+Returning 404 (indistinguishable from a missing resource) was rejected: this is a first-party
+storefront, ids are unguessable ObjectIds, and there is no enumeration surface, so the existence
+of another user's cart item or order is not a meaningful information leak. A distinct 403 is more
+honest and easier to debug.
+
+## Consequences
+
+This is an API contract change. `apps/server/test/cart.route.test.ts` and
+`apps/server/test/order.route.test.ts` assert the new status; nothing in `apps/client` branched on
+a 401 from these routes, so no client change was needed.


### PR DESCRIPTION
Ownership failures in `CartService.updateCartItem`, `CartService.removeFromCart` and `OrderService.getOrderById` threw `UNAUTHORIZED` (401) when an authenticated caller reached for a resource they do not own. 401 means "not authenticated" — the client's `getApi()` interceptor and any future refresh-token logic can reasonably read it as an expired session. These are authorization failures, so they now throw `FORBIDDEN` (403), matching what `authorize()` already returns for a role mismatch.

**403 over 404**: ids are unguessable ObjectIds with no enumeration surface, so making another user's resource indistinguishable from a missing one buys nothing. Recorded in a new `docs/adr/0001-ownership-failures-return-403.md` (first ADR in the repo; follows the numbering and format `docs/agents/domain.md` prescribes).

**Tests**: `cart.route.test.ts` had the 401 pinned as characterization — now asserts 403. `order.route.test.ts` had no ownership test at all (its existing 403 is the admin role check on `PATCH /:orderId/status`), so one was added for `GET /api/v1/orders/:orderId`.

**Client audit**: nothing keys off 401 from these routes. `grep` for `401`/`403`/`UNAUTHORIZED`/`FORBIDDEN` across `apps/client/src` returns zero matches — the axios interceptor only short-circuits `isCancel`, `processAxiosError` classifies by Axios `error.code` and passes `statusCode` through, the TanStack Query retry policy buckets all 4xx alike, and the checkout redirect keys off `isAuthenticated`, not an HTTP status. No client change was needed.

`ErrorCode.FORBIDDEN` already mapped to 403 in `ERROR_CODE_TO_STATUS`; no domain change.

Verified locally: `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` all pass.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)