### PR TITLE
feat: log programmer errors regardless of their mapped status code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Route → validateSchema middleware → Controller → Service → Prisma
 - **`catchAsync<ValidatedRequest<typeof XRequestSchema>>`** — types `req.verified` from the route's schema; use it in every handler that reads validated input
 - **`AppError`** — throw with error codes from `@repo/domain/error-codes`; never throw raw errors
 - **Zod errors** — auto-converted to `AppError(422, VALIDATION_ERROR)` by error middleware
-- **Logging** — `pino` + `pino-http`; inside a request use `req.log` (it carries `requestId`), never the bare `logger`. Errors are logged once, at the boundary: the error middleware puts 5xx on `res.err` and pino-http emits the single line for that request. Layers in between throw, they don't log.
+- **Logging** — `pino` + `pino-http`; inside a request use `req.log` (it carries `requestId`), never the bare `logger`. Errors are logged once, at the boundary: the error middleware puts the error on `res.err` and its severity on `res.errLogLevel` (`error` for our own failures - a non-operational `AppError` or a 5xx - `warn` for client faults) and pino-http emits the single line for that request. Layers in between throw, they don't log.
 
 ### Service layer
 

--- a/apps/server/ERROR_FLOW.md
+++ b/apps/server/ERROR_FLOW.md
@@ -261,8 +261,10 @@ Every response carries an `x-request-id` header - the id the client sent, or one
 request's log line, so a client-reported failure can be looked up directly.
 
 Errors are logged **once, at the boundary**. The error middleware never calls the logger itself:
-for a 5xx it puts the error on `res.err`, and `pino-http` folds it into the single completion line
-it already emits for the request (at `error` level; 4xx stay at `info`). Controllers and services
+it puts the error on `res.err` and the severity it decided on `res.errLogLevel`, and `pino-http`
+folds both into the single completion line it already emits for the request. Severity follows the
+error's origin, not its status: a non-operational `AppError` (a bug of ours, whatever status it maps
+to) or a 5xx is logged at `error`, every other failure at `warn`. Controllers and services
 should not log errors on the way up - throw an `AppError` and let the boundary report it. Anything
 else worth logging inside a request goes through `req.log`, which carries `requestId`, not the
 bare `logger`.

--- a/apps/server/src/middlewares/error.middleware.ts
+++ b/apps/server/src/middlewares/error.middleware.ts
@@ -25,7 +25,14 @@ const handleMissingDocumentDB = (err: Prisma.PrismaClientKnownRequestError) => {
 const handleValidationErrorDB = () => {
   // ** should get caught by zod before this point
   const message = `Invalid query data. -  Unprocessable Content`;
-  return new AppError(message, ErrorCode.VALIDATION_ERROR);
+  // A malformed query is our bug, whatever status the client ends up seeing.
+  return new AppError(
+    message,
+    ErrorCode.VALIDATION_ERROR,
+    undefined,
+    undefined,
+    false,
+  );
 };
 
 // safety net for unexpected zod errors
@@ -209,19 +216,21 @@ export default (
   // Convert known error types to AppError
   const normalizedError = normalizeError(err);
 
-  // Server-side failures are ours to debug; 4xx are the client's problem and
-  // stay off the error level. Handing the error to pino-http instead of
-  // logging it here keeps the failure on the one line that already carries the
-  // request id, method, url and status - the boundary logs once. Finer
-  // severity rules for 4xx are #111.
+  // Severity follows the error's origin, not the status it maps to: a
+  // programmer error laundered into a 4xx is still ours to debug, while a
+  // client fault stays at `warn` - kept as signal, off the error level.
+  // Handing it to pino-http rather than logging here keeps the failure on the
+  // one line that already carries the request id, method, url and status.
   const statusCode =
     normalizedError instanceof AppError ? normalizedError.statusCode : 500;
-  if (statusCode >= 500) {
-    res.err =
-      normalizedError instanceof Error
-        ? normalizedError
-        : new Error(String(normalizedError));
-  }
+  const isOperational =
+    normalizedError instanceof AppError && normalizedError.isOperational;
+
+  res.err =
+    normalizedError instanceof Error
+      ? normalizedError
+      : new Error(String(normalizedError));
+  res.errLogLevel = !isOperational || statusCode >= 500 ? "error" : "warn";
 
   // Send appropriate response based on environment
   if (env.NODE_ENV === "development") {

--- a/apps/server/src/types/http.d.ts
+++ b/apps/server/src/types/http.d.ts
@@ -1,0 +1,8 @@
+import "http";
+
+declare module "http" {
+  interface ServerResponse {
+    // Set by the error boundary; pino-http reads it as the completion line's level.
+    errLogLevel?: "warn" | "error";
+  }
+}

--- a/apps/server/src/utils/logger.ts
+++ b/apps/server/src/utils/logger.ts
@@ -59,12 +59,12 @@ export const httpLoggerOptions: PinoHttpOptions = {
   },
   customProps: (req) => ({ requestId: req.id }),
   // Without this pino-http reports every request at `info`, including the ones
-  // that failed. The error middleware puts the real error on `res.err`, so the
-  // completion line is also the failure line. `res.err` is checked first so
-  // severity follows the boundary's judgement rather than a status code the
-  // boundary may no longer be able to set (a response already on the wire).
+  // that failed. The error middleware puts the real error on `res.err` and the
+  // severity it decided on `res.errLogLevel`, so the completion line is also
+  // the failure line - and only the boundary knows whether the failure was
+  // ours or the caller's, which the status code alone cannot say.
   customLogLevel: (_req, res) =>
-    res.err || res.statusCode >= 500 ? "error" : "info",
+    res.errLogLevel ?? (res.statusCode >= 500 ? "error" : "info"),
 };
 
 export const httpLogger = pinoHttp({ ...httpLoggerOptions, logger });

--- a/apps/server/test/logger.test.ts
+++ b/apps/server/test/logger.test.ts
@@ -144,7 +144,21 @@ describe("error boundary logging", () => {
     expect(res.body.error.requestId).toBe(lines[0]!.requestId);
   });
 
-  it("leaves a client error at the default level with no error attached", async () => {
+  it("logs a server failure the client asked for at error level", async () => {
+    const { lines, logger } = collect();
+
+    const res = await request(
+      appThatFailsWith(logger, () => {
+        throw new AppError("broken", ErrorCode.INTERNAL_ERROR);
+      }),
+    ).get("/boom");
+
+    expect(res.status).toBe(500);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.level).toBe(50);
+  });
+
+  it("downgrades a client fault to warn instead of dropping it", async () => {
     const { lines, logger } = collect();
 
     const res = await request(
@@ -155,8 +169,42 @@ describe("error boundary logging", () => {
 
     expect(res.status).toBe(404);
     expect(lines).toHaveLength(1);
-    expect(lines[0]!.level).toBe(30);
-    expect(lines[0]!.err).toBeUndefined();
+    expect(lines[0]!.level).toBe(40);
+    expect(lines[0]!.err?.message).toBe("nope");
+  });
+
+  // A malformed Prisma query means our query shape is wrong, and `normalizeError`
+  // launders it into an ordinary validation error - so only the origin flag can
+  // still tell the boundary this one is a bug of ours.
+  it("logs a programmer error at error level even when it maps to a 4xx", async () => {
+    const { lines, logger } = collect();
+    const prismaValidationError = Object.assign(
+      new Error("Invalid `prisma.product.findMany()` invocation"),
+      { name: "PrismaClientValidationError" },
+    );
+
+    const res = await request(
+      appThatFailsWith(logger, () => {
+        throw prismaValidationError;
+      }),
+    ).get("/boom");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe(ErrorCode.VALIDATION_ERROR);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.level).toBe(50);
+  });
+
+  it("keeps the operational flag out of the response body", async () => {
+    const { logger } = collect();
+
+    const res = await request(
+      appThatFailsWith(logger, () => {
+        throw new AppError("nope", ErrorCode.NOT_FOUND);
+      }),
+    ).get("/boom");
+
+    expect(JSON.stringify(res.body)).not.toContain("isOperational");
   });
 
   it("keeps a failure at error level when the response already went out", async () => {

--- a/apps/server/test/rate-limit.test.ts
+++ b/apps/server/test/rate-limit.test.ts
@@ -99,8 +99,8 @@ describe("rate limiting", () => {
 
     expect(res.status).toBe(429);
     expect(lines).toHaveLength(2);
-    expect(lines[1]!.level).toBe(30);
-    expect(lines[1]!.err).toBeUndefined();
+    expect(lines[1]!.level).toBe(40);
+    expect(lines[1]!.err?.message).toBe("slow down");
     expect(lines[1]!.res?.statusCode).toBe(429);
   });
 });

--- a/packages/domain/src/app-error.ts
+++ b/packages/domain/src/app-error.ts
@@ -5,17 +5,21 @@ export class AppError extends Error {
   statusCode: number;
   code: ErrorCode;
   details?: ErrorDetail[];
+  // False marks our bug rather than the caller's fault; never sent to clients.
+  isOperational: boolean;
 
   constructor(
     message: string,
     code: ErrorCode,
     statusCode?: number,
     details?: ErrorDetail[],
+    isOperational = true,
   ) {
     super(message);
 
     this.code = code;
     this.details = details;
+    this.isOperational = isOperational;
     // Auto-derive status code from error code if not provided
     this.statusCode = statusCode ?? getStatusCode(code);
 

--- a/packages/domain/src/common.ts
+++ b/packages/domain/src/common.ts
@@ -31,6 +31,9 @@ export type ErrorDetail = z.infer<typeof ErrorDetailSchema>;
 
 /**
  * Error Object Schema
+ *
+ * The satisfies clause omits `isOperational`: it is a server-side log signal
+ * and must never reach the client.
  */
 export const ErrorObjectSchema = z.object({
   code: z.enum(ErrorCode),
@@ -41,7 +44,7 @@ export const ErrorObjectSchema = z.object({
   /** Correlates this response with the server log line for the request. */
   requestId: z.string().optional(),
 }) satisfies z.ZodType<
-  Omit<AppError, "name" | "cause"> & { requestId?: string }
+  Omit<AppError, "name" | "cause" | "isOperational"> & { requestId?: string }
 >;
 
 export type ErrorObject = z.infer<typeof ErrorObjectSchema>;

--- a/packages/domain/test/app-error.test.ts
+++ b/packages/domain/test/app-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { AppError, createErrorResponse, ErrorCode } from "../src/index.js";
+
+// `isOperational` separates a fault the caller caused from a bug of ours, so
+// the log severity of an error no longer has to be read off its status code.
+// It is a server-side signal: the error envelope must never carry it.
+
+describe("AppError.isOperational", () => {
+  it("defaults to true", () => {
+    expect(new AppError("nope", ErrorCode.NOT_FOUND).isOperational).toBe(true);
+  });
+
+  it("can be constructed false", () => {
+    const err = new AppError(
+      "bad query",
+      ErrorCode.VALIDATION_ERROR,
+      undefined,
+      undefined,
+      false,
+    );
+
+    expect(err.isOperational).toBe(false);
+  });
+
+  it("is not serialized into the error envelope", () => {
+    const err = new AppError("nope", ErrorCode.NOT_FOUND);
+
+    const response = createErrorResponse({
+      message: err.message,
+      code: err.code,
+      details: err.details,
+      statusCode: err.statusCode,
+    });
+
+    expect(JSON.stringify(response)).not.toContain("isOperational");
+  });
+});


### PR DESCRIPTION
Loggability is a property of an error's **origin**, not of the response the client gets — and the two come apart. `normalizeError` launders a `PrismaClientValidationError` (our query shape is wrong — a genuine bug, whose handler even comments *"should get caught by zod before this point"*) into an `AppError` with `VALIDATION_ERROR`, indistinguishable from a user typing a bad email. By the time the boundary saw it, the origin was gone and it was never logged.

**Change**: `AppError` carries `isOperational` (default `true`), set `false` where `normalizeError` wraps an unanticipated failure. The error boundary picks severity from that flag rather than the status code — `error` when `!isOperational || statusCode >= 500`, `warn` otherwise.

**Logging mechanism**: the boundary attaches its verdict to a new `res.errLogLevel` alongside `res.err`, and pino-http's existing `customLogLevel` reads it (`res.errLogLevel ?? (res.statusCode >= 500 ? "error" : "info")`). No second logging path — the failure still rides the single completion line that already carries the request id, per CLAUDE.md's "logged once, at the boundary" rule. Deriving the level inside `customLogLevel` instead would have meant re-doing `instanceof AppError` in the logger. `res.errLogLevel` is declared by a module augmentation of `http.ServerResponse` in the new `src/types/http.d.ts`, the same shape pino-http uses for `res.err`.

**Which handlers are non-operational**: `handleValidationErrorDB` only. `handleCastErrorDB` (P2023), `handleDuplicateFieldsDB` (P2002) and `handleMissingDocumentDB` (P2025) are each driven by client input and map to a meaningful 4xx, so they stay operational and log at `warn`; so do Zod errors (required by the acceptance criteria) and JWT invalid/expired. Non-`AppError` errors are non-operational by construction, so `instanceof AppError` is now only the route to the flag, not the signal itself.

**Also**: the boundary now attaches `res.err` for every error, not just 5xx, so the `warn` line carries the actual error — that is what makes a 400/401 spike usable rather than merely counted.

**Response contract unchanged.** `createErrorResponse` builds the envelope field-by-field, and `ErrorObjectSchema`'s `satisfies z.ZodType<Omit<AppError, …>>` clause forced `isOperational` into the `Omit` — a compile-time guarantee the flag cannot be serialized. All existing route tests pass unchanged, including the dev/prod shaping and 429 envelope tests.

**Tests**: new `packages/domain/test/app-error.test.ts` (default `true`, constructible `false`, absent from the envelope); `logger.test.ts` gains a 5xx `AppError` → level 50, a `PrismaClientValidationError` → 400 body but level 50, and `isOperational` absent from the body — and its old "client error stays at info" case became "downgrades a client fault to warn", which is the #94 criterion this ticket supersedes. `rate-limit.test.ts`'s 429 line moves from level 30 to level 40 carrying the limiter's message.

Two doc sentences the change falsified were corrected: CLAUDE.md's logging bullet and `ERROR_FLOW.md`'s "Logging & Correlation" paragraph.

Note: the Prisma-validation case returns **400**, not the 422 the issue text assumes — `VALIDATION_ERROR` maps to 400 in `error-codes.ts`. Since status codes had to stay byte-for-byte identical, the test pins 400 rather than "fixing" the mapping.

Verified locally: `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` all pass.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)