### PR TITLE
fix: reject unknown query keys on list routes

### DIFF
--- a/apps/client/src/features/products/api/get-products.ts
+++ b/apps/client/src/features/products/api/get-products.ts
@@ -6,7 +6,6 @@ import {
 } from "@/types/api";
 import {
   NAME,
-  Product,
   ProductGetAllResponse,
   ProductGetAllResponseSchema,
   ProductGetByCategoryResponse,
@@ -15,15 +14,14 @@ import {
   ProductGetRelatedResponseSchema,
   ProductGetShowCaseResponse,
   ProductGetShowCaseResponseSchema,
+  ProductQueryParams,
 } from "@repo/domain";
 import { queryOptions } from "@tanstack/react-query";
 import productKeys from "./product-keys";
 
 // ** GetProducts
 
-type productKeys = keyof Product;
-
-type TProductFilters = Partial<Record<productKeys, string>>;
+type TProductFilters = Partial<Record<keyof ProductQueryParams, string>>;
 
 type TGetProducts = TBaseHandler<
   ProductGetAllResponse,

--- a/apps/server/src/middlewares/error.middleware.ts
+++ b/apps/server/src/middlewares/error.middleware.ts
@@ -3,6 +3,7 @@ import { AppError, createErrorResponse, ErrorCode } from "@repo/domain";
 import { NextFunction, Request, Response } from "express";
 import { ZodError } from "zod";
 import { env } from "../utils/env.js";
+import { zodIssuesToDetails } from "../utils/zodDetails.js";
 
 // ------------------ Specific Error Handlers ------------------
 
@@ -38,13 +39,7 @@ const handleValidationErrorDB = () => {
 // safety net for unexpected zod errors
 const handleZodError = (err: ZodError) => {
   const message = `Validation failed: ${err.issues.length} error(s)`;
-
-  // Parse Zod issues into structured details
-  const details = err.issues.map((issue) => ({
-    code: issue.code,
-    message: issue.message,
-    path: issue.path.length > 0 ? issue.path.map(String) : undefined,
-  }));
+  const details = zodIssuesToDetails(err);
 
   return new AppError(message, ErrorCode.VALIDATION_ERROR, undefined, details);
 };

--- a/apps/server/src/middlewares/validation.middleware.ts
+++ b/apps/server/src/middlewares/validation.middleware.ts
@@ -3,6 +3,7 @@ import { RequestHandler } from "express";
 import { ZodType } from "zod";
 import { AppError } from "@repo/domain";
 import catchAsync from "../utils/catchAsync.js";
+import { zodIssuesToDetails } from "../utils/zodDetails.js";
 
 // * Middleware to validate request (params, body, query) against a Zod schema
 
@@ -16,13 +17,7 @@ export const validateSchema = (schema: ZodType<any>): RequestHandler =>
 
     if (!parsedRequest.success) {
       const message = `Validation failed: ${parsedRequest.error.issues.length} error(s)`;
-
-      // Parse Zod issues into structured details
-      const details = parsedRequest.error.issues.map((issue) => ({
-        code: issue.code,
-        message: issue.message,
-        path: issue.path.length > 0 ? issue.path.map(String) : undefined,
-      }));
+      const details = zodIssuesToDetails(parsedRequest.error);
 
       return next(
         new AppError(message, ErrorCode.VALIDATION_ERROR, undefined, details),

--- a/apps/server/src/utils/zodDetails.ts
+++ b/apps/server/src/utils/zodDetails.ts
@@ -1,0 +1,25 @@
+import { ErrorDetail } from "@repo/domain";
+import { ZodError } from "zod";
+
+// `unrecognized_keys` carries the offending keys on `issue.keys`, not on
+// `issue.path`, so it is expanded into one detail per key.
+export const zodIssuesToDetails = (error: ZodError): ErrorDetail[] =>
+  error.issues.flatMap((issue): ErrorDetail[] => {
+    const path = issue.path.map(String);
+
+    if (issue.code === "unrecognized_keys") {
+      return issue.keys.map((key) => ({
+        code: issue.code,
+        message: issue.message,
+        path: [...path, key],
+      }));
+    }
+
+    return [
+      {
+        code: issue.code,
+        message: issue.message,
+        path: path.length > 0 ? path : undefined,
+      },
+    ];
+  });

--- a/apps/server/test/list-query.route.test.ts
+++ b/apps/server/test/list-query.route.test.ts
@@ -1,3 +1,4 @@
+import { ErrorCode } from "@repo/domain";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -139,6 +140,17 @@ describe("GET /api/v1/categories", () => {
       orderBy: [{ name: "asc" }],
     });
   });
+
+  it("rejects an unknown query key and names it in the error details", async () => {
+    const { res } = await listCategories("?name=Headphones&foo=1");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ code: "unrecognized_keys", path: ["query", "foo"] }],
+    });
+    expect(findMany).not.toHaveBeenCalled();
+  });
 });
 
 describe("GET /api/v1/products", () => {
@@ -160,6 +172,35 @@ describe("GET /api/v1/products", () => {
       skip: 0,
       take: 20,
     });
+  });
+
+  it("accepts the name filter and the pagination keys", async () => {
+    const { res } = await listProducts(
+      "?name=zx9&fields=id,name&sort=-price&page=2&limit=5",
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a product field that is not a supported filter", async () => {
+    const { res } = await listProducts("?price=100");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ code: "unrecognized_keys", path: ["query", "price"] }],
+    });
+    expect(productFindMany).not.toHaveBeenCalled();
+  });
+
+  it("names every unknown query key in the error details", async () => {
+    const { res } = await listProducts("?utm_source=newsletter&fbclid=abc");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.details).toEqual([
+      expect.objectContaining({ path: ["query", "utm_source"] }),
+      expect.objectContaining({ path: ["query", "fbclid"] }),
+    ]);
   });
 });
 
@@ -190,5 +231,16 @@ describe("GET /api/v1/users", () => {
       skip: 20,
       take: 10,
     });
+  });
+
+  it("rejects an unknown query key and names it in the error details", async () => {
+    const { res } = await listUsers("?role=ADMIN&email=a@b.c");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ code: "unrecognized_keys", path: ["query", "email"] }],
+    });
+    expect(userFindMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/test/order.route.test.ts
+++ b/apps/server/test/order.route.test.ts
@@ -121,6 +121,20 @@ describe("GET /api/v1/orders", () => {
       .set("Cookie", authCookie(other.id));
     expect(otherRes.body.data).toEqual([]);
   });
+
+  it("rejects an unknown query key and names it in the error details", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/orders?status=PENDING&userId=abc")
+      .set("Cookie", authCookie(user.id));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ code: "unrecognized_keys", path: ["query", "userId"] }],
+    });
+  });
 });
 
 describe("GET /api/v1/orders/:orderId", () => {

--- a/packages/domain/src/category.ts
+++ b/packages/domain/src/category.ts
@@ -50,7 +50,7 @@ export type CategoryQueryParams = ExtendedQueryParams<{ name?: NAME }>;
 
 export const CategoryQueryParamsSchema = BaseQueryParamsSchema.extend({
   name: z.enum(NAME).optional(),
-}) satisfies z.ZodType<CategoryQueryParams>;
+}).strict() satisfies z.ZodType<CategoryQueryParams>;
 
 export const CategoryGetAllRequestSchema = createRequestSchema({
   query: CategoryQueryParamsSchema,

--- a/packages/domain/src/order.ts
+++ b/packages/domain/src/order.ts
@@ -159,13 +159,15 @@ export type UpdateOrderStatusInput = z.infer<
 /**
  * Order query params
  */
-export const OrderQueryParamsSchema = z.object({
-  status: OrderStatusSchema.optional(),
-  paymentStatus: PaymentStatusSchema.optional(),
-  page: z.coerce.number().int().positive().default(1),
-  limit: z.coerce.number().int().positive().max(100).default(10),
-  sort: z.string().optional(),
-});
+export const OrderQueryParamsSchema = z
+  .object({
+    status: OrderStatusSchema.optional(),
+    paymentStatus: PaymentStatusSchema.optional(),
+    page: z.coerce.number().int().positive().default(1),
+    limit: z.coerce.number().int().positive().max(100).default(10),
+    sort: z.string().optional(),
+  })
+  .strict();
 
 export type OrderQueryParams = z.infer<typeof OrderQueryParamsSchema>;
 

--- a/packages/domain/src/product.ts
+++ b/packages/domain/src/product.ts
@@ -103,7 +103,7 @@ export type ProductQueryParams = ExtendedQueryParams<{ name?: string }>;
 
 export const ProductQueryParamsSchema = BaseQueryParamsSchema.extend({
   name: z.string().optional(),
-}) satisfies z.ZodType<ProductQueryParams>;
+}).strict() satisfies z.ZodType<ProductQueryParams>;
 
 export const ProductGetAllRequestSchema = createRequestSchema({
   query: ProductQueryParamsSchema,

--- a/packages/domain/src/user.ts
+++ b/packages/domain/src/user.ts
@@ -71,7 +71,7 @@ export type UserQueryParams = ExtendedQueryParams<{ role?: ROLE }>;
 
 export const UserQueryParamsSchema = BaseQueryParamsSchema.extend({
   role: z.enum(ROLE).optional(),
-}) satisfies z.ZodType<UserQueryParams>;
+}).strict() satisfies z.ZodType<UserQueryParams>;
 
 export const UserGetAllRequestSchema = createRequestSchema({
   query: UserQueryParamsSchema,


### PR DESCRIPTION
The four list query schemas (`CategoryQueryParamsSchema`, `ProductQueryParamsSchema`, `UserQueryParamsSchema`, `OrderQueryParamsSchema`) were the only Zod input schemas in the repo without `.strict()`, against CLAUDE.md's validation rules. A caller asking to filter on an unsupported key — `/products?price=100`, `?slug=zx9-speaker` — got the entire unfiltered collection with a 200 and nothing anywhere saying the filter had been dropped. They now get a 400 naming the key.

### Where `.strict()` went

On each of the four composed schemas, not on `BaseQueryParamsSchema`. Zod 4's `.extend()` does preserve a strict catchall, so the helper would also have worked — but strictness is a property of the complete accepted surface, every other input schema in the repo declares it at its own definition site, and `OrderQueryParamsSchema` doesn't build on the helper at all, so the helper alone would never have covered it.

### `handleZodError` needed changing

Zod 4 emits a single `unrecognized_keys` issue whose `path` is just `["query"]`, with the keys on `issue.keys` — so the offending key reached only the human-readable `message`, which is not something a test or a client should parse. The issue→detail mapping was duplicated verbatim in `validation.middleware.ts` (the path query params actually take) and `handleZodError` in `error.middleware.ts` (the safety net); rather than fix it twice and leave the copies to drift, it is extracted to `zodIssuesToDetails`, which expands an `unrecognized_keys` issue into one detail per key with the key appended to the path (`["query","price"]`). Every other issue code maps exactly as before, and `ErrorDetail`'s shape is unchanged.

### Client half

`TProductFilters` was `Partial<Record<keyof Product, string>>` — every product field (`price`, `slug`, `categoryId`, `isNewProduct`, …) while the server accepts only `name`, which `.strict()` would have turned into a 400 generator. It now derives from `ProductQueryParams`. The `Record<…, string>` wrapper stays because `new URLSearchParams(filters)` needs string values while `ProductQueryParams` types `page`/`limit` as numbers. Other call sites confirmed clean: `getCategoriesQueryOptions` sends no query string, and `listOrders` appends only `page`/`limit`/`status`/`paymentStatus`.

### Behaviour table — all 8 rows confirmed

| Request | result |
|---|---|
| `/products?name=zx9` | 200 ✓ |
| `/products?fields=id,name&sort=-price&page=2&limit=5` | 200 ✓ |
| `/products?price=100` | 400, `path: ["query","price"]` ✓ |
| `/products?slug=zx9-speaker` | 400, `path: ["query","slug"]` ✓ |
| `/categories?name=Headphones&foo=1` | 400, `path: ["query","foo"]` ✓ |
| `/users?role=ADMIN&email=a@b.c` | 400, `path: ["query","email"]` ✓ |
| `/products?utm_source=newsletter&fbclid=abc` | 400, two details, one per key ✓ |
| `/products?name=a&name=b` | 400, `invalid_type` (unchanged) ✓ |

### The open question: unknown sort/fields *values*

**Answer: yes in principle, but not in this ticket.** The "silently wrong result" argument does apply — `?sort=hax` returning default ordering with a 200 is the same class of bug as `?price=100` returning everything. But it is a separate runtime-behaviour change: the whitelist in `apps/server/src/utils/query.ts` is pinned by `query.util.test.ts` and six `sort=hax` / `fields=password` cases in `list-query.route.test.ts` that all assert the fallback, and the fallback is *partial* — `?sort=hax,-createdAt` drops only the unknown member today, so a strict version first has to decide whether one bad member fails the whole list. This ticket's acceptance criteria only require the question be answered. Filed as a follow-up.

Two remaining holes in the same class, both out of scope: `EmptyQuerySchema` is still `z.object({})`, so `/products/:id?foo=1` is a 200; and CLAUDE.md says Zod errors map to 422 when `VALIDATION_ERROR` actually maps to 400 (stale doc, matches the table above).

Verified locally: `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` all pass.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)