### PR TITLE
test: cover service-layer business rules

### DIFF
--- a/apps/server/test/ownership.service.test.ts
+++ b/apps/server/test/ownership.service.test.ts
@@ -1,0 +1,100 @@
+import { ErrorCode } from "@repo/domain";
+import { beforeEach, describe, expect, it } from "vitest";
+import { cartService } from "../src/services/cart.service.js";
+import { orderService } from "../src/services/order.service.js";
+import {
+  createProduct,
+  createUser,
+  resetDatabase,
+} from "./helpers/database.js";
+
+// The route tests cover the same guarantee through HTTP; these pin it to the
+// services themselves, which any non-route caller reaches directly.
+
+const checkout = {
+  shippingAddress: {
+    fullName: "Ada Lovelace",
+    email: "ada@example.com",
+    phone: "555-0100",
+    address: "1 Analytical Way",
+    city: "London",
+    state: "London",
+    zipCode: "E1 6AN",
+    country: "UK",
+  },
+  billingAddress: {
+    fullName: "Ada Lovelace",
+    address: "1 Analytical Way",
+    city: "London",
+    state: "London",
+    zipCode: "E1 6AN",
+    country: "UK",
+  },
+  paymentMethod: "e-Money",
+};
+
+const cartItemOf = async (userId: string) => {
+  const product = await createProduct({ price: 100 });
+  const cart = await cartService.addToCart(userId, product.id, 1);
+  return cart.items[0]!;
+};
+
+const orderOf = async (userId: string) => {
+  await cartItemOf(userId);
+  return orderService.createOrder(userId, checkout);
+};
+
+beforeEach(resetDatabase);
+
+describe("CartService ownership", () => {
+  it("refuses to update another user's cart item", async () => {
+    const owner = await createUser();
+    const intruder = await createUser();
+    const item = await cartItemOf(owner.id);
+
+    await expect(
+      cartService.updateCartItem(intruder.id, item.id, 5),
+    ).rejects.toMatchObject({
+      code: ErrorCode.FORBIDDEN,
+      statusCode: 403,
+    });
+
+    const cart = await cartService.getOrCreateCart(owner.id);
+    expect(cart.items).toMatchObject([{ id: item.id, quantity: 1 }]);
+  });
+
+  it("refuses to remove another user's cart item", async () => {
+    const owner = await createUser();
+    const intruder = await createUser();
+    const item = await cartItemOf(owner.id);
+
+    await expect(
+      cartService.removeFromCart(intruder.id, item.id),
+    ).rejects.toMatchObject({
+      code: ErrorCode.FORBIDDEN,
+      statusCode: 403,
+    });
+
+    const cart = await cartService.getOrCreateCart(owner.id);
+    expect(cart.items).toMatchObject([{ id: item.id }]);
+  });
+});
+
+describe("OrderService ownership", () => {
+  it("refuses to read another user's order", async () => {
+    const owner = await createUser();
+    const intruder = await createUser();
+    const order = await orderOf(owner.id);
+
+    await expect(
+      orderService.getOrderById(intruder.id, order.id),
+    ).rejects.toMatchObject({
+      code: ErrorCode.FORBIDDEN,
+      statusCode: 403,
+    });
+
+    await expect(
+      orderService.getOrderById(owner.id, order.id),
+    ).resolves.toMatchObject({ id: order.id, userId: owner.id });
+  });
+});

--- a/apps/server/test/update-whitelist.service.test.ts
+++ b/apps/server/test/update-whitelist.service.test.ts
@@ -1,0 +1,201 @@
+import { prisma } from "@repo/database";
+import { ErrorCode } from "@repo/domain";
+import { beforeEach, describe, expect, it } from "vitest";
+import { categoryService } from "../src/services/category.service.js";
+import { configService } from "../src/services/config.service.js";
+import { productService } from "../src/services/product.service.js";
+import { userService } from "../src/services/user.service.js";
+import {
+  createCategory,
+  createConfig,
+  createProduct,
+  createUser,
+  resetDatabase,
+} from "./helpers/database.js";
+
+// The whitelists are protected hooks, so each case drives the public `update`
+// and reads the row back to prove what did and did not reach the database.
+
+const STALE_DATE = new Date("2000-01-01T00:00:00.000Z");
+
+beforeEach(resetDatabase);
+
+describe("CategoryService.update", () => {
+  it("writes the whitelisted fields", async () => {
+    const category = await createCategory("Headphones");
+    const thumbnail = {
+      altText: "speakers alt",
+      ariaLabel: "speakers aria",
+      src: "https://cdn.example.com/speakers-thumb.jpg",
+    };
+
+    const dto = await categoryService.update(category.id, {
+      name: "Speakers",
+      thumbnail,
+    });
+
+    expect(dto).toMatchObject({ name: "Speakers", thumbnail });
+  });
+
+  it("drops createdAt and v", async () => {
+    const category = await createCategory();
+
+    await categoryService.update(category.id, {
+      name: "Earphones",
+      createdAt: STALE_DATE,
+      v: 99,
+    });
+
+    const stored = await prisma.category.findUniqueOrThrow({
+      where: { id: category.id },
+    });
+    expect(stored).toMatchObject({
+      name: "Earphones",
+      createdAt: category.createdAt,
+      v: category.v,
+    });
+  });
+});
+
+describe("ProductService.update", () => {
+  it("writes the fields outside the blacklist", async () => {
+    const product = await createProduct({ price: 100 });
+
+    const dto = await productService.update(product.id, {
+      price: 250,
+      description: "rewritten description",
+    });
+
+    expect(dto).toMatchObject({
+      price: 250,
+      description: "rewritten description",
+    });
+  });
+
+  it("drops createdAt and v", async () => {
+    const product = await createProduct({ price: 100 });
+
+    await productService.update(product.id, {
+      price: 250,
+      createdAt: STALE_DATE,
+      v: 99,
+    });
+
+    const stored = await prisma.product.findUniqueOrThrow({
+      where: { id: product.id },
+    });
+    expect(stored).toMatchObject({
+      price: 250,
+      createdAt: product.createdAt,
+      v: product.v,
+    });
+  });
+});
+
+describe("ConfigService.update", () => {
+  it("writes the fields outside the blacklist", async () => {
+    const config = await createConfig();
+
+    const dto = await configService.update(config.id, {
+      name: "renamed-config",
+    });
+
+    expect(dto).toMatchObject({ name: "renamed-config" });
+  });
+
+  it("drops createdAt and v", async () => {
+    const config = await createConfig();
+
+    await configService.update(config.id, {
+      name: "renamed-config",
+      createdAt: STALE_DATE,
+      v: 99,
+    });
+
+    const stored = await prisma.config.findUniqueOrThrow({
+      where: { id: config.id },
+    });
+    expect(stored).toMatchObject({
+      name: "renamed-config",
+      createdAt: config.createdAt,
+      v: config.v,
+    });
+  });
+});
+
+describe("UserService.update", () => {
+  it("writes the whitelisted fields", async () => {
+    const user = await createUser();
+
+    const dto = await userService.update(user.id, {
+      name: "renamed-user",
+      email: "renamed-user@example.com",
+      role: "ADMIN",
+      emailVerified: true,
+    });
+
+    expect(dto).toMatchObject({
+      name: "renamed-user",
+      email: "renamed-user@example.com",
+      role: "ADMIN",
+      emailVerified: true,
+    });
+  });
+
+  it("writes the whitelisted active flag that soft-deletes a user", async () => {
+    const user = await createUser();
+
+    await userService.update(user.id, { active: false });
+
+    await expect(userService.get(user.id)).rejects.toMatchObject({
+      code: ErrorCode.NOT_FOUND,
+    });
+  });
+
+  it("drops the credential fields, so an update cannot overwrite a password", async () => {
+    const user = await createUser();
+    const before = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id },
+      omit: { password: false, passwordConfirm: false },
+    });
+
+    await userService.update(user.id, {
+      name: "renamed-user",
+      password: "hijacked-password",
+      passwordConfirm: "hijacked-password",
+      passwordResetToken: "attacker-token",
+      passwordChangedAt: STALE_DATE,
+    });
+
+    const stored = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id },
+      omit: { password: false, passwordConfirm: false },
+    });
+    expect(stored).toMatchObject({
+      name: "renamed-user",
+      password: before.password,
+      passwordConfirm: before.passwordConfirm,
+      passwordResetToken: null,
+      passwordChangedAt: null,
+    });
+  });
+
+  it("drops createdAt and v", async () => {
+    const user = await createUser();
+
+    await userService.update(user.id, {
+      name: "renamed-user",
+      createdAt: STALE_DATE,
+      v: 99,
+    });
+
+    const stored = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id },
+    });
+    expect(stored).toMatchObject({
+      name: "renamed-user",
+      createdAt: user.createdAt,
+      v: user.v,
+    });
+  });
+});


### PR DESCRIPTION
Rules that live in the service layer rather than in schemas had no direct coverage: the `filterUpdateInput` whitelists, and the ownership guards in the cart and order services. Test-only — no production code touched.

### Update whitelists

`filterUpdateInput` is an optional hook on `AbstractCrudService`, called from `update()` before `persistUpdate`. Four of the eight services override it (`cart`, `order` and `auth` do not — they never route writes through `update()`):

| Service | Style | Effect |
|---|---|---|
| `CategoryService` | allowlist `name`, `thumbnail` | drops `createdAt`, `v`, anything else |
| `UserService` | allowlist `name`, `email`, `role`, `emailVerified`, `active` | drops `password`, `passwordConfirm`, `passwordChangedAt`, `passwordResetToken`, `passwordResetExpires`, `createdAt`, `v` |
| `ProductService` | denylist `createdAt`, `v` | everything else passes |
| `ConfigService` | denylist `createdAt`, `v` | everything else passes |

Each test drives the public `update()` and reads the row back through Prisma, so it asserts the field never reached the database — rather than reaching into the `protected` hook. The assertions were checked for vacuousness against a throwaway test confirming those same fields *do* get written when passed straight to `prisma.*.update`.

### Ownership

Asserted at the service boundary rather than restating the route tests #135 added, because:

1. **`CartService.removeFromCart` had no ownership coverage anywhere** — #135 covered `PATCH /cart/items/:id` and `GET /orders/:orderId`, but not `DELETE /cart/items/:cartItemId`.
2. The cart service already has a non-route caller (`OrderService.createOrder` → `cartService.getOrCreateCart`), so pinning the guard at the service boundary is not hypothetical.
3. These tests assert something the route tests don't: that the rejected write left the owner's data unchanged (quantity still 1, item still present) — i.e. the guard fires *before* the mutation, not merely that a 403 came back.

Expected code is `ErrorCode.FORBIDDEN` / 403, per `docs/adr/0001-ownership-failures-return-403.md`. `listUserOrders` scoping is deliberately left to the existing `order.route.test.ts` case rather than duplicated.

Server suite goes from 113 to 126 tests.

### Two things surfaced, neither fixed here

1. **`role` is on the `UserService` update allowlist.** The service alone does not prevent role escalation — the only thing stopping a normal user promoting themselves via `PATCH /users/me` is `UserUpdateMeRequestSchema` permitting just `name` and `email`. The defence is real but lives entirely one layer up. The test asserts current behaviour rather than a guarantee that isn't there.
2. **The denylist services (`Product`, `Config`) would let an unknown key through**, where an allowlist drops anything unrecognised. Nothing can currently reach them with an extra key (`id` is absent from every Prisma `*UpdateInput`, and every caller passes a `.strict()`-validated body), but the two styles are not equivalent in safety if that upstream validation ever loosens.

Verified locally: `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` all pass.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)