### PR TITLE
fix: enforce role escalation guard inside UserService

### DIFF
--- a/apps/server/src/controllers/user.controller.ts
+++ b/apps/server/src/controllers/user.controller.ts
@@ -29,7 +29,7 @@ export const getUser: RequestHandler = catchAsync<
 });
 
 export const deleteMe: RequestHandler = catchAsync(async (req, res, _next) => {
-  await userService.update(req.user!.id, { active: false });
+  await userService.deactivate(req.user!.id);
   res.status(200).json(createEmptyResponse());
 });
 
@@ -53,7 +53,7 @@ export const deleteUser: RequestHandler = catchAsync<
 export const updateUser: RequestHandler = catchAsync<
   ValidatedRequest<typeof UserUpdateByIdRequestSchema>
 >(async (req, res, _next) => {
-  const dto = await userService.update(
+  const dto = await userService.updateAsAdmin(
     req.verified.params.id,
     req.verified.body,
   );

--- a/apps/server/src/services/user.service.ts
+++ b/apps/server/src/services/user.service.ts
@@ -6,6 +6,7 @@ import type {
   UserPublicInfo,
   UserQueryParams,
   UserSelect,
+  UserSelfUpdateInput,
   UserUpdateInput,
 } from "@repo/domain";
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
@@ -21,6 +22,19 @@ const USER_QUERY_FIELDS = [
   "active",
   "v",
 ] as const satisfies readonly (keyof UserSelect)[];
+
+const SELF_UPDATE_FIELDS = [
+  "name",
+  "email",
+] as const satisfies readonly (keyof UserSelfUpdateInput)[];
+
+const PRIVILEGED_UPDATE_FIELDS = [
+  "name",
+  "email",
+  "role",
+  "emailVerified",
+  "active",
+] as const satisfies readonly (keyof UserUpdateInput)[];
 
 export class UserService extends AbstractCrudService<
   UserPublicInfo,
@@ -41,6 +55,30 @@ export class UserService extends AbstractCrudService<
     };
 
     return dto satisfies UserDTO;
+  }
+
+  // ***** Public CRUD Methods *****
+
+  /** Self-service surface: narrows the input to the fields a user owns. */
+  override async update(
+    id: string,
+    input: UserSelfUpdateInput,
+  ): Promise<UserDTO> {
+    return super.update(
+      id,
+      this.pickFieldsByAllowed(input, [
+        ...SELF_UPDATE_FIELDS,
+      ]) as UserUpdateInput,
+    );
+  }
+
+  /** Privileged surface: the only path that may write role, emailVerified or active. */
+  async updateAsAdmin(id: string, input: UserUpdateInput): Promise<UserDTO> {
+    return super.update(id, input);
+  }
+
+  async deactivate(id: string): Promise<void> {
+    await this.updateAsAdmin(id, { active: false });
   }
 
   // ***** Persistence Layer Methods *****
@@ -80,17 +118,9 @@ export class UserService extends AbstractCrudService<
    * Prevents clients from updating fields like 'password', 'passwordConfirm', etc.
    */
   protected filterUpdateInput(input: UserUpdateInput): UserUpdateInput {
-    // Define which fields are allowed to be updated through this service
-    const allowedFields: (keyof UserUpdateInput)[] = [
-      "name",
-      "email",
-      "role",
-      "emailVerified",
-      "active",
-      // Add other updateable fields here
-    ];
-
-    return this.pickFieldsByAllowed(input, allowedFields) as UserUpdateInput;
+    return this.pickFieldsByAllowed(input, [
+      ...PRIVILEGED_UPDATE_FIELDS,
+    ]) as UserUpdateInput;
   }
 
   protected async persistUpdate(id: string, input: UserUpdateInput) {

--- a/apps/server/test/update-whitelist.service.test.ts
+++ b/apps/server/test/update-whitelist.service.test.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@repo/database";
-import { ErrorCode } from "@repo/domain";
+import { ErrorCode, type UserSelfUpdateInput } from "@repo/domain";
 import { beforeEach, describe, expect, it } from "vitest";
 import { categoryService } from "../src/services/category.service.js";
 import { configService } from "../src/services/config.service.js";
@@ -124,10 +124,49 @@ describe("ConfigService.update", () => {
 });
 
 describe("UserService.update", () => {
-  it("writes the whitelisted fields", async () => {
+  it("writes the self-service fields", async () => {
     const user = await createUser();
 
     const dto = await userService.update(user.id, {
+      name: "renamed-user",
+      email: "renamed-user@example.com",
+    });
+
+    expect(dto).toMatchObject({
+      name: "renamed-user",
+      email: "renamed-user@example.com",
+    });
+  });
+
+  it("drops the privileged fields, so a user cannot promote themselves", async () => {
+    const user = await createUser();
+    const escalation = {
+      name: "renamed-user",
+      role: "ADMIN",
+      emailVerified: true,
+      active: false,
+    } as UserSelfUpdateInput;
+
+    await userService.update(user.id, escalation);
+
+    const stored = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id },
+      omit: { active: false },
+    });
+    expect(stored).toMatchObject({
+      name: "renamed-user",
+      role: "USER",
+      emailVerified: false,
+      active: true,
+    });
+  });
+});
+
+describe("UserService.updateAsAdmin", () => {
+  it("writes the privileged fields", async () => {
+    const user = await createUser();
+
+    const dto = await userService.updateAsAdmin(user.id, {
       name: "renamed-user",
       email: "renamed-user@example.com",
       role: "ADMIN",
@@ -142,16 +181,6 @@ describe("UserService.update", () => {
     });
   });
 
-  it("writes the whitelisted active flag that soft-deletes a user", async () => {
-    const user = await createUser();
-
-    await userService.update(user.id, { active: false });
-
-    await expect(userService.get(user.id)).rejects.toMatchObject({
-      code: ErrorCode.NOT_FOUND,
-    });
-  });
-
   it("drops the credential fields, so an update cannot overwrite a password", async () => {
     const user = await createUser();
     const before = await prisma.user.findUniqueOrThrow({
@@ -159,7 +188,7 @@ describe("UserService.update", () => {
       omit: { password: false, passwordConfirm: false },
     });
 
-    await userService.update(user.id, {
+    await userService.updateAsAdmin(user.id, {
       name: "renamed-user",
       password: "hijacked-password",
       passwordConfirm: "hijacked-password",
@@ -183,7 +212,7 @@ describe("UserService.update", () => {
   it("drops createdAt and v", async () => {
     const user = await createUser();
 
-    await userService.update(user.id, {
+    await userService.updateAsAdmin(user.id, {
       name: "renamed-user",
       createdAt: STALE_DATE,
       v: 99,
@@ -196,6 +225,18 @@ describe("UserService.update", () => {
       name: "renamed-user",
       createdAt: user.createdAt,
       v: user.v,
+    });
+  });
+});
+
+describe("UserService.deactivate", () => {
+  it("soft-deletes the user", async () => {
+    const user = await createUser();
+
+    await userService.deactivate(user.id);
+
+    await expect(userService.get(user.id)).rejects.toMatchObject({
+      code: ErrorCode.NOT_FOUND,
     });
   });
 });

--- a/apps/server/test/user.route.test.ts
+++ b/apps/server/test/user.route.test.ts
@@ -102,3 +102,36 @@ describe("GET /api/v1/users/:id", () => {
     });
   });
 });
+
+describe("DELETE /api/v1/users/deleteMe", () => {
+  it("deactivates the signed-in user", async () => {
+    const user = await createUser();
+    const cookie = authCookie(user.id);
+
+    const res = await request(app)
+      .delete("/api/v1/users/deleteMe")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+
+    const after = await request(app)
+      .get("/api/v1/users/me")
+      .set("Cookie", cookie);
+    expect(after.status).toBe(401);
+  });
+});
+
+describe("PATCH /api/v1/users/:id", () => {
+  it("lets an admin promote a user", async () => {
+    const admin = await createAdmin();
+    const user = await createUser();
+
+    const res = await request(app)
+      .patch(`/api/v1/users/${user.id}`)
+      .set("Cookie", authCookie(admin.id))
+      .send({ name: user.name, role: "ADMIN" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.role).toBe("ADMIN");
+  });
+});

--- a/packages/domain/src/user.ts
+++ b/packages/domain/src/user.ts
@@ -21,6 +21,7 @@ import {
 export type User = PrismaUser;
 export type UserCreateInput = Prisma.UserCreateInput;
 export type UserUpdateInput = Prisma.UserUpdateInput;
+export type UserSelfUpdateInput = Pick<UserUpdateInput, "name" | "email">;
 export type UserWhereInput = Prisma.UserWhereInput;
 export type UserSelect = Prisma.UserSelect;
 export type UserScalarFieldEnum = Prisma.UserScalarFieldEnum;
@@ -55,7 +56,7 @@ export const UserUpdateMeRequestSchema = createRequestSchema({
       name: NameValidator("User").optional(),
       email: EmailValidator.optional(),
     })
-    .strict() satisfies z.ZodType<UserUpdateInput>,
+    .strict() satisfies z.ZodType<UserSelfUpdateInput>,
 });
 
 // DELETE - Delete Me


### PR DESCRIPTION
## Approach — option 1, split the surface (with the inherited `update()` as the *safe* half)

The issue offered three options; this PR implements only option 1.

`UserService.update()` is now the self-service path: it narrows input to `SELF_UPDATE_FIELDS` (`name`, `email`) before delegating to the base class, so `role`, `emailVerified` and `active` cannot be written through the method a new caller reaches for by default. Privileged writes now require the explicitly named `updateAsAdmin()` (used only by the admin `PATCH /users/:id` route) and `deactivate()` (used by `deleteMe`), which makes the escalation-capable path something a caller opts into by name rather than gets for free. The allowlists are pinned at the type level (`as const satisfies readonly (keyof UserSelfUpdateInput)[]`) and `update()`'s parameter type is `UserSelfUpdateInput`, so adding `role` to either the list or a self-service call site is a compile error as well as a runtime no-op. The `updateMe` Zod schema stays as a second layer rather than the only one.

Option 2 was skipped because it changes the `AbstractCrudService` signature and touches every service. Option 3's schema-pinning test is subsumed by `UserUpdateMeRequestSchema`'s new `satisfies z.ZodType<UserSelfUpdateInput>`, which pins the same thing at compile time.

## Changes

- `packages/domain/src/user.ts` — added `UserSelfUpdateInput`; `UserUpdateMeRequestSchema` body now `satisfies z.ZodType<UserSelfUpdateInput>`
- `apps/server/src/services/user.service.ts` — split update surface into `update` / `updateAsAdmin` / `deactivate`
- `apps/server/src/controllers/user.controller.ts` — `updateUser` → `updateAsAdmin`, `deleteMe` → `deactivate`
- `apps/server/test/update-whitelist.service.test.ts` — coverage split across the three methods, plus a direct escalation test (verified it fails when the narrowing is removed)
- `apps/server/test/user.route.test.ts` — `DELETE /deleteMe` deactivation and admin-promotes-a-user route tests

## Acceptance criteria

- [x] Escalation blocked at the service, not only the schema
- [x] Admin can still set `role` via `PATCH /api/v1/users/:id`
- [x] A test covers the escalation attempt directly
- [x] Approach justified above

## Verification

`pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` — all green (139 tests).

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)