### PR TITLE
refactor: use an allowlist for every filterUpdateInput override

### DIFF
--- a/apps/server/src/services/abstract-crud.service.ts
+++ b/apps/server/src/services/abstract-crud.service.ts
@@ -144,7 +144,7 @@ export abstract class AbstractCrudService<
 
   /**
    * Optional: Filter/validate update input before persistence.
-   * Override to whitelist or blacklist fields.
+   * Override to whitelist the fields the entity accepts on update.
    */
   protected filterUpdateInput?(input: UpdateInput): UpdateInput;
 
@@ -160,18 +160,5 @@ export abstract class AbstractCrudService<
       }
       return acc;
     }, {} as Partial<T>);
-  }
-
-  protected pickFieldsByNotAllowed<T extends Record<string, any>>(
-    obj: T,
-    fields: (keyof T)[],
-  ): Partial<T> {
-    const result: Partial<T> = {};
-    for (const key in obj) {
-      if (!fields.includes(key as keyof T)) {
-        result[key] = obj[key];
-      }
-    }
-    return result;
   }
 }

--- a/apps/server/src/services/category.service.ts
+++ b/apps/server/src/services/category.service.ts
@@ -19,6 +19,11 @@ const CATEGORY_QUERY_FIELDS = [
   "thumbnail",
 ] as const satisfies readonly (keyof CategorySelect)[];
 
+const CATEGORY_UPDATE_FIELDS = [
+  "name",
+  "thumbnail",
+] as const satisfies readonly (keyof CategoryUpdateInput)[];
+
 export class CategoryService extends AbstractCrudService<
   Category,
   CategoryCreateInput,
@@ -61,8 +66,7 @@ export class CategoryService extends AbstractCrudService<
   }
 
   protected filterUpdateInput(input: CategoryUpdateInput): CategoryUpdateInput {
-    const allowedFields: (keyof CategoryUpdateInput)[] = ["name", "thumbnail"];
-    return this.pickFieldsByAllowed(input, allowedFields);
+    return this.pickFieldsByAllowed(input, [...CATEGORY_UPDATE_FIELDS]);
   }
 
   protected async persistUpdate(id: string, input: CategoryUpdateInput) {

--- a/apps/server/src/services/config.service.ts
+++ b/apps/server/src/services/config.service.ts
@@ -17,6 +17,14 @@ const CONFIG_QUERY_FIELDS = [
   "v",
 ] as const satisfies readonly (keyof ConfigSelect)[];
 
+const CONFIG_UPDATE_FIELDS = [
+  "name",
+  "featuredProductId",
+  "showCaseCoverId",
+  "showCaseWideId",
+  "showCaseGridId",
+] as const satisfies readonly (keyof ConfigUpdateInput)[];
+
 export class ConfigService extends AbstractCrudService<
   Config,
   ConfigCreateInput,
@@ -60,19 +68,8 @@ export class ConfigService extends AbstractCrudService<
     return prisma.config.create({ data: input });
   }
 
-  /**
-   * Whitelist only allowed fields for updates
-   * Prevents clients from updating fields like 'id', 'createdAt', 'v', etc.
-   */
   protected filterUpdateInput(input: ConfigUpdateInput): ConfigUpdateInput {
-    // Define which fields are not allowed to be updated
-    const disallowedFields: (keyof typeof input)[] = [
-      "createdAt",
-      "v",
-      // Add other non-updateable fields here
-    ];
-
-    return this.pickFieldsByNotAllowed(input, disallowedFields);
+    return this.pickFieldsByAllowed(input, [...CONFIG_UPDATE_FIELDS]);
   }
 
   protected async persistUpdate(id: string, input: ConfigUpdateInput) {

--- a/apps/server/src/services/product.service.ts
+++ b/apps/server/src/services/product.service.ts
@@ -36,6 +36,23 @@ const PRODUCT_QUERY_FIELDS = [
   "featuresText",
 ] as const satisfies readonly (keyof Product)[];
 
+const PRODUCT_UPDATE_FIELDS = [
+  "cartLabel",
+  "name",
+  "slug",
+  "price",
+  "categoryId",
+  "shortLabel",
+  "fullLabel",
+  "description",
+  "isNewProduct",
+  "featuredImageText",
+  "showCaseImageText",
+  "featuresText",
+  "includedItems",
+  "images",
+] as const satisfies readonly (keyof ProductUpdateInput)[];
+
 export class ProductService extends AbstractCrudService<
   Product,
   ProductCreateInput,
@@ -92,8 +109,7 @@ export class ProductService extends AbstractCrudService<
   }
 
   protected filterUpdateInput(input: ProductUpdateInput): ProductUpdateInput {
-    const disallowedFields: (keyof typeof input)[] = ["createdAt", "v"];
-    return this.pickFieldsByNotAllowed(input, disallowedFields);
+    return this.pickFieldsByAllowed(input, [...PRODUCT_UPDATE_FIELDS]);
   }
 
   protected async persistUpdate(id: string, input: ProductUpdateInput) {

--- a/apps/server/test/update-whitelist.service.test.ts
+++ b/apps/server/test/update-whitelist.service.test.ts
@@ -1,5 +1,10 @@
 import { prisma } from "@repo/database";
-import { ErrorCode, type UserSelfUpdateInput } from "@repo/domain";
+import {
+  ErrorCode,
+  type ConfigUpdateInput,
+  type ProductUpdateInput,
+  type UserSelfUpdateInput,
+} from "@repo/domain";
 import { beforeEach, describe, expect, it } from "vitest";
 import { categoryService } from "../src/services/category.service.js";
 import { configService } from "../src/services/config.service.js";
@@ -58,7 +63,7 @@ describe("CategoryService.update", () => {
 });
 
 describe("ProductService.update", () => {
-  it("writes the fields outside the blacklist", async () => {
+  it("writes the whitelisted fields", async () => {
     const product = await createProduct({ price: 100 });
 
     const dto = await productService.update(product.id, {
@@ -70,6 +75,32 @@ describe("ProductService.update", () => {
       price: 250,
       description: "rewritten description",
     });
+  });
+
+  it("writes categoryId, the only relation the update route exposes", async () => {
+    const product = await createProduct();
+    const category = await createCategory("Speakers");
+
+    const dto = await productService.update(product.id, {
+      categoryId: category.id,
+    });
+
+    expect(dto).toMatchObject({ categoryId: category.id });
+  });
+
+  it("drops a field no allowlist entry names", async () => {
+    const product = await createProduct({ price: 100 });
+
+    await productService.update(product.id, {
+      price: 250,
+      smuggled: "never persisted",
+    } as ProductUpdateInput);
+
+    const stored = await prisma.product.findUniqueOrThrow({
+      where: { id: product.id },
+    });
+    expect(stored).toMatchObject({ price: 250 });
+    expect(stored).not.toHaveProperty("smuggled");
   });
 
   it("drops createdAt and v", async () => {
@@ -93,14 +124,34 @@ describe("ProductService.update", () => {
 });
 
 describe("ConfigService.update", () => {
-  it("writes the fields outside the blacklist", async () => {
+  it("writes the whitelisted fields", async () => {
     const config = await createConfig();
+    const featured = await createProduct();
 
     const dto = await configService.update(config.id, {
       name: "renamed-config",
+      featuredProductId: featured.id,
     });
 
-    expect(dto).toMatchObject({ name: "renamed-config" });
+    expect(dto).toMatchObject({
+      name: "renamed-config",
+      featuredProductId: featured.id,
+    });
+  });
+
+  it("drops a field no allowlist entry names", async () => {
+    const config = await createConfig();
+
+    await configService.update(config.id, {
+      name: "renamed-config",
+      smuggled: "never persisted",
+    } as ConfigUpdateInput);
+
+    const stored = await prisma.config.findUniqueOrThrow({
+      where: { id: config.id },
+    });
+    expect(stored).toMatchObject({ name: "renamed-config" });
+    expect(stored).not.toHaveProperty("smuggled");
   });
 
   it("drops createdAt and v", async () => {

--- a/packages/domain/src/product.ts
+++ b/packages/domain/src/product.ts
@@ -22,7 +22,7 @@ import { IdValidator } from "./shared.js";
 
 export type Product = PrismaProduct;
 export type ProductCreateInput = Prisma.ProductCreateInput;
-export type ProductUpdateInput = Prisma.ProductUpdateInput;
+export type ProductUpdateInput = Prisma.ProductUncheckedUpdateInput;
 export type ProductWhereInput = Prisma.ProductWhereInput;
 export type ProductSelect = Prisma.ProductSelect;
 export type ProductScalarFieldEnum = Prisma.ProductScalarFieldEnum;


### PR DESCRIPTION
## What changed

`ProductService` and `ConfigService` filtered updates with a denylist (`createdAt`, `v`), so any field later added to their Prisma models would have been writable through `update()` from the moment it existed, with nothing to notice. Both now use `pickFieldsByAllowed`, matching `CategoryService` and `UserService`. `pickFieldsByNotAllowed` had no callers left and is removed from `AbstractCrudService`.

## The allowlists and how they were derived

**Config** — `name`, `featuredProductId`, `showCaseCoverId`, `showCaseWideId`, `showCaseGridId`: exactly the five keys of `ConfigUpdateByIdRequestSchema`'s `.strict()` body. The model's remaining columns are `id`, `v`, `createdAt`, which the route never offered.

**Product** — `cartLabel`, `name`, `slug`, `price`, `categoryId`, `shortLabel`, `fullLabel`, `description`, `isNewProduct`, `featuredImageText`, `showCaseImageText`, `featuresText`, `includedItems`, `images`: `ProductUpdateByIdRequestSchema`'s body is `ProductPropertiesSchema.partial()` — every Prisma scalar/composite plus `id`, `createdAt`, `v` — minus those three immutable ones.

Both are pinned with `as const satisfies readonly (keyof XUpdateInput)[]`, and `CategoryService`'s inline list was lifted to a module-level constant so all four services read identically.

`ProductUpdateInput` now aliases `Prisma.ProductUncheckedUpdateInput` (was the checked variant). That is what makes the Product pin honest: `categoryId` is a field the update route accepts today and Prisma persists at runtime through the unchecked arm of the `XOR`, but it is absent from `Prisma.ProductUpdateInput`, so a `keyof` pin could not have named it without a cast. `ConfigService` already aliased the unchecked variant; the schema's `satisfies z.ZodType<ProductUpdateInput>` still holds.

## Tests

- "drops a field no allowlist entry names" for Product and Config — verified these genuinely distinguish the strategies: with `ProductService.filterUpdateInput` temporarily reverted to the denylist, the product case fails.
- "writes `categoryId`, the only relation the update route exposes" — pins the riskiest acceptance criterion.
- Config happy path extended to write `featuredProductId`.

## Acceptance criteria

- [x] All four services use the allowlist strategy
- [x] An unnamed field is dropped
- [x] `pickFieldsByNotAllowed` removed (no callers remained)
- [x] Update routes still accept every field they accept today, checked against the `*UpdateRequestSchema` bodies

## Noted, not changed

The product update route still *validates* `id`, `createdAt` and `v`, because `ProductPropertiesSchema.partial()` accepts them. `createdAt`/`v` were already dropped by the old denylist; `id` previously reached Prisma and failed with a 500 and is now silently dropped. Tightening the request schema to reject them with a 422 changes route behaviour and is outside this issue.

## Verification

`pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` — all green (142 tests).

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)