### PR TITLE
fix: send 422 for every VALIDATION_ERROR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ pnpm types:watch       # watch mode across all TS projects
 # Quality
 pnpm lint
 pnpm format
-pnpm test          # domain + server vitest suites via Turbo (no network database needed)
+pnpm test          # domain + server + client vitest suites via Turbo (no network database needed)
 ```
 
 ### Running a single workspace

--- a/apps/client/docs/COMPONENT_ERROR_PATTERNS.md
+++ b/apps/client/docs/COMPONENT_ERROR_PATTERNS.md
@@ -203,6 +203,7 @@ export function ProductList() {
 import { useMutation } from "@tanstack/react-query";
 import { postSignUp } from "@/lib/api/auth";
 import { classifyHttpError, isAppError } from "@/lib/errors";
+import { ErrorCode } from "@repo/domain";
 import { useState } from "react";
 
 export function SignUpForm() {
@@ -223,12 +224,14 @@ export function SignUpForm() {
     } catch (error) {
       const appError = classifyHttpError(error);
 
-      // Handle validation errors (400/422)
-      if (appError.statusCode === 422 && appError.details?.fields) {
-        setFieldErrors(appError.details.fields);
-      } else if (appError.statusCode === 400) {
-        // Generic 400 error
-        setFieldErrors({ form: appError.message });
+      // Branch on the code, never the number: the status for a rejected
+      // input lives in ERROR_CODE_TO_STATUS and is free to change.
+      if (appError.code === ErrorCode.VALIDATION_ERROR) {
+        if (appError.details?.fields) {
+          setFieldErrors(appError.details.fields);
+        } else {
+          setFieldErrors({ form: appError.message });
+        }
       } else {
         // Network or server error
         toast({
@@ -282,9 +285,9 @@ export function SignUpForm() {
 2. Request sent → Axios throws raw error
 3. Mutation catches error (no React Query retry for mutations by default)
 4. Component classifies error via `classifyHttpError()`
-5. Check status code:
-   - 422 validation: Set `fieldErrors` from `appError.details`
-   - 400 bad request: Show generic form error
+5. Check the error code:
+   - `VALIDATION_ERROR` with field details: Set `fieldErrors` from `appError.details`
+   - `VALIDATION_ERROR` without them: Show generic form error
    - 5xx/network: Show toast notification
 6. Component re-renders with errors displayed
 

--- a/apps/client/docs/ERROR_FLOW.md
+++ b/apps/client/docs/ERROR_FLOW.md
@@ -242,7 +242,13 @@ export function normalizeError(error: unknown): AppError {
   } else if (error instanceof ZodError) {
     // Validation errors from forms
     const message = `Validation failed: ${error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")}`;
-    return new AppError(message, ErrorCode.VALIDATION_ERROR, 422, error.issues);
+    // Status omitted: AppError derives it from ERROR_CODE_TO_STATUS (422)
+    return new AppError(
+      message,
+      ErrorCode.VALIDATION_ERROR,
+      undefined,
+      error.issues,
+    );
   } else if (error instanceof Error) {
     return new AppError(
       error.message,
@@ -493,8 +499,8 @@ Error Received
         │   │   │
         │   │   └─ NO → Fall back to status code
         │   │
-        │   ├─ Status 400 or 422?
-        │   │   └─ AppError(VALIDATION_ERROR, 400)
+        │   ├─ Status 422?
+        │   │   └─ AppError(VALIDATION_ERROR, 422)
         │   │       "Please check your input..."
         │   │
         │   ├─ Status 401?
@@ -1395,7 +1401,7 @@ Moving from current state (v1) to target state (v2) can be done in phases:
 
 | HTTP Status | ErrorCode              | Meaning                 | User Action              |
 | ----------- | ---------------------- | ----------------------- | ------------------------ |
-| 400         | VALIDATION_ERROR       | Invalid input           | Fix and retry            |
+| 422         | VALIDATION_ERROR       | Invalid input           | Fix and retry            |
 | 401         | UNAUTHORIZED           | Not authenticated       | Log in                   |
 | 403         | FORBIDDEN              | Not authorized          | Contact support          |
 | 404         | NOT_FOUND              | Resource missing        | Navigate elsewhere       |
@@ -1414,7 +1420,7 @@ Moving from current state (v1) to target state (v2) can be done in phases:
 
 **Validation (form errors)**
 
-- VALIDATION_ERROR (400/422)
+- VALIDATION_ERROR (422)
 
 **Not Found (resource missing)**
 
@@ -1669,11 +1675,11 @@ Component shows updated data
 
 ### Production Use Case: Form Validation Details
 
-**Valid scenario:** For `VALIDATION_ERROR` (400/422) responses on form submissions, include `details` field in production to show field-level error messages to the user.
+**Valid scenario:** For `VALIDATION_ERROR` (422) responses on form submissions, include `details` field in production to show field-level error messages to the user.
 
 **When to include `details`:**
 
-✅ `VALIDATION_ERROR` (400/422): Include field-level messages for form errors  
+✅ `VALIDATION_ERROR` (422): Include field-level messages for form errors  
 ❌ `UNAUTHORIZED` (401): No details (no sensitive auth info)  
 ❌ `FORBIDDEN` (403): No details  
 ❌ `NOT_FOUND` (404): No details  
@@ -1845,7 +1851,7 @@ When testing error handling, verify:
 
 - Network disconnection and recovery
 - 404 invalid routes/product slugs
-- 400/422 validation error responses
+- 422 validation error responses
 - 500/503 server error with retry
 - 401 auth redirect
 - Loader function failures

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -9,7 +9,8 @@
     "prod": "vite preview",
     "start": "vite preview",
     "type-check": "tsc -b",
-    "lint": "eslint . --max-warnings 23"
+    "lint": "eslint . --max-warnings 23",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",
@@ -60,6 +61,7 @@
     "typescript": "~5.8.3",
     "vite": "^7.0.6",
     "vite-plugin-svgr": "^4.3.0",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^4.1.11"
   }
 }

--- a/apps/client/src/lib/errors/errors.ts
+++ b/apps/client/src/lib/errors/errors.ts
@@ -27,7 +27,9 @@ const handleZodError = (err: ZodError) => {
     message: issue.message,
     path: issue.path.length > 0 ? issue.path.map(String) : undefined,
   }));
-  return new AppError(message, ErrorCode.VALIDATION_ERROR, 422, details);
+  // Status omitted on purpose: it comes off ERROR_CODE_TO_STATUS, so a
+  // client-side rejection can never diverge from a server-side one.
+  return new AppError(message, ErrorCode.VALIDATION_ERROR, undefined, details);
 };
 
 /**

--- a/apps/client/test/errors.test.ts
+++ b/apps/client/test/errors.test.ts
@@ -1,0 +1,68 @@
+import { ErrorCode, ErrorResponse, getStatusCode } from "@repo/domain";
+import { AxiosError, AxiosHeaders } from "axios";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { normalizeError, processAxiosError } from "../src/lib/errors/errors";
+
+// The same rejection can be produced by the API or by a schema parse in the
+// browser. Both have to carry one status, or a form would branch differently
+// depending on where the input happened to be checked.
+
+const VALIDATION_STATUS = getStatusCode(ErrorCode.VALIDATION_ERROR);
+
+const axiosValidationError = () => {
+  const body: ErrorResponse = {
+    success: false,
+    timestamp: new Date().toISOString(),
+    data: null,
+    error: {
+      code: ErrorCode.VALIDATION_ERROR,
+      message: "Validation failed: 1 error(s)",
+      statusCode: VALIDATION_STATUS,
+      details: [
+        { code: "invalid_type", message: "Required", path: ["body", "name"] },
+      ],
+    },
+  };
+
+  const error = new AxiosError<ErrorResponse>(
+    "Request failed",
+    "ERR_BAD_REQUEST",
+  );
+  error.response = {
+    data: body,
+    status: VALIDATION_STATUS,
+    statusText: "",
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  };
+
+  return error;
+};
+
+describe("client validation errors", () => {
+  it("mirrors the status the server put in the body", () => {
+    const axiosError = axiosValidationError();
+
+    const appError = processAxiosError(axiosError);
+
+    expect(appError.code).toBe(ErrorCode.VALIDATION_ERROR);
+    expect(appError.statusCode).toBe(
+      axiosError.response?.data.error.statusCode,
+    );
+    expect(appError.statusCode).toBe(VALIDATION_STATUS);
+  });
+
+  it("gives a client-side ZodError the same status as a server-side one", () => {
+    const zodError = z
+      .object({ name: z.string() })
+      .safeParse({ name: 1 }).error;
+
+    const clientSide = normalizeError(zodError);
+    const serverSide = normalizeError(axiosValidationError());
+
+    expect(clientSide.code).toBe(ErrorCode.VALIDATION_ERROR);
+    expect(clientSide.statusCode).toBe(serverSide.statusCode);
+    expect(clientSide.statusCode).toBe(VALIDATION_STATUS);
+  });
+});

--- a/apps/client/tsconfig.app.json
+++ b/apps/client/tsconfig.app.json
@@ -24,5 +24,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apps/client/tsconfig.node.json
+++ b/apps/client/tsconfig.node.json
@@ -21,5 +21,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/apps/client/vitest.config.ts
+++ b/apps/client/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  // The `@/` alias is used throughout src, so tests importing it need the
+  // same resolution the app build gets.
+  plugins: [tsconfigPaths()],
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/apps/server/ERROR_FLOW.md
+++ b/apps/server/ERROR_FLOW.md
@@ -120,7 +120,7 @@
 ┌─────────┐  ┌─────────┐  ┌──────────┐  ┌──────────┐  ┌─────────┐       │
 │ handle  │  │P2023:   │  │ handle   │  │Expired:  │  │  Pass   │       │
 │ZodError │  │Cast 400 │  │Validation│  │  401     │  │ through │       │
-│ 400     │  │P2002:   │  │Error 422 │  │Invalid:  │  │         │       │
+│ 422     │  │P2002:   │  │Error 422 │  │Invalid:  │  │         │       │
 │         │  │Dup. 400 │  │          │  │  401     │  │         │       │
 │         │  │P2025:   │  │          │  │          │  │         │       │
 │         │  │Missing  │  │          │  │          │  │         │       │
@@ -163,7 +163,7 @@
 | Error Type            | Handler                   | Status | Message Format                                                                     |
 | --------------------- | ------------------------- | ------ | ---------------------------------------------------------------------------------- |
 | ZodError (middleware) | validateSchema → AppError | 422    | "Unprocessable Content. The following variables are missing or invalid: {details}" |
-| ZodError (global)     | handleZodError            | 400    | "Unprocessable Content. The following variables are missing or invalid: {details}" |
+| ZodError (global)     | handleZodError            | 422    | "Unprocessable Content. The following variables are missing or invalid: {details}" |
 
 ### Database Errors (Prisma)
 
@@ -236,7 +236,7 @@ Error Occurs
     └─ Production?
         └─ YES → Check error type
             │
-            ├─ ZodError? → handleZodError(400)
+            ├─ ZodError? → handleZodError(422)
             ├─ Prisma P2023? → handleCastErrorDB(400)
             ├─ Prisma P2002? → handleDuplicateFieldsDB(400)
             ├─ Prisma P2025? → handleMissingDocumentDB(404)

--- a/apps/server/VALIDATION_STRATEGY.md
+++ b/apps/server/VALIDATION_STRATEGY.md
@@ -27,7 +27,7 @@
          │  ✓ validateSchema(ZodSchema)      │
          │  ✓ Validates structure & types    │
          │  ✓ Transforms data if needed      │
-         │  ✓ REJECT early (422/400)         │
+         │  ✓ REJECT early (422)             │
          └────────────┬──────────────────────┘
                       │
                       ▼ (validated input)
@@ -606,14 +606,14 @@ Database Constraints (Schema)
 
 | Request Type   | Error Detail Level | Status Code | Example                                                    |
 | -------------- | ------------------ | ----------- | ---------------------------------------------------------- |
-| GET            | Low (simple)       | 400         | "Invalid ID format"                                        |
+| GET            | Low (simple)       | 422         | "Invalid ID format"                                        |
 | POST/PUT/PATCH | High (detailed)    | 422         | "body.price: must be positive number, body.name: required" |
-| DELETE         | Medium             | 400/404     | "Resource not found"                                       |
+| DELETE         | Medium             | 404         | "Resource not found"                                       |
 
 **Status Code Usage**:
 
-- `422 Unprocessable Entity` - Validation middleware catches malformed input
-- `400 Bad Request` - Global error handler catches ZodError or semantic errors
+- `422 Unprocessable Entity` - Any rejected input: the validation middleware, the global ZodError safety net, or a Prisma validation error
+- `400 Bad Request` - Semantic errors raised after the input parsed cleanly
 - `404 Not Found` - Resource doesn't exist
 - `401 Unauthorized` - Authentication failed
 - `403 Forbidden` - Authorization failed (authenticated but no permission)

--- a/apps/server/test/auth.route.test.ts
+++ b/apps/server/test/auth.route.test.ts
@@ -48,7 +48,7 @@ describe("POST /api/v1/auth/signup", () => {
       .post("/api/v1/auth/signup")
       .send({ ...signupBody, passwordConfirm: "something-else" });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ path: ["body", "passwordConfirm"] }],

--- a/apps/server/test/cart.route.test.ts
+++ b/apps/server/test/cart.route.test.ts
@@ -64,7 +64,7 @@ describe("POST /api/v1/cart", () => {
       .set("Cookie", authCookie(user.id))
       .send({ productId: "not-an-id", quantity: 1 });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ path: ["body", "productId"] }],

--- a/apps/server/test/category.route.test.ts
+++ b/apps/server/test/category.route.test.ts
@@ -50,7 +50,7 @@ describe("GET /api/v1/categories/:id", () => {
   it("returns VALIDATION_ERROR for a malformed id", async () => {
     const res = await request(app).get("/api/v1/categories/not-an-id");
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ path: ["params", "id"] }],
@@ -75,7 +75,7 @@ describe("GET /api/v1/categories/:category/products", () => {
       "/api/v1/categories/Turntables/products",
     );
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error.code).toBe(ErrorCode.VALIDATION_ERROR);
   });
 });

--- a/apps/server/test/config.route.test.ts
+++ b/apps/server/test/config.route.test.ts
@@ -77,7 +77,7 @@ describe("POST /api/v1/config", () => {
         showCaseWideId: ABSENT_ID,
       });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ path: ["body", "featuredProductId"] }],

--- a/apps/server/test/list-query.route.test.ts
+++ b/apps/server/test/list-query.route.test.ts
@@ -144,7 +144,7 @@ describe("GET /api/v1/categories", () => {
   it("rejects an unknown query key and names it in the error details", async () => {
     const { res } = await listCategories("?name=Headphones&foo=1");
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ code: "unrecognized_keys", path: ["query", "foo"] }],
@@ -185,7 +185,7 @@ describe("GET /api/v1/products", () => {
   it("rejects a product field that is not a supported filter", async () => {
     const { res } = await listProducts("?price=100");
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ code: "unrecognized_keys", path: ["query", "price"] }],
@@ -196,7 +196,7 @@ describe("GET /api/v1/products", () => {
   it("names every unknown query key in the error details", async () => {
     const { res } = await listProducts("?utm_source=newsletter&fbclid=abc");
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error.details).toEqual([
       expect.objectContaining({ path: ["query", "utm_source"] }),
       expect.objectContaining({ path: ["query", "fbclid"] }),
@@ -236,7 +236,7 @@ describe("GET /api/v1/users", () => {
   it("rejects an unknown query key and names it in the error details", async () => {
     const { res } = await listUsers("?role=ADMIN&email=a@b.c");
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ code: "unrecognized_keys", path: ["query", "email"] }],

--- a/apps/server/test/logger.test.ts
+++ b/apps/server/test/logger.test.ts
@@ -222,7 +222,7 @@ describe("error boundary logging", () => {
     ).get("/boom");
     const [line] = await linesReaching(1);
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error.code).toBe(ErrorCode.VALIDATION_ERROR);
     expect(lines).toHaveLength(1);
     expect(line.level).toBe(50);

--- a/apps/server/test/order.route.test.ts
+++ b/apps/server/test/order.route.test.ts
@@ -96,7 +96,7 @@ describe("POST /api/v1/orders", () => {
         shippingAddress: { ...checkout.shippingAddress, city: "" },
       });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ path: ["body", "shippingAddress", "city"] }],
@@ -129,7 +129,7 @@ describe("GET /api/v1/orders", () => {
       .get("/api/v1/orders?status=PENDING&userId=abc")
       .set("Cookie", authCookie(user.id));
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ code: "unrecognized_keys", path: ["query", "userId"] }],
@@ -170,7 +170,7 @@ describe("GET /api/v1/orders/:orderId", () => {
       .get("/api/v1/orders/not-an-id")
       .set("Cookie", authCookie(user.id));
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ path: ["params", "orderId"] }],

--- a/apps/server/test/product.route.test.ts
+++ b/apps/server/test/product.route.test.ts
@@ -45,13 +45,13 @@ describe("GET /api/v1/products/:id", () => {
   it("returns VALIDATION_ERROR for a malformed id", async () => {
     const res = await request(app).get("/api/v1/products/not-an-id");
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body).toMatchObject({
       success: false,
       data: null,
       error: {
         code: ErrorCode.VALIDATION_ERROR,
-        statusCode: 400,
+        statusCode: 422,
         details: [{ path: ["params", "id"] }],
       },
     });

--- a/apps/server/test/user.route.test.ts
+++ b/apps/server/test/user.route.test.ts
@@ -56,7 +56,7 @@ describe("PATCH /api/v1/users/updateMe", () => {
       .set("Cookie", authCookie(user.id))
       .send({ role: "ADMIN" });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error.code).toBe(ErrorCode.VALIDATION_ERROR);
   });
 });
@@ -95,7 +95,7 @@ describe("GET /api/v1/users/:id", () => {
       .get("/api/v1/users/not-an-id")
       .set("Cookie", authCookie(admin.id));
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
     expect(res.body.error).toMatchObject({
       code: ErrorCode.VALIDATION_ERROR,
       details: [{ path: ["params", "id"] }],

--- a/apps/server/test/validation-status.route.test.ts
+++ b/apps/server/test/validation-status.route.test.ts
@@ -1,0 +1,93 @@
+import { ErrorCode, getStatusCode } from "@repo/domain";
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import app from "../src/app.js";
+import globalErrorHandler from "../src/middlewares/error.middleware.js";
+
+// One status for every rejected input, whichever part of the request carried
+// it. These assert against the map rather than a literal so the wire can never
+// drift from `ERROR_CODE_TO_STATUS`; the literal itself is pinned in the
+// domain package.
+
+const VALIDATION_STATUS = getStatusCode(ErrorCode.VALIDATION_ERROR);
+
+// The safety net only fires for a ZodError that never went through
+// `validateSchema`, which no real route can produce on purpose.
+const appThatThrows = (fail: () => never) => {
+  const throwing = express();
+  throwing.get("/boom", () => fail());
+  throwing.use(globalErrorHandler);
+  return throwing;
+};
+
+describe("validation errors share one status", () => {
+  it("rejects a malformed path param", async () => {
+    const res = await request(app).get("/api/v1/products/not-an-id");
+
+    expect(res.status).toBe(VALIDATION_STATUS);
+    expect(res.body).toMatchObject({
+      success: false,
+      error: {
+        code: ErrorCode.VALIDATION_ERROR,
+        statusCode: VALIDATION_STATUS,
+      },
+    });
+    expect(res.body.error.details.length).toBeGreaterThan(0);
+  });
+
+  it("rejects an unknown field in a strict body schema", async () => {
+    const res = await request(app).post("/api/v1/auth/signup").send({
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      password: "test-password-123",
+      passwordConfirm: "test-password-123",
+      role: "ADMIN",
+    });
+
+    expect(res.status).toBe(VALIDATION_STATUS);
+    expect(res.body).toMatchObject({
+      success: false,
+      error: {
+        code: ErrorCode.VALIDATION_ERROR,
+        statusCode: VALIDATION_STATUS,
+        details: [{ code: "unrecognized_keys", path: ["body", "role"] }],
+      },
+    });
+  });
+
+  it("rejects a ZodError that escaped the validation middleware", async () => {
+    const zodError = z.object({ name: z.string() }).safeParse({}).error!;
+
+    const res = await request(
+      appThatThrows(() => {
+        throw zodError;
+      }),
+    ).get("/boom");
+
+    expect(res.status).toBe(VALIDATION_STATUS);
+    expect(res.body).toMatchObject({
+      success: false,
+      error: {
+        code: ErrorCode.VALIDATION_ERROR,
+        statusCode: VALIDATION_STATUS,
+        details: [{ path: ["name"] }],
+      },
+    });
+  });
+
+  it("rejects an invalid query value on a list route", async () => {
+    const res = await request(app).get("/api/v1/products?limit=abc");
+
+    expect(res.status).toBe(VALIDATION_STATUS);
+    expect(res.body).toMatchObject({
+      success: false,
+      error: {
+        code: ErrorCode.VALIDATION_ERROR,
+        statusCode: VALIDATION_STATUS,
+        details: [{ path: ["query", "limit"] }],
+      },
+    });
+  });
+});

--- a/packages/domain/src/error-codes.ts
+++ b/packages/domain/src/error-codes.ts
@@ -6,7 +6,7 @@
  */
 
 export enum ErrorCode {
-  // Validation errors (400)
+  // Validation errors
   VALIDATION_ERROR = "VALIDATION_ERROR",
   INVALID_INPUT = "INVALID_INPUT",
   INVALID_ID = "INVALID_ID",
@@ -65,8 +65,8 @@ export enum ErrorCode {
  * Maps error codes to their corresponding HTTP status codes
  */
 export const ERROR_CODE_TO_STATUS: Record<ErrorCode, number> = {
-  // Validation errors (400)
-  [ErrorCode.VALIDATION_ERROR]: 400,
+  // Validation errors
+  [ErrorCode.VALIDATION_ERROR]: 422,
   [ErrorCode.INVALID_INPUT]: 400,
   [ErrorCode.INVALID_ID]: 400,
   [ErrorCode.MISSING_REQUIRED_FIELD]: 400,

--- a/packages/domain/test/error-codes.test.ts
+++ b/packages/domain/test/error-codes.test.ts
@@ -21,3 +21,23 @@ describe("TOO_MANY_REQUESTS", () => {
     expect(parsed.success).toBe(true);
   });
 });
+
+// The status for a rejected input is a cross-package contract: the server
+// middleware, the client's own Zod handling and every validation doc read it
+// off this map, so a silent edit here would split them apart again.
+
+describe("VALIDATION_ERROR", () => {
+  it("maps to 422", () => {
+    expect(getStatusCode(ErrorCode.VALIDATION_ERROR)).toBe(422);
+  });
+
+  it("is accepted by the error envelope", () => {
+    const parsed = ErrorObjectSchema.safeParse({
+      code: ErrorCode.VALIDATION_ERROR,
+      message: "Validation failed: 1 error(s)",
+      statusCode: getStatusCode(ErrorCode.VALIDATION_ERROR),
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.8.3)(vite@7.2.7(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@24.10.4)(vite@7.2.7(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
 
   apps/server:
     dependencies:


### PR DESCRIPTION
## Decision: 422

`ERROR_CODE_TO_STATUS[VALIDATION_ERROR]` was `400` while every document, the client's own `handleZodError`, and issues #93 and #99 assumed `422`. Per the ticket's default decision, the map moves to **422**: the docs and the client already assumed it, and `UNPROCESSABLE_ENTITY` already maps to 422, so the server had committed to that semantic.

The production change is one line in [`packages/domain/src/error-codes.ts`](packages/domain/src/error-codes.ts). Everything else either derives from it or stops contradicting it.

## Backend

Verified as following the map with no edit needed: `validation.middleware.ts`, `error.middleware.ts` (`handleZodError`, `handleValidationErrorDB`), `sendErrorDev` / `sendErrorProd`. A sweep of `apps/server/src` and `packages/domain/src` confirms no literal status is passed alongside `VALIDATION_ERROR`.

Ten test files that asserted `400` for a validation rejection now assert `422`. The `CART_EMPTY` 400 in `order.route.test.ts` and the `orderFromCart(user.id, 400)` price arguments were left alone.

## Client

`handleZodError` no longer hard-codes `422`; it omits the status so `AppError` derives it from `ERROR_CODE_TO_STATUS`, which makes a client-side and a server-side validation error impossible to diverge again.

A sweep of `apps/client/src` for `=== 400`, `=== 422` and status switches found only the two the ticket blessed: the 4xx-range retry check in `react-query.ts` (400 and 422 behave identically) and the `404` case in `route-error-boundary.tsx`. `apps/client/docs/COMPONENT_ERROR_PATTERNS.md` did contain the literal branch the ticket asked us to eliminate, so its example now keys on `code === ErrorCode.VALIDATION_ERROR`.

## Regression protection

- **Domain** — `getStatusCode(ErrorCode.VALIDATION_ERROR)` is pinned to 422, so a future map edit fails loudly.
- **Server** — new `test/validation-status.route.test.ts` covers a malformed path param, an unknown field in a strict body, an invalid query value on a list route, and the global ZodError safety net. Each asserts the status against `getStatusCode` rather than a literal, plus `success: false` and populated `details`. The Prisma-validation path was already covered in `logger.test.ts`.
- **Client** — `apps/client` gains a vitest setup. `processAxiosError` mirrors the status the server put in the body; `normalizeError` of a client-side `ZodError` yields the same status as the server-side one.

## Verification

`pnpm test` (137 server + 11 domain + 2 client), `pnpm type-check`, `pnpm lint` (0 errors) and `pnpm format:check` all pass.

Manual smoke on the dev server:

```
curl -i localhost:8000/api/v1/products/not-an-id      → HTTP/1.1 422 Unprocessable Entity
curl -i "localhost:8000/api/v1/products?limit=abc"    → HTTP/1.1 422
POST /api/v1/auth/signup with an unknown key          → HTTP/1.1 422
curl -i "localhost:8000/api/v1/products?limit=1"      → HTTP/1.1 200
```

Through the Vite dev proxy, the browser origin sees the same 422 with per-field `details` for `["body","email"]`, `["body","password"]`, `["body","passwordConfirm"]`.

**Not verified:** the browser half of the manual smoke (inline field errors render, no toast, no retry storm) was not driven — no browser automation was available. Note the signup form validates with the same Zod schema client-side via TanStack Form, so invalid input never reaches the network on that path.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)