### PR TITLE
refactor: bind request schemas to their handlers so route and controller cannot drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,9 @@ packages/database  →  packages/domain  →  apps/server
 Route → validateSchema middleware → Controller → Service → Prisma
 ```
 
-- **`catchAsync`** — wrap every async route handler; centralized error middleware handles the rest
-- **`validateSchema(ZodSchema)`** — validates `params`, `body`, `query`; validated data lands in `req.verified`
-- **`catchAsync<ValidatedRequest<typeof XRequestSchema>>`** — types `req.verified` from the route's schema; use it in every handler that reads validated input
+- **`defineHandler(XRequestSchema, fn)`** — how every route that takes input is written. It returns the `[validateSchema(schema), catchAsync(fn)]` pair, the controller exports it as a `ValidatedHandler`, and the route spreads it (`router.post("/", ...controller.createX)`). The schema is named once, in the controller, and `req.verified` is inferred from it. Route files never import a request schema.
+- **`catchAsync`** — wrap every async route handler; centralized error middleware handles the rest. Only for handlers whose route mounts no schema
+- **`validateSchema(ZodSchema)`** — validates `params`, `body`, `query`; validated data lands in `req.verified`. Reached through `defineHandler`, not mounted by hand
 - **`AppError`** — throw with error codes from `@repo/domain/error-codes`; never throw raw errors
 - **Zod errors** — auto-converted to `AppError(422, VALIDATION_ERROR)` by error middleware
 - **Logging** — `pino` + `pino-http`; inside a request use `req.log` (it carries `requestId`), never the bare `logger`. Errors are logged once, at the boundary: the error middleware puts the error on `res.err` and its severity on `res.errLogLevel` (`error` for our own failures - a non-operational `AppError` or a 5xx - `warn` for client faults) and pino-http emits the single line for that request. Layers in between throw, they don't log.
@@ -142,8 +142,8 @@ Used for cross-cutting concerns (auth, logging, timing). Middleware chain runs p
 ## Critical Pitfalls
 
 1. **Regenerate with `pnpm db:generate` after any schema change** — the `prisma-client` generator is configured with `importFileExtension = "js"` (plus `runtime = "nodejs"`, `moduleFormat = "esm"`), so generated imports carry `.js` natively. No post-processing step is involved any more.
-2. **Every async route handler must use `catchAsync`** — uncaught promise rejections won't reach the centralized error middleware otherwise.
-3. **Every route accepting input must use `validateSchema`** — never skip it.
+2. **Every async route handler must use `catchAsync`** — uncaught promise rejections won't reach the centralized error middleware otherwise. `defineHandler` does this for you.
+3. **Every route accepting input must go through `defineHandler`** — never mount `validateSchema` by hand, and never skip it.
 4. **Build order matters**: if types are missing, ensure `packages/database` and `packages/domain` are built before `apps/server`.
 
 ## Environment Variables

--- a/apps/server/src/controllers/auth.controller.ts
+++ b/apps/server/src/controllers/auth.controller.ts
@@ -10,8 +10,8 @@ import {
 } from "@repo/domain";
 import { Request, RequestHandler, Response } from "express";
 import { authService } from "../services/auth.service.js";
-import { ValidatedRequest } from "../types/validated-request.js";
 import catchAsync from "../utils/catchAsync.js";
+import { defineHandler, ValidatedHandler } from "../utils/define-handler.js";
 import { env } from "../utils/env.js";
 import { getTokenFromRequest } from "../middlewares/auth.middleware.js";
 
@@ -66,24 +66,26 @@ const createAndSendAuthCookie = (
  * Sign up a new user
  * Parses request, delegates to service, sends response
  */
-export const signup: RequestHandler = catchAsync<
-  ValidatedRequest<typeof AuthSignUpRequestSchema>
->(async (req, res) => {
-  const { token, user } = await authService.signup(req.verified.body);
-  createAndSendAuthCookie(user, token, 201, req, res);
-});
+export const signup: ValidatedHandler = defineHandler(
+  AuthSignUpRequestSchema,
+  async (req, res) => {
+    const { token, user } = await authService.signup(req.verified.body);
+    createAndSendAuthCookie(user, token, 201, req, res);
+  },
+);
 
 /**
  * Log in a user
  * Validates credentials via service, sends response with token
  */
-export const login: RequestHandler = catchAsync<
-  ValidatedRequest<typeof AuthLoginRequestSchema>
->(async (req, res) => {
-  const { email, password } = req.verified.body;
-  const { user, token } = await authService.login({ email, password });
-  createAndSendAuthCookie(user, token, 200, req, res);
-});
+export const login: ValidatedHandler = defineHandler(
+  AuthLoginRequestSchema,
+  async (req, res) => {
+    const { email, password } = req.verified.body;
+    const { user, token } = await authService.login({ email, password });
+    createAndSendAuthCookie(user, token, 200, req, res);
+  },
+);
 
 /**
  * Log out a user
@@ -105,27 +107,28 @@ export const logout = (req: Request, res: Response) => {
  * Update user password
  * Gets user ID from request(after authentication), delegates to service, sends response with new token
  */
-export const updatePassword: RequestHandler = catchAsync<
-  ValidatedRequest<typeof AuthUpdatePasswordRequestSchema>
->(async (req, res, next) => {
-  // passwordConfirm and currentPassword validation handled in zod schema
-  const { currentPassword, password } = req.verified.body;
-  const userId = req.user?.id;
+export const updatePassword: ValidatedHandler = defineHandler(
+  AuthUpdatePasswordRequestSchema,
+  async (req, res, next) => {
+    // passwordConfirm and currentPassword validation handled in zod schema
+    const { currentPassword, password } = req.verified.body;
+    const userId = req.user?.id;
 
-  if (!userId) {
-    return next(
-      new AppError("User ID not found in request", ErrorCode.UNAUTHORIZED),
+    if (!userId) {
+      return next(
+        new AppError("User ID not found in request", ErrorCode.UNAUTHORIZED),
+      );
+    }
+
+    const userData = await authService.updatePassword(
+      userId,
+      currentPassword,
+      password,
     );
-  }
-
-  const userData = await authService.updatePassword(
-    userId,
-    currentPassword,
-    password,
-  );
-  const { token, user } = userData;
-  createAndSendAuthCookie(user, token, 200, req, res);
-});
+    const { token, user } = userData;
+    createAndSendAuthCookie(user, token, 200, req, res);
+  },
+);
 
 export const getUserAuthStatus: RequestHandler = catchAsync(
   async (req, res, _next) => {

--- a/apps/server/src/controllers/cart.controller.ts
+++ b/apps/server/src/controllers/cart.controller.ts
@@ -1,84 +1,94 @@
 import {
   AddToCartRequestSchema,
+  ClearCartRequestSchema,
   createEmptyResponse,
   createSingleItemResponse,
+  GetCartRequestSchema,
   RemoveFromCartRequestSchema,
   SyncCartRequestSchema,
   UpdateCartItemRequestSchema,
 } from "@repo/domain";
-import { RequestHandler } from "express";
 import { cartService } from "../services/cart.service.js";
-import { ValidatedRequest } from "../types/validated-request.js";
-import catchAsync from "../utils/catchAsync.js";
+import { defineHandler, ValidatedHandler } from "../utils/define-handler.js";
 
 /**
  * Get current user's cart
  */
-export const getCart: RequestHandler = catchAsync(async (req, res) => {
-  const userId = req.user!.id; // User is set by auth middleware
-  const dto = await cartService.getOrCreateCart(userId);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const getCart: ValidatedHandler = defineHandler(
+  GetCartRequestSchema,
+  async (req, res) => {
+    const userId = req.user!.id; // User is set by auth middleware
+    const dto = await cartService.getOrCreateCart(userId);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
 /**
  * Add item to cart
  */
-export const addToCart: RequestHandler = catchAsync<
-  ValidatedRequest<typeof AddToCartRequestSchema>
->(async (req, res) => {
-  const userId = req.user!.id;
-  const { productId, quantity } = req.verified.body;
+export const addToCart: ValidatedHandler = defineHandler(
+  AddToCartRequestSchema,
+  async (req, res) => {
+    const userId = req.user!.id;
+    const { productId, quantity } = req.verified.body;
 
-  const dto = await cartService.addToCart(userId, productId, quantity);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+    const dto = await cartService.addToCart(userId, productId, quantity);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
 /**
  * Sync local cart with server cart
  */
-export const syncCart: RequestHandler = catchAsync<
-  ValidatedRequest<typeof SyncCartRequestSchema>
->(async (req, res) => {
-  const userId = req.user!.id;
-  const { items } = req.verified.body;
+export const syncCart: ValidatedHandler = defineHandler(
+  SyncCartRequestSchema,
+  async (req, res) => {
+    const userId = req.user!.id;
+    const { items } = req.verified.body;
 
-  const dto = await cartService.syncCart(userId, { items });
-  res.status(200).json(createSingleItemResponse(dto));
-});
+    const dto = await cartService.syncCart(userId, { items });
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
 /**
  * Update cart item quantity
  */
-export const updateCartItem: RequestHandler = catchAsync<
-  ValidatedRequest<typeof UpdateCartItemRequestSchema>
->(async (req, res) => {
-  const userId = req.user!.id;
-  const { cartItemId } = req.verified.params;
-  const { quantity } = req.verified.body;
+export const updateCartItem: ValidatedHandler = defineHandler(
+  UpdateCartItemRequestSchema,
+  async (req, res) => {
+    const userId = req.user!.id;
+    const { cartItemId } = req.verified.params;
+    const { quantity } = req.verified.body;
 
-  const dto = await cartService.updateCartItem(userId, cartItemId, quantity);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+    const dto = await cartService.updateCartItem(userId, cartItemId, quantity);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
 /**
  * Remove item from cart
  */
-export const removeFromCart: RequestHandler = catchAsync<
-  ValidatedRequest<typeof RemoveFromCartRequestSchema>
->(async (req, res) => {
-  const userId = req.user!.id;
-  const { cartItemId } = req.verified.params;
+export const removeFromCart: ValidatedHandler = defineHandler(
+  RemoveFromCartRequestSchema,
+  async (req, res) => {
+    const userId = req.user!.id;
+    const { cartItemId } = req.verified.params;
 
-  const dto = await cartService.removeFromCart(userId, cartItemId);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+    const dto = await cartService.removeFromCart(userId, cartItemId);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
 /**
  * Clear all items from cart
  */
-export const clearCart: RequestHandler = catchAsync(async (req, res) => {
-  const userId = req.user!.id;
+export const clearCart: ValidatedHandler = defineHandler(
+  ClearCartRequestSchema,
+  async (req, res) => {
+    const userId = req.user!.id;
 
-  await cartService.clearCart(userId);
-  res.status(200).json(createEmptyResponse());
-});
+    await cartService.clearCart(userId);
+    res.status(200).json(createEmptyResponse());
+  },
+);

--- a/apps/server/src/controllers/category.controller.ts
+++ b/apps/server/src/controllers/category.controller.ts
@@ -8,47 +8,50 @@ import {
   createListResponse,
   createSingleItemResponse,
 } from "@repo/domain";
-import { RequestHandler } from "express";
 import { categoryService } from "../services/category.service.js";
-import { ValidatedRequest } from "../types/validated-request.js";
-import catchAsync from "../utils/catchAsync.js";
+import { defineHandler, ValidatedHandler } from "../utils/define-handler.js";
 
-export const getAllCategories: RequestHandler = catchAsync<
-  ValidatedRequest<typeof CategoryGetAllRequestSchema>
->(async (req, res) => {
-  const result = await categoryService.getAll(req.verified.query);
-  res.status(200).json(createListResponse(result.data, result.meta));
-});
+export const getAllCategories: ValidatedHandler = defineHandler(
+  CategoryGetAllRequestSchema,
+  async (req, res) => {
+    const result = await categoryService.getAll(req.verified.query);
+    res.status(200).json(createListResponse(result.data, result.meta));
+  },
+);
 
-export const getCategoryById: RequestHandler = catchAsync<
-  ValidatedRequest<typeof CategoryGetByIdRequestSchema>
->(async (req, res) => {
-  const dto = await categoryService.get(req.verified.params.id);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const getCategoryById: ValidatedHandler = defineHandler(
+  CategoryGetByIdRequestSchema,
+  async (req, res) => {
+    const dto = await categoryService.get(req.verified.params.id);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
 // * ADMIN CONTROLLERS
 
-export const createCategory: RequestHandler = catchAsync<
-  ValidatedRequest<typeof CategoryCreateRequestSchema>
->(async (req, res) => {
-  const dto = await categoryService.create(req.verified.body);
-  res.status(201).json(createSingleItemResponse(dto));
-});
+export const createCategory: ValidatedHandler = defineHandler(
+  CategoryCreateRequestSchema,
+  async (req, res) => {
+    const dto = await categoryService.create(req.verified.body);
+    res.status(201).json(createSingleItemResponse(dto));
+  },
+);
 
-export const updateCategory: RequestHandler = catchAsync<
-  ValidatedRequest<typeof CategoryUpdateByIdRequestSchema>
->(async (req, res) => {
-  const dto = await categoryService.update(
-    req.verified.params.id,
-    req.verified.body,
-  );
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const updateCategory: ValidatedHandler = defineHandler(
+  CategoryUpdateByIdRequestSchema,
+  async (req, res) => {
+    const dto = await categoryService.update(
+      req.verified.params.id,
+      req.verified.body,
+    );
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
-export const deleteCategory: RequestHandler = catchAsync<
-  ValidatedRequest<typeof CategoryDeleteByIdRequestSchema>
->(async (req, res) => {
-  await categoryService.delete(req.verified.params.id);
-  res.status(200).json(createEmptyResponse());
-});
+export const deleteCategory: ValidatedHandler = defineHandler(
+  CategoryDeleteByIdRequestSchema,
+  async (req, res) => {
+    await categoryService.delete(req.verified.params.id);
+    res.status(200).json(createEmptyResponse());
+  },
+);

--- a/apps/server/src/controllers/config.controller.ts
+++ b/apps/server/src/controllers/config.controller.ts
@@ -1,42 +1,47 @@
 import {
   ConfigCreateRequestSchema,
   ConfigDeleteByIdRequestSchema,
+  ConfigGetUniqueRequestSchema,
   ConfigUpdateByIdRequestSchema,
   createEmptyResponse,
   createSingleItemResponse,
 } from "@repo/domain";
-import { RequestHandler } from "express";
 import { configService } from "../services/config.service.js";
-import { ValidatedRequest } from "../types/validated-request.js";
-import catchAsync from "../utils/catchAsync.js";
+import { defineHandler, ValidatedHandler } from "../utils/define-handler.js";
 
-export const getConfig: RequestHandler = catchAsync(async (_req, res) => {
-  const result = await configService.getUniqueConfig();
-  res.status(200).json(createSingleItemResponse(result));
-});
+export const getConfig: ValidatedHandler = defineHandler(
+  ConfigGetUniqueRequestSchema,
+  async (_req, res) => {
+    const result = await configService.getUniqueConfig();
+    res.status(200).json(createSingleItemResponse(result));
+  },
+);
 
 // * ADMIN CONTROLLERS
 
-export const createConfig: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ConfigCreateRequestSchema>
->(async (req, res) => {
-  const dto = await configService.create(req.verified.body);
-  res.status(201).json(createSingleItemResponse(dto));
-});
+export const createConfig: ValidatedHandler = defineHandler(
+  ConfigCreateRequestSchema,
+  async (req, res) => {
+    const dto = await configService.create(req.verified.body);
+    res.status(201).json(createSingleItemResponse(dto));
+  },
+);
 
-export const updateConfig: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ConfigUpdateByIdRequestSchema>
->(async (req, res) => {
-  const dto = await configService.update(
-    req.verified.params.id,
-    req.verified.body,
-  );
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const updateConfig: ValidatedHandler = defineHandler(
+  ConfigUpdateByIdRequestSchema,
+  async (req, res) => {
+    const dto = await configService.update(
+      req.verified.params.id,
+      req.verified.body,
+    );
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
-export const deleteConfig: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ConfigDeleteByIdRequestSchema>
->(async (req, res) => {
-  await configService.delete(req.verified.params.id);
-  res.status(200).json(createEmptyResponse());
-});
+export const deleteConfig: ValidatedHandler = defineHandler(
+  ConfigDeleteByIdRequestSchema,
+  async (req, res) => {
+    await configService.delete(req.verified.params.id);
+    res.status(200).json(createEmptyResponse());
+  },
+);

--- a/apps/server/src/controllers/order.controller.ts
+++ b/apps/server/src/controllers/order.controller.ts
@@ -6,59 +6,61 @@ import {
   ListOrdersRequestSchema,
   UpdateOrderStatusRequestSchema,
 } from "@repo/domain";
-import { RequestHandler } from "express";
 import { orderService } from "../services/order.service.js";
-import { ValidatedRequest } from "../types/validated-request.js";
-import catchAsync from "../utils/catchAsync.js";
+import { defineHandler, ValidatedHandler } from "../utils/define-handler.js";
 
 /**
  * Create order from cart
  */
-export const createOrder: RequestHandler = catchAsync<
-  ValidatedRequest<typeof CreateOrderRequestSchema>
->(async (req, res) => {
-  const userId = req.user!.id; // User is set by auth middleware
-  const orderInput = req.verified.body;
+export const createOrder: ValidatedHandler = defineHandler(
+  CreateOrderRequestSchema,
+  async (req, res) => {
+    const userId = req.user!.id; // User is set by auth middleware
+    const orderInput = req.verified.body;
 
-  const dto = await orderService.createOrder(userId, orderInput);
-  res.status(201).json(createSingleItemResponse(dto));
-});
+    const dto = await orderService.createOrder(userId, orderInput);
+    res.status(201).json(createSingleItemResponse(dto));
+  },
+);
 
 /**
  * Get order by ID
  */
-export const getOrder: RequestHandler = catchAsync<
-  ValidatedRequest<typeof GetOrderRequestSchema>
->(async (req, res) => {
-  const userId = req.user!.id;
-  const { orderId } = req.verified.params;
+export const getOrder: ValidatedHandler = defineHandler(
+  GetOrderRequestSchema,
+  async (req, res) => {
+    const userId = req.user!.id;
+    const { orderId } = req.verified.params;
 
-  const dto = await orderService.getOrderById(userId, orderId);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+    const dto = await orderService.getOrderById(userId, orderId);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
 /**
  * List user's orders
  */
-export const listOrders: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ListOrdersRequestSchema>
->(async (req, res) => {
-  const userId = req.user!.id;
-  const query = req.verified.query;
+export const listOrders: ValidatedHandler = defineHandler(
+  ListOrdersRequestSchema,
+  async (req, res) => {
+    const userId = req.user!.id;
+    const query = req.verified.query;
 
-  const result = await orderService.listUserOrders(userId, query);
-  res.status(200).json(createListResponse(result.data, result.meta));
-});
+    const result = await orderService.listUserOrders(userId, query);
+    res.status(200).json(createListResponse(result.data, result.meta));
+  },
+);
 
 /**
  * Update order status (admin only)
  */
-export const updateOrderStatus: RequestHandler = catchAsync<
-  ValidatedRequest<typeof UpdateOrderStatusRequestSchema>
->(async (req, res) => {
-  const { orderId } = req.verified.params;
-  const { status } = req.verified.body;
+export const updateOrderStatus: ValidatedHandler = defineHandler(
+  UpdateOrderStatusRequestSchema,
+  async (req, res) => {
+    const { orderId } = req.verified.params;
+    const { status } = req.verified.body;
 
-  const dto = await orderService.updateOrderStatus(orderId, status);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+    const dto = await orderService.updateOrderStatus(orderId, status);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);

--- a/apps/server/src/controllers/product.controller.ts
+++ b/apps/server/src/controllers/product.controller.ts
@@ -7,63 +7,69 @@ import {
   ProductGetAllRequestSchema,
   ProductGetByCategorySchema,
   ProductGetByIdRequestSchema,
+  ProductGetByPathSchema,
   ProductGetBySlugSchema,
   ProductGetRelatedByIdRequestSchema,
   ProductUpdateByIdRequestSchema,
 } from "@repo/domain";
-import { RequestHandler } from "express";
 import { productService } from "../services/product.service.js";
-import { ValidatedRequest } from "../types/validated-request.js";
-import catchAsync from "../utils/catchAsync.js";
+import { defineHandler, ValidatedHandler } from "../utils/define-handler.js";
 
-export const getAllProducts: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ProductGetAllRequestSchema>
->(async (req, res) => {
-  const result = await productService.getAll(req.verified.query);
-  res.status(200).json(createListResponse(result.data, result.meta));
-});
+export const getAllProducts: ValidatedHandler = defineHandler(
+  ProductGetAllRequestSchema,
+  async (req, res) => {
+    const result = await productService.getAll(req.verified.query);
+    res.status(200).json(createListResponse(result.data, result.meta));
+  },
+);
 
-export const getProductById: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ProductGetByIdRequestSchema>
->(async (req, res) => {
-  const dto = await productService.get(req.verified.params.id);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const getProductById: ValidatedHandler = defineHandler(
+  ProductGetByIdRequestSchema,
+  async (req, res) => {
+    const dto = await productService.get(req.verified.params.id);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
-export const getProductBySlug: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ProductGetBySlugSchema>
->(async (req, res) => {
-  const dto = await productService.getProductBySlug(req.verified.params.slug);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const getProductBySlug: ValidatedHandler = defineHandler(
+  ProductGetBySlugSchema,
+  async (req, res) => {
+    const dto = await productService.getProductBySlug(req.verified.params.slug);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
-export const getRelatedProducts: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ProductGetRelatedByIdRequestSchema>
->(async (req, res) => {
-  const result = await productService.getRelatedProducts(
-    req.verified.params.id,
-  );
-  res.status(200).json(createListResponse(result.data, result.meta));
-});
+export const getRelatedProducts: ValidatedHandler = defineHandler(
+  ProductGetRelatedByIdRequestSchema,
+  async (req, res) => {
+    const result = await productService.getRelatedProducts(
+      req.verified.params.id,
+    );
+    res.status(200).json(createListResponse(result.data, result.meta));
+  },
+);
 
-export const getProductsByCategoryName: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ProductGetByCategorySchema>
->(async (req, res) => {
-  const result = await productService.getProductsByCategoryName(
-    req.verified.params.category,
-  );
-  res.status(200).json(createListResponse(result.data, result.meta));
-});
+export const getProductsByCategoryName: ValidatedHandler = defineHandler(
+  ProductGetByCategorySchema,
+  async (req, res) => {
+    const result = await productService.getProductsByCategoryName(
+      req.verified.params.category,
+    );
+    res.status(200).json(createListResponse(result.data, result.meta));
+  },
+);
 
 // not exactly SingleItemResponse response but ok for now
-export const getShowCaseProducts: RequestHandler = catchAsync(
+export const getShowCaseProducts: ValidatedHandler = defineHandler(
+  ProductGetByPathSchema,
   async (_req, res) => {
     const dto = await productService.getShowCaseProducts();
     res.status(200).json(createSingleItemResponse(dto));
   },
 );
 
-export const getFeaturedProduct: RequestHandler = catchAsync(
+export const getFeaturedProduct: ValidatedHandler = defineHandler(
+  ProductGetByPathSchema,
   async (_req, res) => {
     const dto = await productService.getFeaturedProduct();
     res.status(200).json(createSingleItemResponse(dto));
@@ -72,26 +78,29 @@ export const getFeaturedProduct: RequestHandler = catchAsync(
 
 // * ADMIN CONTROLLERS
 
-export const createProduct: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ProductCreateRequestSchema>
->(async (req, res) => {
-  const dto = await productService.create(req.verified.body);
-  res.status(201).json(createSingleItemResponse(dto));
-});
+export const createProduct: ValidatedHandler = defineHandler(
+  ProductCreateRequestSchema,
+  async (req, res) => {
+    const dto = await productService.create(req.verified.body);
+    res.status(201).json(createSingleItemResponse(dto));
+  },
+);
 
-export const updateProduct: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ProductUpdateByIdRequestSchema>
->(async (req, res) => {
-  const dto = await productService.update(
-    req.verified.params.id,
-    req.verified.body,
-  );
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const updateProduct: ValidatedHandler = defineHandler(
+  ProductUpdateByIdRequestSchema,
+  async (req, res) => {
+    const dto = await productService.update(
+      req.verified.params.id,
+      req.verified.body,
+    );
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
-export const deleteProduct: RequestHandler = catchAsync<
-  ValidatedRequest<typeof ProductDeleteByIdRequestSchema>
->(async (req, res) => {
-  await productService.delete(req.verified.params.id);
-  res.status(200).json(createEmptyResponse());
-});
+export const deleteProduct: ValidatedHandler = defineHandler(
+  ProductDeleteByIdRequestSchema,
+  async (req, res) => {
+    await productService.delete(req.verified.params.id);
+    res.status(200).json(createEmptyResponse());
+  },
+);

--- a/apps/server/src/controllers/user.controller.ts
+++ b/apps/server/src/controllers/user.controller.ts
@@ -4,72 +4,84 @@ import {
   createSingleItemResponse,
   UserCreateRequestSchema,
   UserDeleteByIdRequestSchema,
+  UserDeleteMeRequestSchema,
   UserGetAllRequestSchema,
   UserGetByIdRequestSchema,
+  UserGetMeRequestSchema,
   UserUpdateByIdRequestSchema,
   UserUpdateMeRequestSchema,
 } from "@repo/domain";
-import { RequestHandler } from "express";
 import { userService } from "../services/user.service.js";
-import { ValidatedRequest } from "../types/validated-request.js";
-import catchAsync from "../utils/catchAsync.js";
+import { defineHandler, ValidatedHandler } from "../utils/define-handler.js";
 
 // Get the authenticated user's own record
-export const getMe: RequestHandler = catchAsync(async (req, res, _next) => {
-  const dto = await userService.get(req.user!.id);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const getMe: ValidatedHandler = defineHandler(
+  UserGetMeRequestSchema,
+  async (req, res, _next) => {
+    const dto = await userService.get(req.user!.id);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
 // Get a single user
-export const getUser: RequestHandler = catchAsync<
-  ValidatedRequest<typeof UserGetByIdRequestSchema>
->(async (req, res, _next) => {
-  const dto = await userService.get(req.verified.params.id);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const getUser: ValidatedHandler = defineHandler(
+  UserGetByIdRequestSchema,
+  async (req, res, _next) => {
+    const dto = await userService.get(req.verified.params.id);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
-export const deleteMe: RequestHandler = catchAsync(async (req, res, _next) => {
-  await userService.deactivate(req.user!.id);
-  res.status(200).json(createEmptyResponse());
-});
+export const deleteMe: ValidatedHandler = defineHandler(
+  UserDeleteMeRequestSchema,
+  async (req, res, _next) => {
+    await userService.deactivate(req.user!.id);
+    res.status(200).json(createEmptyResponse());
+  },
+);
 
 // Get all Users
-export const getAllUsers: RequestHandler = catchAsync<
-  ValidatedRequest<typeof UserGetAllRequestSchema>
->(async (req, res, _next) => {
-  const result = await userService.getAll(req.verified.query);
-  res.status(200).json(createListResponse(result.data, result.meta));
-});
+export const getAllUsers: ValidatedHandler = defineHandler(
+  UserGetAllRequestSchema,
+  async (req, res, _next) => {
+    const result = await userService.getAll(req.verified.query);
+    res.status(200).json(createListResponse(result.data, result.meta));
+  },
+);
 
 // deleting a user
-export const deleteUser: RequestHandler = catchAsync<
-  ValidatedRequest<typeof UserDeleteByIdRequestSchema>
->(async (req, res, _next) => {
-  await userService.delete(req.verified.params.id);
-  res.status(200).json(createEmptyResponse());
-});
+export const deleteUser: ValidatedHandler = defineHandler(
+  UserDeleteByIdRequestSchema,
+  async (req, res, _next) => {
+    await userService.delete(req.verified.params.id);
+    res.status(200).json(createEmptyResponse());
+  },
+);
 
 // updating a single user
-export const updateUser: RequestHandler = catchAsync<
-  ValidatedRequest<typeof UserUpdateByIdRequestSchema>
->(async (req, res, _next) => {
-  const dto = await userService.updateAsAdmin(
-    req.verified.params.id,
-    req.verified.body,
-  );
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const updateUser: ValidatedHandler = defineHandler(
+  UserUpdateByIdRequestSchema,
+  async (req, res, _next) => {
+    const dto = await userService.updateAsAdmin(
+      req.verified.params.id,
+      req.verified.body,
+    );
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
-export const updateMe: RequestHandler = catchAsync<
-  ValidatedRequest<typeof UserUpdateMeRequestSchema>
->(async (req, res, _next) => {
-  const dto = await userService.update(req.user!.id, req.verified.body);
-  res.status(200).json(createSingleItemResponse(dto));
-});
+export const updateMe: ValidatedHandler = defineHandler(
+  UserUpdateMeRequestSchema,
+  async (req, res, _next) => {
+    const dto = await userService.update(req.user!.id, req.verified.body);
+    res.status(200).json(createSingleItemResponse(dto));
+  },
+);
 
-export const createUser: RequestHandler = catchAsync<
-  ValidatedRequest<typeof UserCreateRequestSchema>
->(async (req, res, _next) => {
-  const dto = await userService.create(req.verified.body);
-  res.status(201).json(createSingleItemResponse(dto));
-});
+export const createUser: ValidatedHandler = defineHandler(
+  UserCreateRequestSchema,
+  async (req, res, _next) => {
+    const dto = await userService.create(req.verified.body);
+    res.status(201).json(createSingleItemResponse(dto));
+  },
+);

--- a/apps/server/src/routes/auth.route.ts
+++ b/apps/server/src/routes/auth.route.ts
@@ -1,31 +1,15 @@
-import {
-  AuthLoginRequestSchema,
-  AuthSignUpRequestSchema,
-  AuthUpdatePasswordRequestSchema,
-} from "@repo/domain";
 import express from "express";
 import * as authController from "../controllers/auth.controller.js";
 import { authenticate } from "../middlewares/auth.middleware.js";
-import { validateSchema } from "../middlewares/validation.middleware.js";
 import { loginLimiter, signupLimiter } from "../utils/rateLimiters.js";
 
 const authRouter: express.Router = express.Router();
 
 // * AUTH ROUTES (open for all)
 
-authRouter.post(
-  "/signup",
-  signupLimiter,
-  validateSchema(AuthSignUpRequestSchema),
-  authController.signup,
-);
+authRouter.post("/signup", signupLimiter, ...authController.signup);
 
-authRouter.post(
-  "/login",
-  loginLimiter,
-  validateSchema(AuthLoginRequestSchema),
-  authController.login,
-);
+authRouter.post("/login", loginLimiter, ...authController.login);
 
 authRouter.get("/status", authController.getUserAuthStatus);
 
@@ -38,10 +22,6 @@ authRouter.use(authenticate);
 
 authRouter.post("/logout", authController.logout);
 
-authRouter.patch(
-  "/updateMyPassword",
-  validateSchema(AuthUpdatePasswordRequestSchema),
-  authController.updatePassword,
-);
+authRouter.patch("/updateMyPassword", ...authController.updatePassword);
 
 export default authRouter;

--- a/apps/server/src/routes/cart.route.ts
+++ b/apps/server/src/routes/cart.route.ts
@@ -1,15 +1,6 @@
-import {
-  AddToCartRequestSchema,
-  ClearCartRequestSchema,
-  GetCartRequestSchema,
-  RemoveFromCartRequestSchema,
-  SyncCartRequestSchema,
-  UpdateCartItemRequestSchema,
-} from "@repo/domain";
 import express from "express";
 import * as cartController from "../controllers/cart.controller.js";
 import { authenticate } from "../middlewares/auth.middleware.js";
-import { validateSchema } from "../middlewares/validation.middleware.js";
 
 const cartRouter: express.Router = express.Router();
 
@@ -17,45 +8,21 @@ const cartRouter: express.Router = express.Router();
 cartRouter.use(authenticate);
 
 // Get current user's cart
-cartRouter.get(
-  "/",
-  validateSchema(GetCartRequestSchema),
-  cartController.getCart,
-);
+cartRouter.get("/", ...cartController.getCart);
 
 // Add item to cart
-cartRouter.post(
-  "/",
-  validateSchema(AddToCartRequestSchema),
-  cartController.addToCart,
-);
+cartRouter.post("/", ...cartController.addToCart);
 
 // Sync local cart with server cart
-cartRouter.post(
-  "/sync",
-  validateSchema(SyncCartRequestSchema),
-  cartController.syncCart,
-);
+cartRouter.post("/sync", ...cartController.syncCart);
 
 // Update cart item quantity
-cartRouter.patch(
-  "/items/:cartItemId",
-  validateSchema(UpdateCartItemRequestSchema),
-  cartController.updateCartItem,
-);
+cartRouter.patch("/items/:cartItemId", ...cartController.updateCartItem);
 
 // Remove item from cart
-cartRouter.delete(
-  "/items/:cartItemId",
-  validateSchema(RemoveFromCartRequestSchema),
-  cartController.removeFromCart,
-);
+cartRouter.delete("/items/:cartItemId", ...cartController.removeFromCart);
 
 // Clear cart
-cartRouter.delete(
-  "/",
-  validateSchema(ClearCartRequestSchema),
-  cartController.clearCart,
-);
+cartRouter.delete("/", ...cartController.clearCart);
 
 export default cartRouter;

--- a/apps/server/src/routes/category.route.ts
+++ b/apps/server/src/routes/category.route.ts
@@ -1,56 +1,28 @@
-import {
-  CategoryCreateRequestSchema,
-  CategoryDeleteByIdRequestSchema,
-  CategoryGetAllRequestSchema,
-  CategoryGetByIdRequestSchema,
-  CategoryUpdateByIdRequestSchema,
-  ProductGetByCategorySchema,
-} from "@repo/domain";
 import express from "express";
 import * as categoryController from "../controllers/category.controller.js";
 import * as productController from "../controllers/product.controller.js";
 import { authenticate, authorize } from "../middlewares/auth.middleware.js";
-import { validateSchema } from "../middlewares/validation.middleware.js";
 
 const categoryRouter: express.Router = express.Router();
 
-categoryRouter.get(
-  "/",
-  validateSchema(CategoryGetAllRequestSchema),
-  categoryController.getAllCategories,
-);
+categoryRouter.get("/", ...categoryController.getAllCategories);
 
 categoryRouter.get(
   "/:category/products",
-  validateSchema(ProductGetByCategorySchema),
-  productController.getProductsByCategoryName,
+  ...productController.getProductsByCategoryName,
 );
 
-categoryRouter.get(
-  "/:id",
-  validateSchema(CategoryGetByIdRequestSchema),
-  categoryController.getCategoryById,
-);
+categoryRouter.get("/:id", ...categoryController.getCategoryById);
 
 // * ADMIN ROUTES (restricted to admin roles)
 
 categoryRouter.use(authenticate, authorize("ADMIN"));
 
-categoryRouter.post(
-  "/",
-  validateSchema(CategoryCreateRequestSchema),
-  categoryController.createCategory,
-);
+categoryRouter.post("/", ...categoryController.createCategory);
 
 categoryRouter
   .route("/:id")
-  .patch(
-    validateSchema(CategoryUpdateByIdRequestSchema),
-    categoryController.updateCategory,
-  )
-  .delete(
-    validateSchema(CategoryDeleteByIdRequestSchema),
-    categoryController.deleteCategory,
-  );
+  .patch(...categoryController.updateCategory)
+  .delete(...categoryController.deleteCategory);
 
 export default categoryRouter;

--- a/apps/server/src/routes/config.route.ts
+++ b/apps/server/src/routes/config.route.ts
@@ -1,43 +1,20 @@
-import {
-  ConfigCreateRequestSchema,
-  ConfigDeleteByIdRequestSchema,
-  ConfigGetUniqueRequestSchema,
-  ConfigUpdateByIdRequestSchema,
-} from "@repo/domain";
 import express from "express";
 import * as configController from "../controllers/config.controller.js";
 import { authenticate, authorize } from "../middlewares/auth.middleware.js";
-import { validateSchema } from "../middlewares/validation.middleware.js";
 
 const configRouter: express.Router = express.Router();
 
 // * PUBLIC ROUTES
 
-configRouter.get(
-  "/",
-  validateSchema(ConfigGetUniqueRequestSchema),
-  configController.getConfig,
-);
+configRouter.get("/", ...configController.getConfig);
 
 // * ADMIN ROUTES (restricted to admin roles)
 configRouter.use(authenticate, authorize("ADMIN"));
 
-configRouter.post(
-  "/",
-  validateSchema(ConfigCreateRequestSchema),
-  configController.createConfig,
-);
+configRouter.post("/", ...configController.createConfig);
 
-configRouter.patch(
-  "/:id",
-  validateSchema(ConfigUpdateByIdRequestSchema),
-  configController.updateConfig,
-);
+configRouter.patch("/:id", ...configController.updateConfig);
 
-configRouter.delete(
-  "/:id",
-  validateSchema(ConfigDeleteByIdRequestSchema),
-  configController.deleteConfig,
-);
+configRouter.delete("/:id", ...configController.deleteConfig);
 
 export default configRouter;

--- a/apps/server/src/routes/order.route.ts
+++ b/apps/server/src/routes/order.route.ts
@@ -1,13 +1,6 @@
-import {
-  CreateOrderRequestSchema,
-  GetOrderRequestSchema,
-  ListOrdersRequestSchema,
-  UpdateOrderStatusRequestSchema,
-} from "@repo/domain";
 import express from "express";
 import * as orderController from "../controllers/order.controller.js";
 import { authenticate, authorize } from "../middlewares/auth.middleware.js";
-import { validateSchema } from "../middlewares/validation.middleware.js";
 import { createOrderLimiter } from "../utils/rateLimiters.js";
 
 const orderRouter: express.Router = express.Router();
@@ -16,36 +9,19 @@ const orderRouter: express.Router = express.Router();
 orderRouter.use(authenticate);
 
 // Create order from cart
-orderRouter.post(
-  "/",
-  createOrderLimiter,
-  validateSchema(CreateOrderRequestSchema),
-  orderController.createOrder,
-);
+orderRouter.post("/", createOrderLimiter, ...orderController.createOrder);
 
 // List user's orders
-orderRouter.get(
-  "/",
-  validateSchema(ListOrdersRequestSchema),
-  orderController.listOrders,
-);
+orderRouter.get("/", ...orderController.listOrders);
 
 // Get specific order
-orderRouter.get(
-  "/:orderId",
-  validateSchema(GetOrderRequestSchema),
-  orderController.getOrder,
-);
+orderRouter.get("/:orderId", ...orderController.getOrder);
 
 // * ADMIN ROUTES (restricted to admin roles)
 
 orderRouter.use(authorize("ADMIN"));
 
 // Update order status (admin only)
-orderRouter.patch(
-  "/:orderId/status",
-  validateSchema(UpdateOrderStatusRequestSchema),
-  orderController.updateOrderStatus,
-);
+orderRouter.patch("/:orderId/status", ...orderController.updateOrderStatus);
 
 export default orderRouter;

--- a/apps/server/src/routes/product.route.ts
+++ b/apps/server/src/routes/product.route.ts
@@ -1,73 +1,31 @@
-import {
-  ProductCreateRequestSchema,
-  ProductDeleteByIdRequestSchema,
-  ProductGetAllRequestSchema,
-  ProductGetByIdRequestSchema,
-  ProductGetByPathSchema,
-  ProductGetBySlugSchema,
-  ProductGetRelatedByIdRequestSchema,
-  ProductUpdateByIdRequestSchema,
-} from "@repo/domain";
 import express from "express";
 import * as productController from "../controllers/product.controller.js";
 import { authenticate, authorize } from "../middlewares/auth.middleware.js";
-import { validateSchema } from "../middlewares/validation.middleware.js";
 
 const productRouter: express.Router = express.Router();
 
-productRouter.get(
-  "/",
-  validateSchema(ProductGetAllRequestSchema),
-  productController.getAllProducts,
-);
-productRouter.get(
-  "/featured",
-  validateSchema(ProductGetByPathSchema),
-  productController.getFeaturedProduct,
-);
-productRouter.get(
-  "/show-case",
-  validateSchema(ProductGetByPathSchema),
-  productController.getShowCaseProducts,
-);
+productRouter.get("/", ...productController.getAllProducts);
+productRouter.get("/featured", ...productController.getFeaturedProduct);
+productRouter.get("/show-case", ...productController.getShowCaseProducts);
 
 productRouter.get(
   "/related-products/:id",
-  validateSchema(ProductGetRelatedByIdRequestSchema),
-  productController.getRelatedProducts,
+  ...productController.getRelatedProducts,
 );
 
-productRouter.get(
-  "/:id",
-  validateSchema(ProductGetByIdRequestSchema),
-  productController.getProductById,
-);
+productRouter.get("/:id", ...productController.getProductById);
 
-productRouter.get(
-  "/slug/:slug",
-  validateSchema(ProductGetBySlugSchema),
-  productController.getProductBySlug,
-);
+productRouter.get("/slug/:slug", ...productController.getProductBySlug);
 
 // * ADMIN ROUTES (restricted to admin roles)
 
 productRouter.use(authenticate, authorize("ADMIN"));
 
-productRouter.post(
-  "/",
-  validateSchema(ProductCreateRequestSchema),
-  productController.createProduct,
-);
+productRouter.post("/", ...productController.createProduct);
 
 productRouter
   .route("/:id")
-  .patch(
-    validateSchema(ProductUpdateByIdRequestSchema),
-    productController.updateProduct,
-  )
-  .delete(
-    validateSchema(ProductDeleteByIdRequestSchema),
-    productController.deleteProduct,
-  );
+  .patch(...productController.updateProduct)
+  .delete(...productController.deleteProduct);
 
 export default productRouter;

--- a/apps/server/src/routes/user.route.ts
+++ b/apps/server/src/routes/user.route.ts
@@ -1,17 +1,6 @@
-import {
-  UserCreateRequestSchema,
-  UserDeleteByIdRequestSchema,
-  UserDeleteMeRequestSchema,
-  UserGetAllRequestSchema,
-  UserGetByIdRequestSchema,
-  UserGetMeRequestSchema,
-  UserUpdateByIdRequestSchema,
-  UserUpdateMeRequestSchema,
-} from "@repo/domain";
 import express from "express";
 import * as userController from "../controllers/user.controller.js";
 import { authenticate, authorize } from "../middlewares/auth.middleware.js";
-import { validateSchema } from "../middlewares/validation.middleware.js";
 
 const userRouter: express.Router = express.Router();
 
@@ -19,56 +8,24 @@ const userRouter: express.Router = express.Router();
 
 userRouter.use(authenticate);
 
-userRouter.get(
-  "/me",
-  validateSchema(UserGetMeRequestSchema),
-  userController.getMe,
-);
+userRouter.get("/me", ...userController.getMe);
 
-userRouter.patch(
-  "/updateMe",
-  validateSchema(UserUpdateMeRequestSchema),
-  userController.updateMe,
-);
+userRouter.patch("/updateMe", ...userController.updateMe);
 
-userRouter.delete(
-  "/deleteMe",
-  validateSchema(UserDeleteMeRequestSchema),
-  userController.deleteMe,
-);
+userRouter.delete("/deleteMe", ...userController.deleteMe);
 
 // * ADMIN ROUTES (restricted to admin roles)
 
 userRouter.use(authorize("ADMIN"));
 
-userRouter.get(
-  "/",
-  validateSchema(UserGetAllRequestSchema),
-  userController.getAllUsers,
-);
+userRouter.get("/", ...userController.getAllUsers);
 
-userRouter.post(
-  "/",
-  validateSchema(UserCreateRequestSchema),
-  userController.createUser,
-);
+userRouter.post("/", ...userController.createUser);
 
-userRouter.get(
-  "/:id",
-  validateSchema(UserGetByIdRequestSchema),
-  userController.getUser,
-);
+userRouter.get("/:id", ...userController.getUser);
 
-userRouter.patch(
-  "/:id",
-  validateSchema(UserUpdateByIdRequestSchema),
-  userController.updateUser,
-);
+userRouter.patch("/:id", ...userController.updateUser);
 
-userRouter.delete(
-  "/:id",
-  validateSchema(UserDeleteByIdRequestSchema),
-  userController.deleteUser,
-);
+userRouter.delete("/:id", ...userController.deleteUser);
 
 export default userRouter;

--- a/apps/server/src/utils/define-handler.ts
+++ b/apps/server/src/utils/define-handler.ts
@@ -6,8 +6,7 @@ import catchAsync from "./catchAsync.js";
 
 export type ValidatedHandler = readonly [RequestHandler, RequestHandler];
 
-// Pairs a request schema with the handler that reads it, so a route mounts
-// both together and the two can never name different schemas.
+// Binds a schema to the handler that reads it, so the two cannot drift.
 export const defineHandler = <S extends ZodType>(
   schema: S,
   fn: (

--- a/apps/server/src/utils/define-handler.ts
+++ b/apps/server/src/utils/define-handler.ts
@@ -1,0 +1,18 @@
+import { NextFunction, RequestHandler, Response } from "express";
+import { ZodType } from "zod";
+import { validateSchema } from "../middlewares/validation.middleware.js";
+import { ValidatedRequest } from "../types/validated-request.js";
+import catchAsync from "./catchAsync.js";
+
+export type ValidatedHandler = readonly [RequestHandler, RequestHandler];
+
+// Pairs a request schema with the handler that reads it, so a route mounts
+// both together and the two can never name different schemas.
+export const defineHandler = <S extends ZodType>(
+  schema: S,
+  fn: (
+    req: ValidatedRequest<S>,
+    res: Response,
+    next: NextFunction,
+  ) => Promise<unknown>,
+): ValidatedHandler => [validateSchema(schema), catchAsync(fn)];

--- a/apps/server/test/define-handler.test-d.ts
+++ b/apps/server/test/define-handler.test-d.ts
@@ -1,0 +1,67 @@
+import type {
+  GetOrderRequestSchema,
+  ProductGetAllRequestSchema,
+  UpdateOrderStatusRequestSchema,
+} from "@repo/domain";
+import express, { type Response } from "express";
+import { describe, expectTypeOf, it } from "vitest";
+import type { ValidatedRequest } from "../src/types/validated-request.js";
+import {
+  defineHandler,
+  type ValidatedHandler,
+} from "../src/utils/define-handler.js";
+
+declare const GetOrder: typeof GetOrderRequestSchema;
+declare const ListProducts: typeof ProductGetAllRequestSchema;
+declare const UpdateOrderStatus: typeof UpdateOrderStatusRequestSchema;
+
+describe("defineHandler", () => {
+  it("infers req.verified from the schema argument alone", () => {
+    defineHandler(UpdateOrderStatus, async (req) => {
+      expectTypeOf(req.verified.params).toEqualTypeOf<{ orderId: string }>();
+      expectTypeOf(req.verified.body.status).toEqualTypeOf<
+        "PENDING" | "PROCESSING" | "SHIPPED" | "DELIVERED" | "CANCELLED"
+      >();
+    });
+
+    defineHandler(ListProducts, async (req) => {
+      expectTypeOf(req.verified.query.name).toEqualTypeOf<string | undefined>();
+    });
+  });
+
+  it("rejects a field the schema does not declare", () => {
+    defineHandler(GetOrder, async (req) => {
+      // @ts-expect-error the schema declares `orderId`, not `id`
+      expectTypeOf(req.verified.params.id);
+      // @ts-expect-error this route validates no body
+      expectTypeOf(req.verified.body.status);
+    });
+  });
+
+  it("rejects a handler written against a different schema", () => {
+    const readsOrderStatus = async (
+      req: ValidatedRequest<typeof UpdateOrderStatusRequestSchema>,
+      res: Response,
+    ) => {
+      res.json({ status: req.verified.body.status });
+    };
+
+    // @ts-expect-error the handler reads a body `GetOrder` does not validate
+    defineHandler(GetOrder, readsOrderStatus);
+  });
+
+  it("spreads into a router without a cast", () => {
+    const router = express.Router();
+    const handler = defineHandler(GetOrder, async (req, res) => {
+      res.json({ orderId: req.verified.params.orderId });
+    });
+
+    expectTypeOf(handler).toEqualTypeOf<ValidatedHandler>();
+    router.get("/:orderId", ...handler);
+    router
+      .route("/:orderId")
+      .patch(
+        ...defineHandler(UpdateOrderStatus, async (_req, res) => res.end()),
+      );
+  });
+});

--- a/apps/server/test/route-manifest.test.ts
+++ b/apps/server/test/route-manifest.test.ts
@@ -9,8 +9,7 @@ import orderRouter from "../src/routes/order.route.js";
 import productRouter from "../src/routes/product.route.js";
 import userRouter from "../src/routes/user.route.js";
 
-// Reads Express internals on purpose: the mounted stack is the only place the
-// real middleware order lives. Keep the walk here, never in production code.
+// Reads Express internals: keep the walk here, never in production code.
 
 type RouteLayer = {
   name: string;
@@ -24,8 +23,7 @@ type RouteLayer = {
 
 type StackHolder = { stack: RouteLayer[] };
 
-// Express 5 keeps the mount prefix in the parent layer's matcher function, out
-// of reach of a stack walk, so groups are named by router identity instead.
+// Express 5 hides the mount prefix in the parent matcher: name groups by identity.
 const ROUTER_NAMES = new Map<unknown, string>([
   [healthRouter, "health"],
   [userRouter, "users"],

--- a/apps/server/test/route-manifest.test.ts
+++ b/apps/server/test/route-manifest.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import authRouter from "../src/routes/auth.route.js";
+import cartRouter from "../src/routes/cart.route.js";
+import categoryRouter from "../src/routes/category.route.js";
+import configRouter from "../src/routes/config.route.js";
+import healthRouter from "../src/routes/health.route.js";
+import indexRoute from "../src/routes/index.js";
+import orderRouter from "../src/routes/order.route.js";
+import productRouter from "../src/routes/product.route.js";
+import userRouter from "../src/routes/user.route.js";
+
+// Reads Express internals on purpose: the mounted stack is the only place the
+// real middleware order lives. Keep the walk here, never in production code.
+
+type RouteLayer = {
+  name: string;
+  handle: unknown;
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: unknown[];
+  };
+};
+
+type StackHolder = { stack: RouteLayer[] };
+
+// Express 5 keeps the mount prefix in the parent layer's matcher function, out
+// of reach of a stack walk, so groups are named by router identity instead.
+const ROUTER_NAMES = new Map<unknown, string>([
+  [healthRouter, "health"],
+  [userRouter, "users"],
+  [authRouter, "auth"],
+  [categoryRouter, "categories"],
+  [productRouter, "products"],
+  [configRouter, "config"],
+  [cartRouter, "cart"],
+  [orderRouter, "orders"],
+]);
+
+const isStackHolder = (value: unknown): value is StackHolder =>
+  typeof value === "function" && Array.isArray((value as StackHolder).stack);
+
+const describeLayer = (layer: RouteLayer): string => {
+  const { route } = layer;
+  if (!route) return `use ${layer.name || "<anonymous>"}`;
+
+  const methods = Object.keys(route.methods).sort().join("|");
+  return `${methods} ${route.path} [${route.stack.length} handlers]`;
+};
+
+const walk = (router: StackHolder, indent = ""): string[] =>
+  router.stack.flatMap((layer) => {
+    const group = ROUTER_NAMES.get(layer.handle);
+    if (group && isStackHolder(layer.handle)) {
+      return [`${indent}${group}`, ...walk(layer.handle, `${indent}  `)];
+    }
+    return [`${indent}${describeLayer(layer)}`];
+  });
+
+describe("route manifest", () => {
+  it("mounts every route with the same middleware chain", () => {
+    expect(walk(indexRoute as unknown as StackHolder).join("\n"))
+      .toMatchInlineSnapshot(`
+        "health
+          get / [1 handlers]
+        users
+          use <anonymous>
+          get /me [2 handlers]
+          patch /updateMe [2 handlers]
+          delete /deleteMe [2 handlers]
+          use <anonymous>
+          get / [2 handlers]
+          post / [2 handlers]
+          get /:id [2 handlers]
+          patch /:id [2 handlers]
+          delete /:id [2 handlers]
+        auth
+          post /signup [3 handlers]
+          post /login [3 handlers]
+          get /status [1 handlers]
+          use <anonymous>
+          post /logout [1 handlers]
+          patch /updateMyPassword [2 handlers]
+        categories
+          get / [2 handlers]
+          get /:category/products [2 handlers]
+          get /:id [2 handlers]
+          use <anonymous>
+          use <anonymous>
+          post / [2 handlers]
+          delete|patch /:id [4 handlers]
+        products
+          get / [2 handlers]
+          get /featured [2 handlers]
+          get /show-case [2 handlers]
+          get /related-products/:id [2 handlers]
+          get /:id [2 handlers]
+          get /slug/:slug [2 handlers]
+          use <anonymous>
+          use <anonymous>
+          post / [2 handlers]
+          delete|patch /:id [4 handlers]
+        config
+          get / [2 handlers]
+          use <anonymous>
+          use <anonymous>
+          post / [2 handlers]
+          patch /:id [2 handlers]
+          delete /:id [2 handlers]
+        cart
+          use <anonymous>
+          get / [2 handlers]
+          post / [2 handlers]
+          post /sync [2 handlers]
+          patch /items/:cartItemId [2 handlers]
+          delete /items/:cartItemId [2 handlers]
+          delete / [2 handlers]
+        orders
+          use <anonymous>
+          post / [3 handlers]
+          get / [2 handlers]
+          get /:orderId [2 handlers]
+          use <anonymous>
+          patch /:orderId/status [2 handlers]"
+      `);
+  });
+});

--- a/apps/server/test/validation-wired.route.test.ts
+++ b/apps/server/test/validation-wired.route.test.ts
@@ -1,0 +1,274 @@
+import { ErrorCode, getStatusCode, UserPublicInfo } from "@repo/domain";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import app from "../src/app.js";
+import { authService } from "../src/services/auth.service.js";
+
+// Every schema-guarded route, sent an input its own schema must reject. If a
+// route ever stops mounting its `validateSchema`, the request falls through to
+// the controller and the status changes. The asserted `details[].path` proves
+// the *right* schema ran, which a status alone does not.
+//
+// `authenticate` is the only database touch ahead of validation, so stubbing
+// the token lookup is enough to reach `validateSchema` with no database.
+
+const VALIDATION_STATUS = getStatusCode(ErrorCode.VALIDATION_ERROR);
+
+const ADMIN: UserPublicInfo = {
+  id: "0123456789abcdef01234567",
+  name: "Test Admin",
+  email: "admin@example.com",
+  role: "ADMIN",
+};
+
+const BAD_ID = "not-an-id";
+const UNEXPECTED_BODY = { unexpected: true };
+
+type Case = {
+  route: string;
+  send: () => request.Test;
+  path: string[];
+};
+
+const cases: Case[] = [
+  // products
+  {
+    route: "GET /products",
+    send: () => request(app).get("/api/v1/products?limit=abc"),
+    path: ["query", "limit"],
+  },
+  {
+    route: "GET /products/featured",
+    send: () =>
+      request(app).get("/api/v1/products/featured").send(UNEXPECTED_BODY),
+    path: ["body"],
+  },
+  {
+    route: "GET /products/show-case",
+    send: () =>
+      request(app).get("/api/v1/products/show-case").send(UNEXPECTED_BODY),
+    path: ["body"],
+  },
+  {
+    route: "GET /products/related-products/:id",
+    send: () => request(app).get(`/api/v1/products/related-products/${BAD_ID}`),
+    path: ["params", "id"],
+  },
+  {
+    route: "GET /products/:id",
+    send: () => request(app).get(`/api/v1/products/${BAD_ID}`),
+    path: ["params", "id"],
+  },
+  {
+    route: "GET /products/slug/:slug",
+    send: () => request(app).get("/api/v1/products/slug/a"),
+    path: ["params", "slug"],
+  },
+  {
+    route: "POST /products",
+    send: () => request(app).post("/api/v1/products").send({}),
+    path: ["body", "cartLabel"],
+  },
+  {
+    route: "PATCH /products/:id",
+    send: () => request(app).patch(`/api/v1/products/${BAD_ID}`).send({}),
+    path: ["params", "id"],
+  },
+  {
+    route: "DELETE /products/:id",
+    send: () => request(app).delete(`/api/v1/products/${BAD_ID}`),
+    path: ["params", "id"],
+  },
+
+  // categories
+  {
+    route: "GET /categories",
+    send: () => request(app).get("/api/v1/categories?limit=abc"),
+    path: ["query", "limit"],
+  },
+  {
+    route: "GET /categories/:category/products",
+    send: () => request(app).get("/api/v1/categories/not-a-category/products"),
+    path: ["params", "category"],
+  },
+  {
+    route: "GET /categories/:id",
+    send: () => request(app).get(`/api/v1/categories/${BAD_ID}`),
+    path: ["params", "id"],
+  },
+  {
+    route: "POST /categories",
+    send: () => request(app).post("/api/v1/categories").send({}),
+    path: ["body", "name"],
+  },
+  {
+    route: "PATCH /categories/:id",
+    send: () => request(app).patch(`/api/v1/categories/${BAD_ID}`).send({}),
+    path: ["params", "id"],
+  },
+  {
+    route: "DELETE /categories/:id",
+    send: () => request(app).delete(`/api/v1/categories/${BAD_ID}`),
+    path: ["params", "id"],
+  },
+
+  // config
+  {
+    route: "GET /config",
+    send: () => request(app).get("/api/v1/config").send(UNEXPECTED_BODY),
+    path: ["body"],
+  },
+  {
+    route: "POST /config",
+    send: () => request(app).post("/api/v1/config").send({}),
+    path: ["body", "name"],
+  },
+  {
+    route: "PATCH /config/:id",
+    send: () => request(app).patch(`/api/v1/config/${BAD_ID}`).send({}),
+    path: ["params", "id"],
+  },
+  {
+    route: "DELETE /config/:id",
+    send: () => request(app).delete(`/api/v1/config/${BAD_ID}`),
+    path: ["params", "id"],
+  },
+
+  // users
+  {
+    route: "GET /users/me",
+    send: () => request(app).get("/api/v1/users/me").send(UNEXPECTED_BODY),
+    path: ["body"],
+  },
+  {
+    route: "PATCH /users/updateMe",
+    send: () =>
+      request(app).patch("/api/v1/users/updateMe").send(UNEXPECTED_BODY),
+    path: ["body", "unexpected"],
+  },
+  {
+    route: "DELETE /users/deleteMe",
+    send: () =>
+      request(app).delete("/api/v1/users/deleteMe").send(UNEXPECTED_BODY),
+    path: ["body"],
+  },
+  {
+    route: "GET /users",
+    send: () => request(app).get("/api/v1/users?limit=abc"),
+    path: ["query", "limit"],
+  },
+  {
+    route: "POST /users",
+    send: () => request(app).post("/api/v1/users").send({}),
+    path: ["body", "name"],
+  },
+  {
+    route: "GET /users/:id",
+    send: () => request(app).get(`/api/v1/users/${BAD_ID}`),
+    path: ["params", "id"],
+  },
+  {
+    route: "PATCH /users/:id",
+    send: () => request(app).patch(`/api/v1/users/${BAD_ID}`).send({}),
+    path: ["params", "id"],
+  },
+  {
+    route: "DELETE /users/:id",
+    send: () => request(app).delete(`/api/v1/users/${BAD_ID}`),
+    path: ["params", "id"],
+  },
+
+  // auth
+  {
+    route: "POST /auth/signup",
+    send: () => request(app).post("/api/v1/auth/signup").send({}),
+    path: ["body", "name"],
+  },
+  {
+    route: "POST /auth/login",
+    send: () => request(app).post("/api/v1/auth/login").send({}),
+    path: ["body", "email"],
+  },
+  {
+    route: "PATCH /auth/updateMyPassword",
+    send: () => request(app).patch("/api/v1/auth/updateMyPassword").send({}),
+    path: ["body", "currentPassword"],
+  },
+
+  // cart
+  {
+    route: "GET /cart",
+    send: () => request(app).get("/api/v1/cart").send(UNEXPECTED_BODY),
+    path: ["body"],
+  },
+  {
+    route: "POST /cart",
+    send: () => request(app).post("/api/v1/cart").send({}),
+    path: ["body", "productId"],
+  },
+  {
+    route: "POST /cart/sync",
+    send: () => request(app).post("/api/v1/cart/sync").send({}),
+    path: ["body", "items"],
+  },
+  {
+    route: "PATCH /cart/items/:cartItemId",
+    send: () => request(app).patch(`/api/v1/cart/items/${BAD_ID}`).send({}),
+    path: ["params", "cartItemId"],
+  },
+  {
+    route: "DELETE /cart/items/:cartItemId",
+    send: () => request(app).delete(`/api/v1/cart/items/${BAD_ID}`),
+    path: ["params", "cartItemId"],
+  },
+  {
+    route: "DELETE /cart",
+    send: () => request(app).delete("/api/v1/cart").send(UNEXPECTED_BODY),
+    path: ["body"],
+  },
+
+  // orders
+  {
+    route: "POST /orders",
+    send: () => request(app).post("/api/v1/orders").send({}),
+    path: ["body", "shippingAddress"],
+  },
+  {
+    route: "GET /orders",
+    send: () => request(app).get("/api/v1/orders?limit=abc"),
+    path: ["query", "limit"],
+  },
+  {
+    route: "GET /orders/:orderId",
+    send: () => request(app).get(`/api/v1/orders/${BAD_ID}`),
+    path: ["params", "orderId"],
+  },
+  {
+    route: "PATCH /orders/:orderId/status",
+    send: () => request(app).patch(`/api/v1/orders/${BAD_ID}/status`).send({}),
+    path: ["params", "orderId"],
+  },
+];
+
+beforeEach(() => {
+  vi.spyOn(authService, "validateTokenAndGetUser").mockResolvedValue(ADMIN);
+});
+
+describe("every schema-guarded route still runs its schema", () => {
+  it.each(cases)("$route", async ({ send, path }) => {
+    const res = await send();
+
+    expect(res.status).toBe(VALIDATION_STATUS);
+    expect(res.body).toMatchObject({
+      success: false,
+      data: null,
+      error: {
+        code: ErrorCode.VALIDATION_ERROR,
+        statusCode: VALIDATION_STATUS,
+      },
+    });
+    expect(res.body.error.details).toContainEqual(
+      expect.objectContaining({ path }),
+    );
+  });
+});

--- a/apps/server/test/validation-wired.route.test.ts
+++ b/apps/server/test/validation-wired.route.test.ts
@@ -4,13 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import app from "../src/app.js";
 import { authService } from "../src/services/auth.service.js";
 
-// Every schema-guarded route, sent an input its own schema must reject. If a
-// route ever stops mounting its `validateSchema`, the request falls through to
-// the controller and the status changes. The asserted `details[].path` proves
-// the *right* schema ran, which a status alone does not.
-//
-// `authenticate` is the only database touch ahead of validation, so stubbing
-// the token lookup is enough to reach `validateSchema` with no database.
+// Every schema-guarded route, sent an input its own schema must reject. The
+// asserted `details[].path` proves the *right* schema ran, not merely one.
 
 const VALIDATION_STATUS = getStatusCode(ErrorCode.VALIDATION_ERROR);
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,10 @@ Base class handles pagination meta; concrete subclasses implement six abstract m
 Instead of try/catch in every handler, all async controllers are wrapped once. Errors propagate to a centralized error middleware.
 
 **3. `req.verified` contract**
-Validated input is written here by `validateSchema(ZodSchema)` middleware before the controller even runs. Controllers never touch raw `req.body` or `req.params`. Zod schemas use `.strict()` to reject unknown fields. Handlers declare `catchAsync<ValidatedRequest<typeof XRequestSchema>>`, which narrows `req.verified` to the schema's inferred type, so renaming a schema field breaks the controller at compile time.
+Validated input is written here by `validateSchema(ZodSchema)` middleware before the controller even runs. Controllers never touch raw `req.body` or `req.params`. Zod schemas use `.strict()` to reject unknown fields. `req.verified` is narrowed to the schema's inferred type, so renaming a schema field breaks the controller at compile time.
+
+**3a. `defineHandler(schema, fn)`**
+The schema and the handler that reads it are declared together: `defineHandler` returns the `[validateSchema(schema), catchAsync(fn)]` pair, the controller exports it, and the route spreads it (`router.post("/", ...controller.createX)`). The schema is named once, route files import none, and a handler cannot be mounted against a schema other than the one it was written for — the drift is unrepresentable rather than merely detectable. `catchAsync` alone remains for the handful of handlers whose routes mount no schema.
 
 **4. Semantic `ErrorCode` enum (in `@repo/domain`)**
 Shared between client and server. One source of truth maps `ErrorCode → HTTP status`. Both sides speak the same error vocabulary.


### PR DESCRIPTION
## What

The request schema used to be named twice — once in the route's `validateSchema(X)` and once in the controller's `catchAsync<ValidatedRequest<typeof X>>`. Nothing checked the two agreed, and since #103 removed the `?.` guards on `req.verified`, a mismatch became a runtime `TypeError` → 500 rather than a compile error.

`defineHandler(schema, fn)` returns the `[validateSchema(schema), catchAsync(fn)]` pair; the controller exports it and the route spreads it:

```ts
export const createConfig: ValidatedHandler = defineHandler(
  ConfigCreateRequestSchema,
  async (req, res) => {
    const dto = await configService.create(req.verified.body);
    res.status(201).json(createSingleItemResponse(dto));
  },
);

configRouter.post("/", ...configController.createConfig);
```

The schema is named once, `req.verified` is inferred from it, and route files import no schemas at all.

## Tests, written first

The first two landed in `4a4e2e2`, green against `main`, so they prove the refactor changed nothing. Both were verified to have teeth by removing a single `validateSchema` — both failed.

1. **`test/route-manifest.test.ts`** — inline snapshot of every mounted route's method, path and handler count. **Byte-identical across the refactor.**
2. **`test/validation-wired.route.test.ts`** — 40 cases, one per schema-guarded route, each sent an input its own schema must reject, asserting the 422 envelope *and* `error.details[].path`. No database; the token lookup is stubbed.
3. **`test/define-handler.test-d.ts`** — inference, undeclared-field rejection, router assignability, and the drift case itself: a handler written against one schema, mounted with another, fails to compile.

`pnpm test` 182 passed / no type errors · `pnpm lint` 0 errors · `pnpm build` and all three type-checks pass.

## Deviation from the ticket's Scope

The Scope section says the handlers reading no validated input "stay on plain `catchAsync`" with their routes' `validateSchema(...)` "unchanged". But 7 of those routes *do* mount a schema, so that reading makes the acceptance criterion *"No route file imports a request schema from `@repo/domain` any more"* unsatisfiable, and dropping those schemas instead would change the manifest. All 40 schema-guarded routes are converted; `logout` and `getUserAuthStatus`, whose routes mount no schema, stay as they were. Behaviour-identical either way.

## Follow-up worth considering

Drift is unrepresentable *through `defineHandler`*, but `catchAsync` still carries its `<TRequest>` generic and `validateSchema` is still exported, so new code could hand-roll the old pairing. Closing that means narrowing `catchAsync`'s signature — a public signature this ticket never mentions — so it is left out deliberately.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)