### PR TITLE
refactor: burn down no-explicit-any (36 sites, 0 disables) (#133)

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -9,7 +9,7 @@
     "prod": "vite preview",
     "start": "vite preview",
     "type-check": "tsc -b",
-    "lint": "eslint . --max-warnings 23",
+    "lint": "eslint . --max-warnings 17",
     "test": "vitest run"
   },
   "dependencies": {

--- a/apps/client/src/app/router.tsx
+++ b/apps/client/src/app/router.tsx
@@ -17,9 +17,6 @@ import {
 } from "react-router";
 // import { ProtectedRoute } from "@/lib/auth";
 
-// The shape every lazily imported route module in this app exports: a default
-// component, plus loaders/actions that take the query client and return the
-// real react-router handler.
 type RouteModule = {
   default: ComponentType;
   clientLoader?: (queryClient: QueryClient) => LoaderFunction;

--- a/apps/client/src/app/router.tsx
+++ b/apps/client/src/app/router.tsx
@@ -7,11 +7,26 @@ import {
 } from "@/components/layouts/root-layout";
 import { paths } from "@/config/paths";
 import { QueryClient, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
-import { createBrowserRouter, Navigate, RouterProvider } from "react-router";
+import { ComponentType, useMemo } from "react";
+import {
+  ActionFunction,
+  createBrowserRouter,
+  LoaderFunction,
+  Navigate,
+  RouterProvider,
+} from "react-router";
 // import { ProtectedRoute } from "@/lib/auth";
 
-const convert = (queryClient: QueryClient) => (m: any) => {
+// The shape every lazily imported route module in this app exports: a default
+// component, plus loaders/actions that take the query client and return the
+// real react-router handler.
+type RouteModule = {
+  default: ComponentType;
+  clientLoader?: (queryClient: QueryClient) => LoaderFunction;
+  clientAction?: (queryClient: QueryClient) => ActionFunction;
+};
+
+const convert = (queryClient: QueryClient) => (m: RouteModule) => {
   const { clientLoader, clientAction, default: Component, ...rest } = m;
   return {
     ...rest,

--- a/apps/client/src/features/orders/api/order-keys.ts
+++ b/apps/client/src/features/orders/api/order-keys.ts
@@ -1,7 +1,7 @@
 const orderKeys = {
   all: ["orders"] as const,
   lists: () => [...orderKeys.all, "list"] as const,
-  list: (filters: Record<string, any>) =>
+  list: (filters: Record<string, unknown>) =>
     [...orderKeys.lists(), filters] as const,
   details: () => [...orderKeys.all, "detail"] as const,
   detail: (id: string) => [...orderKeys.details(), id] as const,

--- a/apps/client/src/lib/errors/errors.ts
+++ b/apps/client/src/lib/errors/errors.ts
@@ -7,14 +7,20 @@ export const isClientZodError = (err: unknown): err is ZodError => {
   return err instanceof ZodError;
 };
 
+const isErrorCode = (code: string): code is ErrorCode =>
+  Object.values<string>(ErrorCode).includes(code);
+
 const isAppError = (err: unknown): err is AppError => {
   return (
     typeof err === "object" &&
     err !== null &&
-    typeof (err as any).code === "string" &&
-    Object.values(ErrorCode).includes((err as any).code) &&
-    typeof (err as any).statusCode === "number" &&
-    typeof (err as any).message === "string"
+    "code" in err &&
+    typeof err.code === "string" &&
+    isErrorCode(err.code) &&
+    "statusCode" in err &&
+    typeof err.statusCode === "number" &&
+    "message" in err &&
+    typeof err.message === "string"
   );
 };
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "build:tsc": "NODE_OPTIONS='--max-old-space-size=8192' tsc -p tsconfig.build.json",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "start": "node dist/index.js",
-    "lint": "eslint . --max-warnings 28",
+    "lint": "eslint . --max-warnings 15",
     "test": "vitest run"
   },
   "dependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "build:tsc": "NODE_OPTIONS='--max-old-space-size=8192' tsc -p tsconfig.build.json",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "start": "node dist/index.js",
-    "lint": "eslint . --max-warnings 15",
+    "lint": "eslint . --max-warnings 6",
     "test": "vitest run"
   },
   "dependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "build:tsc": "NODE_OPTIONS='--max-old-space-size=8192' tsc -p tsconfig.build.json",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "start": "node dist/index.js",
-    "lint": "eslint . --max-warnings 6",
+    "lint": "eslint . --max-warnings 0",
     "test": "vitest run"
   },
   "dependencies": {

--- a/apps/server/src/middlewares/error.middleware.ts
+++ b/apps/server/src/middlewares/error.middleware.ts
@@ -3,6 +3,10 @@ import { AppError, createErrorResponse, ErrorCode } from "@repo/domain";
 import { NextFunction, Request, Response } from "express";
 import { ZodError } from "zod";
 import { env } from "../utils/env.js";
+import {
+  isPrismaKnownRequestError,
+  isPrismaValidationError,
+} from "../utils/prisma-errors.js";
 import { zodIssuesToDetails } from "../utils/zodDetails.js";
 
 // ------------------ Specific Error Handlers ------------------
@@ -54,42 +58,14 @@ const handleJWTExpiredError = () =>
   );
 
 // ------------------ Type guards ------------------
-const isPrismaKnownRequestError = (
-  err: unknown,
-): err is Prisma.PrismaClientKnownRequestError => {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    ("code" in err || (err as any).name === "PrismaClientKnownRequestError")
-  );
-};
+const isErrorNamed = (err: unknown, name: string): err is Error =>
+  err instanceof Error && err.name === name;
 
-const isPrismaValidationError = (
-  err: unknown,
-): err is Prisma.PrismaClientValidationError => {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    (err as any).name === "PrismaClientValidationError"
-  );
-};
+const isJwtExpiredError = (err: unknown): boolean =>
+  isErrorNamed(err, "TokenExpiredError");
 
-const isJwtExpiredError = (err: unknown): boolean => {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    (err as any).name === "TokenExpiredError"
-  );
-};
-
-const isJwtError = (err: unknown): err is Error => {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    ((err as any).name === "JsonWebTokenError" ||
-      (err as any).name === "TokenExpiredError")
-  );
-};
+const isJwtError = (err: unknown): err is Error =>
+  isErrorNamed(err, "JsonWebTokenError") || isJwtExpiredError(err);
 
 const isZodError = (err: unknown): err is ZodError => {
   return err instanceof ZodError;

--- a/apps/server/src/middlewares/validation.middleware.ts
+++ b/apps/server/src/middlewares/validation.middleware.ts
@@ -7,7 +7,7 @@ import { zodIssuesToDetails } from "../utils/zodDetails.js";
 
 // * Middleware to validate request (params, body, query) against a Zod schema
 
-export const validateSchema = (schema: ZodType<any>): RequestHandler =>
+export const validateSchema = (schema: ZodType): RequestHandler =>
   catchAsync(async (req, _res, next) => {
     const parsedRequest = schema.safeParse({
       params: req.params,

--- a/apps/server/src/services/abstract-crud.service.ts
+++ b/apps/server/src/services/abstract-crud.service.ts
@@ -150,7 +150,7 @@ export abstract class AbstractCrudService<
 
   // ** Helper Methods **
 
-  protected pickFieldsByAllowed<T extends Record<string, any>>(
+  protected pickFieldsByAllowed<T extends Record<string, unknown>>(
     obj: T,
     fields: (keyof T)[],
   ): Partial<T> {

--- a/apps/server/src/services/category.service.ts
+++ b/apps/server/src/services/category.service.ts
@@ -9,6 +9,7 @@ import type {
   NAME,
 } from "@repo/domain";
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
+import { isRecordNotFoundError } from "../utils/prisma-errors.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
 
 const CATEGORY_QUERY_FIELDS = [
@@ -76,8 +77,8 @@ export class CategoryService extends AbstractCrudService<
         data: input,
       });
       return entity;
-    } catch (e: any) {
-      if (e?.code === "P2025") return null;
+    } catch (e) {
+      if (isRecordNotFoundError(e)) return null;
       throw e;
     }
   }
@@ -86,8 +87,8 @@ export class CategoryService extends AbstractCrudService<
     try {
       await prisma.category.delete({ where: { id } });
       return true;
-    } catch (e: any) {
-      if (e?.code === "P2025") return false;
+    } catch (e) {
+      if (isRecordNotFoundError(e)) return false;
       throw e;
     }
   }

--- a/apps/server/src/services/config.service.ts
+++ b/apps/server/src/services/config.service.ts
@@ -8,6 +8,7 @@ import type {
   ConfigUpdateInput,
 } from "@repo/domain";
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
+import { isRecordNotFoundError } from "../utils/prisma-errors.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
 
 const CONFIG_QUERY_FIELDS = [
@@ -79,8 +80,8 @@ export class ConfigService extends AbstractCrudService<
         data: input,
       });
       return entity;
-    } catch (e: any) {
-      if (e?.code === "P2025") return null;
+    } catch (e) {
+      if (isRecordNotFoundError(e)) return null;
       throw e;
     }
   }
@@ -89,8 +90,8 @@ export class ConfigService extends AbstractCrudService<
     try {
       await prisma.config.delete({ where: { id } });
       return true;
-    } catch (e: any) {
-      if (e?.code === "P2025") return false;
+    } catch (e) {
+      if (isRecordNotFoundError(e)) return false;
       throw e;
     }
   }

--- a/apps/server/src/services/order.service.ts
+++ b/apps/server/src/services/order.service.ts
@@ -7,6 +7,7 @@ import {
   Order,
   OrderCreateInput,
   OrderDTO,
+  ORDER_INCLUDE,
   OrderItemDTO,
   OrderQueryParams,
   type OrderStatus,
@@ -126,20 +127,7 @@ export class OrderService extends AbstractCrudService<
       // Fetch complete order with items
       return tx.order.findUnique({
         where: { id: newOrder.id },
-        include: {
-          items: {
-            include: {
-              product: {
-                select: {
-                  id: true,
-                  cartLabel: true,
-                  slug: true,
-                  images: true,
-                },
-              },
-            },
-          },
-        },
+        include: ORDER_INCLUDE,
       });
     });
 
@@ -156,20 +144,7 @@ export class OrderService extends AbstractCrudService<
   async getOrderById(userId: string, orderId: string): Promise<OrderDTO> {
     const order = await prisma.order.findUnique({
       where: { id: orderId },
-      include: {
-        items: {
-          include: {
-            product: {
-              select: {
-                id: true,
-                cartLabel: true,
-                slug: true,
-                images: true,
-              },
-            },
-          },
-        },
-      },
+      include: ORDER_INCLUDE,
     });
 
     if (!order) {
@@ -202,20 +177,7 @@ export class OrderService extends AbstractCrudService<
         skip,
         take,
         orderBy: { createdAt: "desc" },
-        include: {
-          items: {
-            include: {
-              product: {
-                select: {
-                  id: true,
-                  cartLabel: true,
-                  slug: true,
-                  images: true,
-                },
-              },
-            },
-          },
-        },
+        include: ORDER_INCLUDE,
       }),
       prisma.order.count({ where }),
     ]);
@@ -262,20 +224,7 @@ export class OrderService extends AbstractCrudService<
     const updatedOrder = await prisma.order.update({
       where: { id: orderId },
       data: { status },
-      include: {
-        items: {
-          include: {
-            product: {
-              select: {
-                id: true,
-                cartLabel: true,
-                slug: true,
-                images: true,
-              },
-            },
-          },
-        },
-      },
+      include: ORDER_INCLUDE,
     });
 
     return this.toDTO(updatedOrder);
@@ -314,20 +263,7 @@ export class OrderService extends AbstractCrudService<
         skip,
         take,
         orderBy: { createdAt: "desc" },
-        include: {
-          items: {
-            include: {
-              product: {
-                select: {
-                  id: true,
-                  cartLabel: true,
-                  slug: true,
-                  images: true,
-                },
-              },
-            },
-          },
-        },
+        include: ORDER_INCLUDE,
       }),
       prisma.order.count({ where }),
     ]);
@@ -338,20 +274,7 @@ export class OrderService extends AbstractCrudService<
   protected async persistFindById(id: string): Promise<Order | null> {
     const order = await prisma.order.findUnique({
       where: { id },
-      include: {
-        items: {
-          include: {
-            product: {
-              select: {
-                id: true,
-                cartLabel: true,
-                slug: true,
-                images: true,
-              },
-            },
-          },
-        },
-      },
+      include: ORDER_INCLUDE,
     });
 
     return order;
@@ -360,20 +283,7 @@ export class OrderService extends AbstractCrudService<
   protected async persistCreate(data: OrderCreateInput): Promise<Order> {
     const order = await prisma.order.create({
       data,
-      include: {
-        items: {
-          include: {
-            product: {
-              select: {
-                id: true,
-                cartLabel: true,
-                slug: true,
-                images: true,
-              },
-            },
-          },
-        },
-      },
+      include: ORDER_INCLUDE,
     });
 
     return order;
@@ -386,20 +296,7 @@ export class OrderService extends AbstractCrudService<
     const order = await prisma.order.update({
       where: { id },
       data,
-      include: {
-        items: {
-          include: {
-            product: {
-              select: {
-                id: true,
-                cartLabel: true,
-                slug: true,
-                images: true,
-              },
-            },
-          },
-        },
-      },
+      include: ORDER_INCLUDE,
     });
 
     return order;

--- a/apps/server/src/services/order.service.ts
+++ b/apps/server/src/services/order.service.ts
@@ -3,16 +3,20 @@ import {
   AppError,
   CreateOrderInput,
   ErrorCode,
+  type Meta,
   Order,
   OrderCreateInput,
   OrderDTO,
   OrderItemDTO,
+  OrderQueryParams,
   type OrderStatus,
   ORDER_STATUS,
   OrderUpdateInput,
+  OrderWhereInput,
   type PaymentStatus,
   PAYMENT_STATUS,
 } from "@repo/domain";
+import { buildMeta, parsePagination, type Pagination } from "../utils/query.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
 import { cartService } from "./cart.service.js";
 
@@ -20,14 +24,15 @@ export class OrderService extends AbstractCrudService<
   Order,
   OrderCreateInput,
   OrderUpdateInput,
-  OrderDTO
+  OrderDTO,
+  OrderQueryParams
 > {
   /**
    * Transform Order entity to OrderDTO
    */
   protected toDTO(entity: Order): OrderDTO {
     // Transform order items with product details
-    const items: OrderItemDTO[] = (entity.items || []).map((item: any) => ({
+    const items: OrderItemDTO[] = (entity.items || []).map((item) => ({
       id: item.id,
       productId: item.productId,
       productName: item.product.cartLabel,
@@ -142,7 +147,7 @@ export class OrderService extends AbstractCrudService<
       throw new AppError("Failed to create order", ErrorCode.OPERATION_FAILED);
     }
 
-    return this.toDTO(order as any);
+    return this.toDTO(order);
   }
 
   /**
@@ -176,7 +181,7 @@ export class OrderService extends AbstractCrudService<
       throw new AppError("Forbidden", ErrorCode.FORBIDDEN);
     }
 
-    return this.toDTO(order as any);
+    return this.toDTO(order);
   }
 
   /**
@@ -184,26 +189,18 @@ export class OrderService extends AbstractCrudService<
    */
   async listUserOrders(
     userId: string,
-    query: {
-      page?: number;
-      limit?: number;
-      status?: OrderStatus;
-      paymentStatus?: PaymentStatus;
-    },
-  ): Promise<{ data: OrderDTO[]; meta: any }> {
-    const { page = 1, limit = 10, status, paymentStatus } = query;
-    const skip = (page - 1) * limit;
+    query: OrderQueryParams,
+  ): Promise<{ data: OrderDTO[]; meta: Meta }> {
+    const { status, paymentStatus } = query;
+    const { page, limit, skip, take } = parsePagination(query);
 
-    // Build where clause
-    const where: any = { userId };
-    if (status) where.status = status;
-    if (paymentStatus) where.paymentStatus = paymentStatus;
+    const where = this.buildOrderWhere({ status, paymentStatus, userId });
 
     const [data, total] = await prisma.$transaction([
       prisma.order.findMany({
         where,
         skip,
-        take: limit,
+        take,
         orderBy: { createdAt: "desc" },
         include: {
           items: {
@@ -223,13 +220,9 @@ export class OrderService extends AbstractCrudService<
       prisma.order.count({ where }),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-    const hasNext = page < totalPages;
-    const hasPrev = page > 1;
-
     return {
-      data: data.map((order) => this.toDTO(order as any)),
-      meta: { page, limit, total, totalPages, hasNext, hasPrev },
+      data: data.map((order) => this.toDTO(order)),
+      meta: buildMeta({ page, limit, total }),
     };
   }
 
@@ -285,29 +278,41 @@ export class OrderService extends AbstractCrudService<
       },
     });
 
-    return this.toDTO(updatedOrder as any);
+    return this.toDTO(updatedOrder);
+  }
+
+  // ===== Private Query Builders =====
+
+  private buildOrderWhere({
+    userId,
+    status,
+    paymentStatus,
+  }: {
+    userId?: string;
+    status?: OrderStatus;
+    paymentStatus?: PaymentStatus;
+  }): OrderWhereInput {
+    return {
+      ...(userId && { userId }),
+      ...(status && { status }),
+      ...(paymentStatus && { paymentStatus }),
+    };
   }
 
   // ===== Abstract Method Implementations =====
 
-  protected async persistFindMany(params: {
-    page?: number;
-    limit?: number;
-    status?: OrderStatus;
-    paymentStatus?: PaymentStatus;
-  }): Promise<{ data: Order[]; total: number }> {
-    const { page = 1, limit = 20, status, paymentStatus } = params;
-    const skip = (page - 1) * limit;
+  protected async persistFindMany(
+    params: Pagination & OrderQueryParams,
+  ): Promise<{ data: Order[]; total: number }> {
+    const { skip, take, status, paymentStatus } = params;
 
-    const where: any = {};
-    if (status) where.status = status;
-    if (paymentStatus) where.paymentStatus = paymentStatus;
+    const where = this.buildOrderWhere({ status, paymentStatus });
 
     const [data, total] = await prisma.$transaction([
       prisma.order.findMany({
         where,
         skip,
-        take: limit,
+        take,
         orderBy: { createdAt: "desc" },
         include: {
           items: {
@@ -327,7 +332,7 @@ export class OrderService extends AbstractCrudService<
       prisma.order.count({ where }),
     ]);
 
-    return { data: data as any[], total };
+    return { data, total };
   }
 
   protected async persistFindById(id: string): Promise<Order | null> {
@@ -349,7 +354,7 @@ export class OrderService extends AbstractCrudService<
       },
     });
 
-    return order as any;
+    return order;
   }
 
   protected async persistCreate(data: OrderCreateInput): Promise<Order> {
@@ -371,7 +376,7 @@ export class OrderService extends AbstractCrudService<
       },
     });
 
-    return order as any;
+    return order;
   }
 
   protected async persistUpdate(
@@ -397,7 +402,7 @@ export class OrderService extends AbstractCrudService<
       },
     });
 
-    return order as any;
+    return order;
   }
 
   protected async persistDelete(id: string): Promise<boolean> {

--- a/apps/server/src/services/product.service.ts
+++ b/apps/server/src/services/product.service.ts
@@ -16,6 +16,7 @@ import {
   ProductWhereInput,
 } from "@repo/domain";
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
+import { isRecordNotFoundError } from "../utils/prisma-errors.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
 
 const PRODUCT_QUERY_FIELDS = [
@@ -119,8 +120,8 @@ export class ProductService extends AbstractCrudService<
         data: input,
       });
       return entity;
-    } catch (e: any) {
-      if (e?.code === "P2025") return null;
+    } catch (e) {
+      if (isRecordNotFoundError(e)) return null;
       throw e;
     }
   }
@@ -129,8 +130,8 @@ export class ProductService extends AbstractCrudService<
     try {
       await prisma.product.delete({ where: { id } });
       return true;
-    } catch (e: any) {
-      if (e?.code === "P2025") return false;
+    } catch (e) {
+      if (isRecordNotFoundError(e)) return false;
       throw e;
     }
   }

--- a/apps/server/src/services/user.service.ts
+++ b/apps/server/src/services/user.service.ts
@@ -10,6 +10,7 @@ import type {
   UserUpdateInput,
 } from "@repo/domain";
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
+import { isRecordNotFoundError } from "../utils/prisma-errors.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
 
 const USER_QUERY_FIELDS = [
@@ -130,8 +131,8 @@ export class UserService extends AbstractCrudService<
         data: input,
       });
       return entity;
-    } catch (e: any) {
-      if (e?.code === "P2025") return null;
+    } catch (e) {
+      if (isRecordNotFoundError(e)) return null;
       throw e;
     }
   }
@@ -140,8 +141,8 @@ export class UserService extends AbstractCrudService<
     try {
       await prisma.user.delete({ where: { id } });
       return true;
-    } catch (e: any) {
-      if (e?.code === "P2025") return false;
+    } catch (e) {
+      if (isRecordNotFoundError(e)) return false;
       throw e;
     }
   }

--- a/apps/server/src/utils/prisma-errors.ts
+++ b/apps/server/src/utils/prisma-errors.ts
@@ -1,0 +1,17 @@
+import { Prisma } from "@repo/database";
+
+/**
+ * Prisma reports "the row you targeted does not exist" as P2025, which is how
+ * update and delete tell a missing id apart from a real failure.
+ */
+const RECORD_NOT_FOUND = "P2025";
+
+export const isPrismaKnownRequestError = (
+  err: unknown,
+): err is Prisma.PrismaClientKnownRequestError =>
+  err instanceof Error &&
+  err.name === "PrismaClientKnownRequestError" &&
+  "code" in err;
+
+export const isRecordNotFoundError = (err: unknown): boolean =>
+  isPrismaKnownRequestError(err) && err.code === RECORD_NOT_FOUND;

--- a/apps/server/src/utils/prisma-errors.ts
+++ b/apps/server/src/utils/prisma-errors.ts
@@ -1,9 +1,5 @@
 import { Prisma } from "@repo/database";
 
-/**
- * Prisma reports "the row you targeted does not exist" as P2025, which is how
- * update and delete tell a missing id apart from a real failure.
- */
 const RECORD_NOT_FOUND = "P2025";
 
 export const isPrismaKnownRequestError = (

--- a/apps/server/src/utils/prisma-errors.ts
+++ b/apps/server/src/utils/prisma-errors.ts
@@ -13,5 +13,10 @@ export const isPrismaKnownRequestError = (
   err.name === "PrismaClientKnownRequestError" &&
   "code" in err;
 
+export const isPrismaValidationError = (
+  err: unknown,
+): err is Prisma.PrismaClientValidationError =>
+  err instanceof Error && err.name === "PrismaClientValidationError";
+
 export const isRecordNotFoundError = (err: unknown): boolean =>
   isPrismaKnownRequestError(err) && err.code === RECORD_NOT_FOUND;

--- a/apps/server/test/product.route.test.ts
+++ b/apps/server/test/product.route.test.ts
@@ -101,9 +101,7 @@ describe("DELETE /api/v1/products/:id", () => {
     expect(res.body.error.code).toBe(ErrorCode.UNAUTHORIZED);
   });
 
-  // The message pins which path produced the 404: the service recognised
-  // Prisma's P2025 and returned `false`, rather than letting the raw Prisma
-  // error reach the error middleware.
+  // The message pins the service path; a raw Prisma error would 404 too.
   it("returns NOT_FOUND for a well-formed id that matches nothing", async () => {
     const admin = await createAdmin();
 

--- a/apps/server/test/product.route.test.ts
+++ b/apps/server/test/product.route.test.ts
@@ -100,4 +100,38 @@ describe("DELETE /api/v1/products/:id", () => {
     expect(res.status).toBe(401);
     expect(res.body.error.code).toBe(ErrorCode.UNAUTHORIZED);
   });
+
+  // The message pins which path produced the 404: the service recognised
+  // Prisma's P2025 and returned `false`, rather than letting the raw Prisma
+  // error reach the error middleware.
+  it("returns NOT_FOUND for a well-formed id that matches nothing", async () => {
+    const admin = await createAdmin();
+
+    const res = await request(app)
+      .delete(`/api/v1/products/${ABSENT_ID}`)
+      .set("Cookie", authCookie(admin.id));
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.NOT_FOUND,
+      message: "No document found with that ID",
+    });
+  });
+});
+
+describe("PATCH /api/v1/products/:id", () => {
+  it("returns NOT_FOUND for a well-formed id that matches nothing", async () => {
+    const admin = await createAdmin();
+
+    const res = await request(app)
+      .patch(`/api/v1/products/${ABSENT_ID}`)
+      .set("Cookie", authCookie(admin.id))
+      .send({ price: 999 });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.NOT_FOUND,
+      message: "No document found with that ID",
+    });
+  });
 });

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -21,7 +21,7 @@
     "db:reset": "pnpm db:push --force-reset && pnpm db:generate && pnpm db:seed",
     "studio": "prisma studio",
     "format": "prisma format",
-    "lint": "eslint . --max-warnings 3",
+    "lint": "eslint . --max-warnings 0",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "build": "pnpm db:generate && tsc -p tsconfig.build.json",
     "build:watch": "tsc -p tsconfig.build.json -w"

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -28,17 +28,20 @@ const fullyExtendedClient = clientWithProductExtensions.$extends({
   query: {
     user: {
       $allOperations({ operation, args, query }) {
-        const findMethods: readonly string[] = [
+        const findMethods = [
           "findFirst",
           "findMany",
           "findFirstOrThrow",
           "aggregate",
           "findUniqueOrThrow",
           "findUnique",
-        ];
-        // `where` is absent from create/upsert args, so the union needs the
-        // `in` check before the soft-delete filter can be merged into it.
-        if (findMethods.includes(operation) && "where" in args && args.where) {
+        ] as const;
+        // `where` is absent from the create and upsert members of this union.
+        if (
+          (findMethods as readonly string[]).includes(operation) &&
+          "where" in args &&
+          args.where
+        ) {
           return query({
             ...args,
             where: { ...args.where, active: { not: false } },

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -27,37 +27,33 @@ const fullyExtendedClient = clientWithProductExtensions.$extends({
   name: "userExtensions",
   query: {
     user: {
-      $allOperations(params: any) {
-        const { model: _model, operation, args, query } = params;
-        const findMethods = [
+      $allOperations({ operation, args, query }) {
+        const findMethods: readonly string[] = [
           "findFirst",
           "findMany",
           "findFirstOrThrow",
           "aggregate",
           "findUniqueOrThrow",
           "findUnique",
-          "findMany",
-        ] as const;
-        type FindMethod = (typeof findMethods)[number];
-        let queryArgs = args;
-        if (findMethods.includes(operation as FindMethod)) {
-          queryArgs = {
+        ];
+        // `where` is absent from create/upsert args, so the union needs the
+        // `in` check before the soft-delete filter can be merged into it.
+        if (findMethods.includes(operation) && "where" in args && args.where) {
+          return query({
             ...args,
-            ...(args.where
-              ? { where: { ...args.where, active: { not: false } } }
-              : {}),
-          };
+            where: { ...args.where, active: { not: false } },
+          });
         }
-        return query(queryArgs);
+        return query(args);
       },
       // ** user input should be validated before this functions are called
-      async create({ args, query }: any) {
+      async create({ args, query }) {
         const hashedPassword = await hashPassword(args.data.password);
         args.data.password = hashedPassword;
         args.data.passwordConfirm = hashedPassword;
         return query(args);
       },
-      async update({ args, query }: any) {
+      async update({ args, query }) {
         // if password and password confirm exist ,iit can only be update password route
         if (args.data.password && args.data.passwordConfirm) {
           const hashedPassword = await hashPassword(

--- a/packages/domain/src/order.ts
+++ b/packages/domain/src/order.ts
@@ -3,6 +3,7 @@ import type {
   Prisma,
   Order as PrismaOrder,
   OrderItem as PrismaOrderItem,
+  Product as PrismaProduct,
   ShippingAddress,
 } from "@repo/database";
 import { z } from "zod";
@@ -18,7 +19,16 @@ import { IdValidator } from "./shared.js";
 // * ===== Database Type Re-exports (Service Generics) =====
 
 export type OrderItem = PrismaOrderItem;
-export type Order = PrismaOrder & { items: OrderItem[] };
+
+/** The product fields every order query selects alongside its items. */
+export type OrderItemProduct = Pick<
+  PrismaProduct,
+  "id" | "cartLabel" | "slug" | "images"
+>;
+export type OrderItemWithProduct = PrismaOrderItem & {
+  product: OrderItemProduct;
+};
+export type Order = PrismaOrder & { items: OrderItemWithProduct[] };
 export type OrderCreateInput = Prisma.OrderCreateInput;
 export type OrderUpdateInput = Prisma.OrderUpdateInput;
 export type OrderWhereInput = Prisma.OrderWhereInput;

--- a/packages/domain/src/order.ts
+++ b/packages/domain/src/order.ts
@@ -1,9 +1,7 @@
 import type {
   BillingAddress,
   Prisma,
-  Order as PrismaOrder,
   OrderItem as PrismaOrderItem,
-  Product as PrismaProduct,
   ShippingAddress,
 } from "@repo/database";
 import { z } from "zod";
@@ -20,15 +18,19 @@ import { IdValidator } from "./shared.js";
 
 export type OrderItem = PrismaOrderItem;
 
-/** The product fields every order query selects alongside its items. */
-export type OrderItemProduct = Pick<
-  PrismaProduct,
-  "id" | "cartLabel" | "slug" | "images"
->;
-export type OrderItemWithProduct = PrismaOrderItem & {
-  product: OrderItemProduct;
-};
-export type Order = PrismaOrder & { items: OrderItemWithProduct[] };
+// Every order query loads its items with these product fields, and `Order` is
+// derived from the same object, so the two cannot drift.
+export const ORDER_INCLUDE = {
+  items: {
+    include: {
+      product: {
+        select: { id: true, cartLabel: true, slug: true, images: true },
+      },
+    },
+  },
+} as const satisfies Prisma.OrderInclude;
+
+export type Order = Prisma.OrderGetPayload<{ include: typeof ORDER_INCLUDE }>;
 export type OrderCreateInput = Prisma.OrderCreateInput;
 export type OrderUpdateInput = Prisma.OrderUpdateInput;
 export type OrderWhereInput = Prisma.OrderWhereInput;


### PR DESCRIPTION
Closes #133

All 36 `@typescript-eslint/no-explicit-any` sites removed. None needed an eslint-disable. `--max-warnings` lowered to the exact new count in every affected package: **server 28 → 0**, **database 3 → 0**, **client 23 → 17** (the 17 left are `react-refresh` / `no-unused-expressions` / `no-empty-object-type`, outside this ticket).

The ticket asked for one PR per slice; the maintainer chose one branch with one commit per slice instead, so each slice is still independently reviewable and revertable. #117 and #111, which the ticket flags as overlapping slice 3, are both closed, so slice 3 is included.

## The bug it exposed

#103 was the precedent, and the same thing happened here. Domain `Order` declared `items: OrderItem[]`, but `toDTO` reads `item.product.cartLabel`, `.slug` and `.images.thumbnail.src` — fields no `OrderItem` carries. Five `as any` casts and an `item: any` kept the compiler from seeing it.

`Order` is now `Prisma.OrderGetPayload` over `ORDER_INCLUDE`, the single include object all eight order queries pass, so the entity type and the queries cannot drift.

## Slices

| commit | area | sites |
|---|---|---|
| 792926d | `order.service.ts` + domain `Order` | 12 |
| 4b11c37 | 4 CRUD services + `abstract-crud.service.ts` | 9 |
| 8dd0fb5 | `error.middleware.ts` + `validation.middleware.ts` | 6 |
| 6e04646 | `packages/database/src/client.ts` | 3 |
| ec6d42c | `errors.ts`, `router.tsx`, `order-keys.ts` | 6 |
| c4ebefe | review fixes | — |

## Also worth knowing

- `catch (e: any)` + `e?.code === "P2025"` in four services would have matched **any** thrown object carrying a `code` — a JWT error, a Node syscall error. `isPrismaKnownRequestError` in the error middleware had the same hole, claiming anything with a `code` property was a Prisma error. Both now check it is Prisma's own error first, through a shared `apps/server/src/utils/prisma-errors.ts`.
- Those two P2025 paths (DELETE and PATCH against a well-formed id matching nothing) had **no test coverage**. Two tests added; they assert the error message so they pin the service path rather than the middleware's fallback, which returns 404 as well.
- `$allOperations` in the Prisma user extension needed a real fix, not just an annotation removal: `args` is a union across every operation and `where` is absent from the create and upsert members, so the `findMethods.includes(operation)` check narrowed nothing.

## Not changed

No public HTTP API signature, status code or response shape. `pnpm build`, `pnpm lint`, `pnpm type-check` and `pnpm test` (197 tests) all pass.

Three follow-ups found during review are filed separately rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)