### PR TITLE
fix: reject unknown sort and fields values instead of falling back (#148)

### DIFF
--- a/apps/server/src/services/category.service.ts
+++ b/apps/server/src/services/category.service.ts
@@ -4,21 +4,13 @@ import type {
   CategoryCreateInput,
   CategoryDTO,
   CategoryQueryParams,
-  CategorySelect,
   CategoryUpdateInput,
   NAME,
 } from "@repo/domain";
+import { CATEGORY_QUERY_FIELDS } from "@repo/domain";
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
 import { isRecordNotFoundError } from "../utils/prisma-errors.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
-
-const CATEGORY_QUERY_FIELDS = [
-  "id",
-  "name",
-  "createdAt",
-  "v",
-  "thumbnail",
-] as const satisfies readonly (keyof CategorySelect)[];
 
 const CATEGORY_UPDATE_FIELDS = [
   "name",

--- a/apps/server/src/services/product.service.ts
+++ b/apps/server/src/services/product.service.ts
@@ -4,6 +4,7 @@ import {
   ErrorCode,
   Meta,
   Product,
+  PRODUCT_QUERY_FIELDS,
   ProductCreateInput,
   ProductDTO,
   ProductFeaturedProductsDTO,
@@ -18,24 +19,6 @@ import {
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
 import { isRecordNotFoundError } from "../utils/prisma-errors.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
-
-const PRODUCT_QUERY_FIELDS = [
-  "id",
-  "cartLabel",
-  "name",
-  "slug",
-  "price",
-  "categoryId",
-  "createdAt",
-  "v",
-  "shortLabel",
-  "fullLabel",
-  "description",
-  "isNewProduct",
-  "featuredImageText",
-  "showCaseImageText",
-  "featuresText",
-] as const satisfies readonly (keyof Product)[];
 
 const PRODUCT_UPDATE_FIELDS = [
   "cartLabel",

--- a/apps/server/src/services/user.service.ts
+++ b/apps/server/src/services/user.service.ts
@@ -5,24 +5,13 @@ import type {
   UserDTO,
   UserPublicInfo,
   UserQueryParams,
-  UserSelect,
   UserSelfUpdateInput,
   UserUpdateInput,
 } from "@repo/domain";
+import { USER_QUERY_FIELDS } from "@repo/domain";
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
 import { isRecordNotFoundError } from "../utils/prisma-errors.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
-
-const USER_QUERY_FIELDS = [
-  "id",
-  "name",
-  "email",
-  "role",
-  "emailVerified",
-  "createdAt",
-  "active",
-  "v",
-] as const satisfies readonly (keyof UserSelect)[];
 
 const SELF_UPDATE_FIELDS = [
   "name",

--- a/apps/server/src/utils/query.ts
+++ b/apps/server/src/utils/query.ts
@@ -1,4 +1,11 @@
-import type { Meta } from "@repo/domain";
+import {
+  AppError,
+  ErrorCode,
+  sortFieldName,
+  unknownFieldListMembers,
+  type FieldListKey,
+  type Meta,
+} from "@repo/domain";
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 20;
@@ -49,40 +56,48 @@ export const buildMeta = ({
   };
 };
 
+// A request schema rejects these first; this is the guard for a drifted whitelist.
+const rejectUnknownMembers = (
+  key: FieldListKey,
+  value: string,
+  allowedFields: readonly string[],
+) => {
+  const details = unknownFieldListMembers(key, value, allowedFields);
+  if (details.length === 0) return;
+
+  throw new AppError(
+    `Validation failed: ${details.length} error(s)`,
+    ErrorCode.VALIDATION_ERROR,
+    undefined,
+    details,
+  );
+};
+
 export const parseSelect = <Field extends string>(
   fields: unknown,
   allowedFields: readonly Field[],
 ): Record<Field, true> | undefined => {
-  if (typeof fields !== "string" || !fields) return undefined;
+  if (typeof fields !== "string") return undefined;
+
+  rejectUnknownMembers("fields", fields, allowedFields);
 
   const select = {} as Record<Field, true>;
   for (const field of fields.split(",")) {
-    if ((allowedFields as readonly string[]).includes(field)) {
-      select[field as Field] = true;
-    }
+    select[field as Field] = true;
   }
 
-  return Object.keys(select).length > 0 ? select : undefined;
+  return select;
 };
 
 export const parseOrderBy = <Field extends string>(
   sort: unknown,
   allowedFields: readonly Field[],
 ): OrderBy[] => {
-  const defaultOrderBy: OrderBy[] = [{ id: "desc" }];
-  if (typeof sort !== "string" || !sort) return defaultOrderBy;
+  if (typeof sort !== "string") return [{ id: "desc" }];
 
-  const orderBy = sort
-    .split(",")
-    .map((field) => {
-      const isDescending = field.startsWith("-");
-      const fieldName = isDescending ? field.substring(1) : field;
-      if (!(allowedFields as readonly string[]).includes(fieldName)) {
-        return undefined;
-      }
-      return { [fieldName]: isDescending ? "desc" : "asc" } satisfies OrderBy;
-    })
-    .filter((entry): entry is OrderBy => entry !== undefined);
+  rejectUnknownMembers("sort", sort, allowedFields);
 
-  return orderBy.length > 0 ? orderBy : defaultOrderBy;
+  return sort.split(",").map((field) => ({
+    [sortFieldName(field)]: field.startsWith("-") ? "desc" : "asc",
+  }));
 };

--- a/apps/server/src/utils/zodDetails.ts
+++ b/apps/server/src/utils/zodDetails.ts
@@ -15,9 +15,15 @@ export const zodIssuesToDetails = (error: ZodError): ErrorDetail[] =>
       }));
     }
 
+    // A custom issue may name a more specific code than zod's "custom".
+    const code =
+      issue.code === "custom" && typeof issue.params?.code === "string"
+        ? issue.params.code
+        : issue.code;
+
     return [
       {
-        code: issue.code,
+        code,
         message: issue.message,
         path: path.length > 0 ? path : undefined,
       },

--- a/apps/server/test/list-query.route.test.ts
+++ b/apps/server/test/list-query.route.test.ts
@@ -72,11 +72,21 @@ beforeEach(() => {
 });
 
 describe("GET /api/v1/categories", () => {
-  it("ignores an unknown sort field and falls back to the default order", async () => {
-    const { res, args } = await listCategories("?sort=hax");
+  it("rejects an unknown sort field and names it in the error details", async () => {
+    const { res } = await listCategories("?sort=hax");
 
-    expect(res.status).toBe(200);
-    expect(args.orderBy).toEqual([{ id: "desc" }]);
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [
+        {
+          code: "unknown_value",
+          message: expect.stringContaining('Unknown sort value "hax"'),
+          path: ["query", "sort"],
+        },
+      ],
+    });
+    expect(findMany).not.toHaveBeenCalled();
   });
 
   it("keeps a valid sort list, descending fields included", async () => {
@@ -85,22 +95,37 @@ describe("GET /api/v1/categories", () => {
     expect(args.orderBy).toEqual([{ name: "desc" }, { createdAt: "asc" }]);
   });
 
-  it("drops only the unknown members of a mixed sort list", async () => {
-    const { args } = await listCategories("?sort=hax,-createdAt");
+  it("rejects a mixed sort list rather than dropping its unknown members", async () => {
+    const { res } = await listCategories("?sort=hax,-createdAt");
 
-    expect(args.orderBy).toEqual([{ createdAt: "desc" }]);
+    expect(res.status).toBe(422);
+    expect(res.body.error.details).toEqual([
+      expect.objectContaining({ path: ["query", "sort"] }),
+    ]);
+    expect(findMany).not.toHaveBeenCalled();
   });
 
-  it("selects only whitelisted fields", async () => {
-    const { args } = await listCategories("?fields=id,name,password");
+  it("selects the requested fields when all are whitelisted", async () => {
+    const { args } = await listCategories("?fields=id,name");
 
     expect(args.select).toEqual({ id: true, name: true });
   });
 
-  it("omits select entirely when no requested field is whitelisted", async () => {
-    const { args } = await listCategories("?fields=password");
+  it("rejects an unknown field and names it in the error details", async () => {
+    const { res } = await listCategories("?fields=id,name,password");
 
-    expect(args.select).toBeUndefined();
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [
+        {
+          code: "unknown_value",
+          message: expect.stringContaining('Unknown fields value "password"'),
+          path: ["query", "fields"],
+        },
+      ],
+    });
+    expect(findMany).not.toHaveBeenCalled();
   });
 
   it("defaults to the first page of 20", async () => {
@@ -154,17 +179,15 @@ describe("GET /api/v1/categories", () => {
 });
 
 describe("GET /api/v1/products", () => {
-  it("ignores an unknown sort field and falls back to the default order", async () => {
-    const { res, args } = await listProducts("?sort=hax");
+  it("rejects an unknown sort field", async () => {
+    const { res } = await listProducts("?sort=hax");
 
-    expect(res.status).toBe(200);
-    expect(args.orderBy).toEqual([{ id: "desc" }]);
+    expect(res.status).toBe(422);
+    expect(productFindMany).not.toHaveBeenCalled();
   });
 
-  it("keeps a valid sort list and whitelisted fields", async () => {
-    const { args } = await listProducts(
-      "?sort=-price,name&fields=id,price,hax",
-    );
+  it("keeps a valid sort list and field selection", async () => {
+    const { args } = await listProducts("?sort=-price,name&fields=id,price");
 
     expect(args).toMatchObject({
       orderBy: [{ price: "desc" }, { name: "asc" }],
@@ -172,6 +195,18 @@ describe("GET /api/v1/products", () => {
       skip: 0,
       take: 20,
     });
+  });
+
+  it("names every unknown sort and field value in one response", async () => {
+    const { res } = await listProducts("?sort=hax,-nope&fields=password");
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.details).toEqual([
+      expect.objectContaining({ path: ["query", "sort"] }),
+      expect.objectContaining({ path: ["query", "sort"] }),
+      expect.objectContaining({ path: ["query", "fields"] }),
+    ]);
+    expect(productFindMany).not.toHaveBeenCalled();
   });
 
   it("accepts the name filter and the pagination keys", async () => {
@@ -205,22 +240,30 @@ describe("GET /api/v1/products", () => {
 });
 
 describe("GET /api/v1/users", () => {
-  it("ignores an unknown sort field and falls back to the default order", async () => {
-    const { res, args } = await listUsers("?sort=hax");
+  it("rejects an unknown sort field", async () => {
+    const { res } = await listUsers("?sort=hax");
 
-    expect(res.status).toBe(200);
-    expect(args.orderBy).toEqual([{ id: "desc" }]);
+    expect(res.status).toBe(422);
+    expect(userFindMany).not.toHaveBeenCalled();
   });
 
-  it("keeps a valid sort list and whitelisted fields", async () => {
-    const { args } = await listUsers(
-      "?sort=-createdAt,email&fields=id,email,password",
-    );
+  it("keeps a valid sort list and field selection", async () => {
+    const { args } = await listUsers("?sort=-createdAt,email&fields=id,email");
 
     expect(args).toMatchObject({
       orderBy: [{ createdAt: "desc" }, { email: "asc" }],
       select: { id: true, email: true },
     });
+  });
+
+  it("rejects a field the user list does not expose", async () => {
+    const { res } = await listUsers("?fields=id,email,password");
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.details).toEqual([
+      expect.objectContaining({ path: ["query", "fields"] }),
+    ]);
+    expect(userFindMany).not.toHaveBeenCalled();
   });
 
   it("still applies the role filter alongside the parsed query", async () => {

--- a/apps/server/test/query.util.test.ts
+++ b/apps/server/test/query.util.test.ts
@@ -1,3 +1,4 @@
+import { AppError, ErrorCode } from "@repo/domain";
 import { describe, expect, it } from "vitest";
 import {
   buildMeta,
@@ -90,29 +91,64 @@ describe("buildMeta", () => {
   });
 });
 
+const detailsOf = (run: () => unknown) => {
+  try {
+    run();
+  } catch (err) {
+    expect(err).toBeInstanceOf(AppError);
+    expect((err as AppError).code).toBe(ErrorCode.VALIDATION_ERROR);
+    return (err as AppError).details ?? [];
+  }
+
+  throw new Error("expected the call to throw");
+};
+
 describe("parseSelect", () => {
   it("returns undefined when no fields are requested", () => {
     expect(parseSelect(undefined, ALLOWED)).toBeUndefined();
-    expect(parseSelect("", ALLOWED)).toBeUndefined();
     expect(parseSelect(42, ALLOWED)).toBeUndefined();
   });
 
-  it("keeps only allowed fields", () => {
-    expect(parseSelect("id,name,secret", ALLOWED)).toEqual({
+  it("rejects an empty value, as the request schema does", () => {
+    expect(() => parseSelect("", ALLOWED)).toThrow(AppError);
+  });
+
+  it("keeps every requested field when all are allowed", () => {
+    expect(parseSelect("id,name", ALLOWED)).toEqual({
       id: true,
       name: true,
     });
   });
 
-  it("returns undefined when nothing survives the whitelist", () => {
-    expect(parseSelect("secret,password", ALLOWED)).toBeUndefined();
+  it("rejects the whole list when one field is outside the whitelist", () => {
+    const details = detailsOf(() => parseSelect("id,name,secret", ALLOWED));
+
+    expect(details).toEqual([
+      {
+        code: "unknown_value",
+        message: expect.stringContaining('Unknown fields value "secret"'),
+        path: ["query", "fields"],
+      },
+    ]);
+  });
+
+  it("names every field outside the whitelist", () => {
+    const details = detailsOf(() => parseSelect("secret,password", ALLOWED));
+
+    expect(details.map((detail) => detail.message)).toEqual([
+      expect.stringContaining('"secret"'),
+      expect.stringContaining('"password"'),
+    ]);
   });
 });
 
 describe("parseOrderBy", () => {
   it("defaults to descending id", () => {
     expect(parseOrderBy(undefined, ALLOWED)).toEqual([{ id: "desc" }]);
-    expect(parseOrderBy("", ALLOWED)).toEqual([{ id: "desc" }]);
+  });
+
+  it("rejects an empty value, as the request schema does", () => {
+    expect(() => parseOrderBy("", ALLOWED)).toThrow(AppError);
   });
 
   it("reads a leading minus as descending", () => {
@@ -126,15 +162,32 @@ describe("parseOrderBy", () => {
     ]);
   });
 
-  it("drops fields outside the whitelist", () => {
-    expect(parseOrderBy("name,hax", ALLOWED)).toEqual([{ name: "asc" }]);
-    expect(parseOrderBy("-hax,createdAt", ALLOWED)).toEqual([
-      { createdAt: "asc" },
+  it("rejects the whole list when one field is outside the whitelist", () => {
+    const details = detailsOf(() => parseOrderBy("name,hax", ALLOWED));
+
+    expect(details).toEqual([
+      {
+        code: "unknown_value",
+        message: expect.stringContaining('Unknown sort value "hax"'),
+        path: ["query", "sort"],
+      },
     ]);
   });
 
-  it("falls back to the default order when nothing survives", () => {
-    expect(parseOrderBy("hax", ALLOWED)).toEqual([{ id: "desc" }]);
-    expect(parseOrderBy("-hax,-alsoHax", ALLOWED)).toEqual([{ id: "desc" }]);
+  it("names the offending member with its direction prefix intact", () => {
+    const details = detailsOf(() => parseOrderBy("-hax,createdAt", ALLOWED));
+
+    expect(details.map((detail) => detail.message)).toEqual([
+      expect.stringContaining('"-hax"'),
+    ]);
+  });
+
+  it("names every member outside the whitelist", () => {
+    const details = detailsOf(() => parseOrderBy("-hax,-alsoHax", ALLOWED));
+
+    expect(details.map((detail) => detail.message)).toEqual([
+      expect.stringContaining('"-hax"'),
+      expect.stringContaining('"-alsoHax"'),
+    ]);
   });
 });

--- a/apps/server/test/validation-wired.route.test.ts
+++ b/apps/server/test/validation-wired.route.test.ts
@@ -17,6 +17,7 @@ const ADMIN: UserPublicInfo = {
 };
 
 const BAD_ID = "not-an-id";
+const VALID_ID = "0123456789abcdef01234567";
 const UNEXPECTED_BODY = { unexpected: true };
 
 type Case = {
@@ -264,6 +265,32 @@ describe("every schema-guarded route still runs its schema", () => {
     });
     expect(res.body.error.details).toContainEqual(
       expect.objectContaining({ path }),
+    );
+  });
+});
+
+// Routes that declare no query params still validate the query they were given.
+const noQueryRoutes = [
+  {
+    route: "GET /products/:id",
+    send: () => request(app).get(`/api/v1/products/${VALID_ID}?foo=1`),
+  },
+  {
+    route: "GET /config",
+    send: () => request(app).get("/api/v1/config?foo=1"),
+  },
+];
+
+describe("a route declaring no query params rejects unknown ones", () => {
+  it.each(noQueryRoutes)("$route", async ({ send }) => {
+    const res = await send();
+
+    expect(res.status).toBe(VALIDATION_STATUS);
+    expect(res.body.error.details).toContainEqual(
+      expect.objectContaining({
+        code: "unrecognized_keys",
+        path: ["query", "foo"],
+      }),
     );
   });
 });

--- a/docs/adr/0002-unknown-sort-and-fields-values-are-rejected.md
+++ b/docs/adr/0002-unknown-sort-and-fields-values-are-rejected.md
@@ -1,0 +1,39 @@
+# Unknown `sort` and `fields` values are rejected, not dropped
+
+A list query naming a field outside its whitelist — `?sort=hax`, `?fields=password` — now returns
+`ErrorCode.VALIDATION_ERROR` (422) and names every offending member in `error.details`, instead of
+falling back to the default ordering or dropping the field. This extends to the whole list: one
+unknown member rejects the request, so `?sort=hax,-createdAt` is a 422 rather than a sort by
+`createdAt` alone.
+
+This reverses the deliberate whitelist-and-fall-back behaviour introduced with the shared query
+utilities. It is the same "caller asked for something, got a different result, no signal" bug that
+made unknown query _keys_ a 422, one level down from keys to values.
+
+## Considered options
+
+Dropping only the unknown members and honouring the rest was rejected: a partially honoured sort is
+still a silently different answer, and the caller has no way to tell which half ran. Either the
+query the client wrote is the query the server runs, or the client hears about it.
+
+The whitelist is enforced twice. `createQueryParamsSchema(allowedFields)` in
+`packages/domain/src/common.ts` binds it to the request schema of every list route that takes one —
+categories, products, users — so the rejection happens at the same validation seam as unknown keys,
+before auth or any database work. `parseSelect` / `parseOrderBy` in `apps/server/src/utils/query.ts`
+throw on the same input, which is unreachable for a client but fires loudly if a schema and its
+service ever stop sharing a whitelist. Both layers call the same
+`unknownFieldListMembers(key, value, allowedFields)` over the same exported constant per entity
+(`CATEGORY_QUERY_FIELDS` and friends), which is why they cannot disagree on which members are
+unknown or on the `unknown_value` detail they report. `/config` has no query-taking route, so its
+field list stays in the service that reads it.
+
+`EmptyQuerySchema` became `.strict()` in the same pass, so a route declaring no query params rejects
+`?foo=1` rather than ignoring it.
+
+## Consequences
+
+This is an API contract change. `?sort=` and `?fields=` with an empty value are now 422s too — an
+empty member is not a field name, and the uniform rule is easier to explain than an exception.
+`OrderQueryParamsSchema` lost its `sort` key, which the order service never read: an accepted and
+ignored parameter is the same bug with no whitelist involved, so it is now an unrecognized key.
+Nothing in `apps/client` sends `sort` or `fields`.

--- a/packages/domain/src/category.ts
+++ b/packages/domain/src/category.ts
@@ -11,7 +11,7 @@ import type {
   SingleItemResponse,
 } from "./common.js";
 import {
-  BaseQueryParamsSchema,
+  createQueryParamsSchema,
   createRequestSchema,
   EmptyResponseSchema,
   ListResponseSchema,
@@ -48,9 +48,19 @@ export const CategoryThumbnailSchema = z.object({
 // LIST - Get all categories (pagination + filtering)
 export type CategoryQueryParams = ExtendedQueryParams<{ name?: NAME }>;
 
-export const CategoryQueryParamsSchema = BaseQueryParamsSchema.extend({
-  name: z.enum(NAME).optional(),
-}).strict() satisfies z.ZodType<CategoryQueryParams>;
+export const CATEGORY_QUERY_FIELDS = [
+  "id",
+  "name",
+  "createdAt",
+  "v",
+  "thumbnail",
+] as const satisfies readonly (keyof CategorySelect)[];
+
+export const CategoryQueryParamsSchema = createQueryParamsSchema(
+  CATEGORY_QUERY_FIELDS,
+)
+  .extend({ name: z.enum(NAME).optional() })
+  .strict() satisfies z.ZodType<CategoryQueryParams>;
 
 export const CategoryGetAllRequestSchema = createRequestSchema({
   query: CategoryQueryParamsSchema,

--- a/packages/domain/src/common.ts
+++ b/packages/domain/src/common.ts
@@ -239,7 +239,7 @@ export const ApiResponseSchema = <T extends z.ZodTypeAny>(item: T) =>
 
 const EmptyParamsSchema = z.object({}).strict();
 const EmptyBodySchema = z.undefined();
-const EmptyQuerySchema = z.object({});
+const EmptyQuerySchema = z.object({}).strict();
 
 /**
  * Create a typed request schema that validates params, body, and query
@@ -267,11 +267,60 @@ export interface baseQueryParams {
   fields?: string;
 }
 
-export const BaseQueryParamsSchema = z.object({
-  sort: z.string().optional(),
-  fields: z.string().optional(),
-  page: z.coerce.number().int().positive().optional(),
-  limit: z.coerce.number().int().positive().optional(),
-}) satisfies z.ZodType<baseQueryParams>;
+export type FieldListKey = "sort" | "fields";
+
+export const sortFieldName = (member: string) =>
+  member.startsWith("-") ? member.slice(1) : member;
+
+/**
+ * One unknown member rejects the whole list, and each gets its own detail.
+ */
+export const unknownFieldListMembers = (
+  key: FieldListKey,
+  value: string,
+  allowedFields: readonly string[],
+): ErrorDetail[] =>
+  value
+    .split(",")
+    .filter(
+      (member) =>
+        !allowedFields.includes(
+          key === "sort" ? sortFieldName(member) : member,
+        ),
+    )
+    .map((member) => ({
+      code: "unknown_value",
+      message: `Unknown ${key} value "${member}". Allowed values: ${allowedFields.join(", ")}`,
+      path: ["query", key],
+    }));
+
+const FieldListValidator = (
+  key: FieldListKey,
+  allowedFields: readonly string[],
+) =>
+  z
+    .string()
+    .optional()
+    .superRefine((value, ctx) => {
+      if (value === undefined) return;
+
+      for (const detail of unknownFieldListMembers(key, value, allowedFields)) {
+        ctx.addIssue({
+          code: "custom",
+          message: detail.message,
+          params: { code: detail.code },
+        });
+      }
+    });
+
+export const createQueryParamsSchema = <Field extends string>(
+  allowedFields: readonly Field[],
+) =>
+  z.object({
+    sort: FieldListValidator("sort", allowedFields),
+    fields: FieldListValidator("fields", allowedFields),
+    page: z.coerce.number().int().positive().optional(),
+    limit: z.coerce.number().int().positive().optional(),
+  }) satisfies z.ZodType<baseQueryParams>;
 
 export type ExtendedQueryParams<T> = baseQueryParams & T;

--- a/packages/domain/src/order.ts
+++ b/packages/domain/src/order.ts
@@ -177,7 +177,6 @@ export const OrderQueryParamsSchema = z
     paymentStatus: PaymentStatusSchema.optional(),
     page: z.coerce.number().int().positive().default(1),
     limit: z.coerce.number().int().positive().max(100).default(10),
-    sort: z.string().optional(),
   })
   .strict();
 

--- a/packages/domain/src/product.ts
+++ b/packages/domain/src/product.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { NAME } from "./category.js";
 import type { ExtendedQueryParams } from "./common.js";
 import {
-  BaseQueryParamsSchema,
+  createQueryParamsSchema,
   createRequestSchema,
   EmptyResponse,
   EmptyResponseSchema,
@@ -101,9 +101,29 @@ const ProductPropertiesSchema = z
 // LIST - Get all Products (pagination + filtering)
 export type ProductQueryParams = ExtendedQueryParams<{ name?: string }>;
 
-export const ProductQueryParamsSchema = BaseQueryParamsSchema.extend({
-  name: z.string().optional(),
-}).strict() satisfies z.ZodType<ProductQueryParams>;
+export const PRODUCT_QUERY_FIELDS = [
+  "id",
+  "cartLabel",
+  "name",
+  "slug",
+  "price",
+  "categoryId",
+  "createdAt",
+  "v",
+  "shortLabel",
+  "fullLabel",
+  "description",
+  "isNewProduct",
+  "featuredImageText",
+  "showCaseImageText",
+  "featuresText",
+] as const satisfies readonly (keyof Product)[];
+
+export const ProductQueryParamsSchema = createQueryParamsSchema(
+  PRODUCT_QUERY_FIELDS,
+)
+  .extend({ name: z.string().optional() })
+  .strict() satisfies z.ZodType<ProductQueryParams>;
 
 export const ProductGetAllRequestSchema = createRequestSchema({
   query: ProductQueryParamsSchema,

--- a/packages/domain/src/user.ts
+++ b/packages/domain/src/user.ts
@@ -2,7 +2,7 @@ import type { Prisma, User as PrismaUser } from "@repo/database";
 import { z } from "zod";
 import type { ExtendedQueryParams } from "./common.js";
 import {
-  BaseQueryParamsSchema,
+  createQueryParamsSchema,
   createRequestSchema,
   ListResponse,
   ListResponseSchema,
@@ -70,9 +70,20 @@ export const UserDeleteMeRequestSchema = createRequestSchema({
 
 export type UserQueryParams = ExtendedQueryParams<{ role?: ROLE }>;
 
-export const UserQueryParamsSchema = BaseQueryParamsSchema.extend({
-  role: z.enum(ROLE).optional(),
-}).strict() satisfies z.ZodType<UserQueryParams>;
+export const USER_QUERY_FIELDS = [
+  "id",
+  "name",
+  "email",
+  "role",
+  "emailVerified",
+  "createdAt",
+  "active",
+  "v",
+] as const satisfies readonly (keyof UserSelect)[];
+
+export const UserQueryParamsSchema = createQueryParamsSchema(USER_QUERY_FIELDS)
+  .extend({ role: z.enum(ROLE).optional() })
+  .strict() satisfies z.ZodType<UserQueryParams>;
 
 export const UserGetAllRequestSchema = createRequestSchema({
   query: UserQueryParamsSchema,


### PR DESCRIPTION
Closes #148.

`?sort=hax` returned the default ordering with a 200 and `?fields=password` was dropped without a word — the same "caller asked for something, got a different result, no signal" bug that made unknown query keys a 422 (#124), one level down from keys to values.

## The design question

The ticket asked whether one bad member fails the whole list or is dropped. **The whole list fails.** A partially honoured sort is still a silently different answer, and the caller has no way to tell which half ran. So `?sort=hax,-createdAt` is now a 422 rather than a sort by `createdAt` alone.

Every offending member is named in `error.details` under `code: "unknown_value"`, matching what `zodIssuesToDetails` does for unknown keys.

## Where it is enforced

- `createQueryParamsSchema(allowedFields)` in `packages/domain/src/common.ts` replaces `BaseQueryParamsSchema` and binds each entity's whitelist to its request schema, so the rejection lands at the same seam as unknown keys — before auth or any database work.
- The whitelists moved from the services into the domain package so schema and service read one constant. `CONFIG_QUERY_FIELDS` stayed in its service: `/config` has no query-taking route to bind.
- `parseSelect` / `parseOrderBy` throw on the same input rather than filtering. Unreachable for a client, but it fires if a schema and its service ever stop sharing a whitelist. Both layers call the same `unknownFieldListMembers`, so they cannot disagree on which members are unknown or on the detail they report.
- `zodDetails` now lets a custom issue carry its own code through instead of zod's generic `"custom"`.

Decision recorded in `docs/adr/0002-unknown-sort-and-fields-values-are-rejected.md`, reversing the deliberate fallback from #101.

## Folded in, same class

The ticket invited folding in same-class issues:

- `EmptyQuerySchema` is now `.strict()`, so a route declaring no query params rejects `?foo=1` (`/products/:id?foo=1` is a 422).
- `OrderQueryParamsSchema` drops `sort`, which the order service never read — accepted and ignored is the same bug with no whitelist involved. Happy to split this out if it should be its own ticket.

## Contract changes

- `?sort=` and `?fields=` with empty values are 422s too: an empty member is not a field name, and the uniform rule is easier to explain than an exception.
- Nothing in `apps/client` sends `sort` or `fields`.

## Verification

`pnpm type-check` clean, `pnpm test` green (192 server, 11 domain, 2 client), `pnpm lint` clean. The six `sort=hax` / `fields=password` cases in `list-query.route.test.ts` and the fallback assertions in `query.util.test.ts` were rewritten; `validation-wired.route.test.ts` gained cases pinning the `EmptyQuerySchema` strictness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)