### PR TITLE
fix: type-check the test helpers, not just the type-test files

### DIFF
--- a/apps/server/test/helpers/database.ts
+++ b/apps/server/test/helpers/database.ts
@@ -1,4 +1,4 @@
-import { prisma, type NAME } from "@repo/database";
+import { prisma, type Category, type NAME } from "@repo/database";
 import jwt from "jsonwebtoken";
 import { env } from "../../src/utils/env.js";
 
@@ -79,7 +79,7 @@ const thumbnail = (label: string) => ({
   src: `https://cdn.example.com/${label}-thumb.jpg`,
 });
 
-export const createCategory = (name: NAME = "Headphones") =>
+export const createCategory = (name: NAME = "Headphones"): Promise<Category> =>
   prisma.category.create({
     data: { name, thumbnail: thumbnail(name.toLowerCase()) },
   });

--- a/apps/server/test/missing-record.service.test.ts
+++ b/apps/server/test/missing-record.service.test.ts
@@ -65,9 +65,9 @@ describe("a missing row on update", () => {
   });
 
   it("becomes a NOT_FOUND for carts", async () => {
-    await expect(
-      cartService.update(ABSENT_ID, { v: 1 }),
-    ).rejects.toMatchObject({ code: ErrorCode.NOT_FOUND });
+    await expect(cartService.update(ABSENT_ID, { v: 1 })).rejects.toMatchObject(
+      { code: ErrorCode.NOT_FOUND },
+    );
   });
 
   it("propagates any other failure", async () => {

--- a/apps/server/tsconfig.typecheck.json
+++ b/apps/server/tsconfig.typecheck.json
@@ -5,5 +5,5 @@
     "composite": false,
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "test/**/*.test-d.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
## What

`apps/server/test/helpers/` belonged to no TypeScript project: `tsconfig.json` includes `src/**` only, and `tsconfig.typecheck.json` included `src/**` plus `test/**/*.test-d.ts`.

Editors therefore fell back to an inferred config that cannot resolve `vitest`. The `declare module "vitest"` augmentation in `global-setup.ts` failed, and every `provide("databaseUrl")` call typed as `never`:

```
TS2664: Invalid module name in augmentation, module 'vitest' cannot be found.
TS2345: Argument of type '"databaseUrl"' is not assignable to parameter of type 'never'.
```

Errors visible in the IDE that neither `pnpm type-check` nor CI could see, because neither looked at the file. Confirmed pre-existing — `main`'s version of the file produces the identical pair.

## Changes

- `tsconfig.typecheck.json`: `test/**/*.test-d.ts` → `test/**/*.ts`, so the helpers are type-checked.
- `test/helpers/database.ts`: widening the include surfaced one real portability problem — `createCategory`'s inferred type reached into the generated Prisma namespace (TS2742) — so it gets the explicit `Promise<Category>` annotation.

Also carries a Prettier fix for `missing-record.service.test.ts`, which was failing `format:check` on `main`.

## Verification

`pnpm type-check`, `pnpm lint`, `pnpm test` (207 passed) and `pnpm format:check` all pass. `format:check` was failing on `main` before this branch. Confirmed via `tsc --listFilesOnly` that `global-setup.ts` is now part of the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)