### PR TITLE
chore: run dev, tests and Compass against one Dockerised MongoDB replica set (#163)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,15 +121,15 @@ The generator block sets `runtime = "nodejs"`, `moduleFormat = "esm"` and `impor
 ### packages/database/.env
 
 ```
-DATABASE_URL=mongodb+srv://[user]:[password]@[cluster].mongodb.net/[database]?retryWrites=true&w=majority&appName=[appName]
+DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
 ```
 
-Required for Prisma migrations, seeding, and client generation. Uses **MongoDB Atlas** connection string format.
+Required for Prisma migrations, seeding, and client generation. Points at the local Docker replica set (see below); the `mongodb+srv://` Atlas form is for deployment only.
 
 ### apps/server/.env
 
 ```
-DATABASE_URL=mongodb+srv://[user]:[password]@[cluster].mongodb.net/[database]?retryWrites=true&w=majority&appName=[appName]
+DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
 NODE_ENV=development
 JWT_SECRET=your-secret-key-for-signing-tokens-min-32-chars
 JWT_EXPIRES_IN=90d
@@ -139,21 +139,23 @@ PORT=8000
 
 **Key variables:**
 
-- `DATABASE_URL`: MongoDB Atlas connection string; must match database/.env
+- `DATABASE_URL`: MongoDB connection string; must match database/.env
 - `NODE_ENV`: `development` or `production` (affects error responses, logging)
 - `JWT_SECRET`: Used to sign/verify JWT tokens; must be at least 32 characters for production security
 - `JWT_EXPIRES_IN`: Token expiration (e.g., `90d`, `7d`, `24h`); parsed by `ms` package
 - `JWT_COOKIE_EXPIRES_IN`: Cookie expiration in milliseconds
 - `PORT`: Server listening port (default: 8000)
 
-### MongoDB Atlas Setup
+### Local MongoDB Setup
 
-This project uses **MongoDB Atlas** (cloud-hosted MongoDB):
+Dev, seeding and the opt-in test path (`TEST_DATABASE_URL`) use the single-node replica set in
+`docker-compose.yml`; Atlas is production only.
 
-1. Create a cluster at [mongodb.com/atlas](https://www.mongodb.com/atlas)
-2. Create a database user with read/write access
-3. Whitelist your IP address (or use `0.0.0.0/0` for development)
-4. Copy the connection string and update both `.env` files
+1. Make sure nothing else holds port 27017 (`brew services stop mongodb-community` if a Homebrew mongod runs)
+2. `docker compose up -d --wait` at the repo root (`--wait` blocks until the set is writable)
+3. `pnpm db:push && pnpm db:seed`
+
+Details and the version pin rationale: `CLAUDE.md` ("Local database") and `docs/adr/0004-local-mongodb-is-a-docker-replica-set-on-8-2.md`.
 
 ---
 
@@ -333,4 +335,4 @@ See [todos.js](todos.js) for tracked tasks, including:
 - Move product route endpoint to category route
 - Consider adding config ID to environment variables
 
-**Last Updated:** February 10, 2026
+**Last Updated:** September 4, 2026

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -152,8 +152,8 @@ Dev, seeding and the opt-in test path (`TEST_DATABASE_URL`) use the single-node 
 `docker-compose.yml`; Atlas is production only.
 
 1. Make sure nothing else holds port 27017 (`brew services stop mongodb-community` if a Homebrew mongod runs)
-2. `docker compose up -d --wait` at the repo root (`--wait` blocks until the set is writable)
-3. `pnpm db:push && pnpm db:seed`
+2. `pnpm db:setup` at the repo root: starts the container (`pnpm db:up`, which is `docker compose up -d --wait`), pushes the schema, regenerates the client and seeds
+3. `pnpm dev` starts the container itself; `pnpm db:down` stops it, `pnpm db:reset` wipes and reseeds, `pnpm test:db` runs the server suite against it
 
 Details and the version pin rationale: `CLAUDE.md` ("Local database") and `docs/adr/0004-local-mongodb-is-a-docker-replica-set-on-8-2.md`.
 
@@ -335,4 +335,4 @@ See [todos.js](todos.js) for tracked tasks, including:
 - Move product route endpoint to category route
 - Consider adding config ID to environment variables
 
-**Last Updated:** September 4, 2026
+**Last Updated:** September 6, 2026

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,13 @@ pnpm dev:server        # server only
 pnpm build             # all packages + apps (Turbo, respects dependency order)
 
 # Database (local Docker replica set, see "Local database")
-docker compose up -d --wait   # start MongoDB; `--wait` blocks until the set can be written to
+pnpm db:up             # start MongoDB (docker compose up -d --wait); dev, db:setup, db:reset and test:db run it first
+pnpm db:down           # stop and remove the container; the data volume survives
 pnpm db:generate       # regenerate the Prisma client after any schema change
 pnpm db:push           # push schema to the local database
 pnpm db:seed           # seed database
+pnpm db:setup          # up + push + generate + seed: a fresh clone's one command after install
+pnpm db:reset          # up + push --force-reset + generate + seed: wipe dev data and start over
 
 # Type-check
 pnpm type-check        # tsc across every workspace via Turbo
@@ -27,7 +30,7 @@ pnpm types:watch       # watch mode across all TS projects
 pnpm lint
 pnpm format
 pnpm test          # domain + server + client vitest suites via Turbo (no network database needed)
-TEST_DATABASE_URL=<url> pnpm test   # server suite against the Docker database (see "Local database")
+pnpm test:db       # server suite against the Docker database, left in place for Compass (see "Local database")
 ```
 
 ### Running a single workspace
@@ -88,8 +91,9 @@ globally; `global-setup.ts` pins the version it runs.
 
 Setting `TEST_DATABASE_URL` skips the in-memory boot and runs the server suite against that
 database instead (schema pushed, nothing torn down), so a failed run can be inspected in Compass
-afterwards. Point it at the Docker database with its own database name, `audiophile-test`, never at
-`audiophile`: `resetDatabase` truncates every collection it knows about. The switch is keyed on
+afterwards. `pnpm test:db` does this against the Docker database, using its own database name,
+`audiophile-test`. Never point it at `audiophile`: `resetDatabase` truncates every collection it
+knows about. The switch is keyed on
 `TEST_DATABASE_URL` only; `DATABASE_URL` is ignored by the test setup, which is what keeps a local
 `.env` and the `DATABASE_URL` CI sets from redirecting a run. In-memory stays the default, so
 `pnpm test` on a fresh clone and in CI needs no Docker.
@@ -160,9 +164,12 @@ Used for cross-cutting concerns (auth, logging, timing). Middleware chain runs p
 
 Dev, seeding, the opt-in test path and Compass all use the one MongoDB in `docker-compose.yml`: a
 single-node replica set (`rs0`) on `localhost:27017`, which Prisma requires because nested writes run
-in transactions. Start it with `docker compose up -d --wait`; plain `up -d` returns before the
+in transactions. `pnpm db:up` starts it (`docker compose up -d --wait`), and `pnpm dev`,
+`dev:server`, `db:setup`, `db:reset` and `test:db` all run that first, so the container is only ever
+started by hand after a `pnpm db:down`. The `--wait` matters: plain `up -d` returns before the
 healthcheck has initiated the set, and the first schema push then fails. The healthcheck is what
-runs `rs.initiate()`, so the service works when started on its own.
+runs `rs.initiate()`, so the service works when started on its own. `pnpm test` and CI never start
+it.
 
 ```
 dev     -> mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,10 @@ pnpm dev:server        # server only
 # Build
 pnpm build             # all packages + apps (Turbo, respects dependency order)
 
-# Database
+# Database (local Docker replica set, see "Local database")
+docker compose up -d --wait   # start MongoDB; `--wait` blocks until the set can be written to
 pnpm db:generate       # regenerate the Prisma client after any schema change
-pnpm db:push           # push schema to MongoDB Atlas
+pnpm db:push           # push schema to the local database
 pnpm db:seed           # seed database
 
 # Type-check
@@ -26,6 +27,7 @@ pnpm types:watch       # watch mode across all TS projects
 pnpm lint
 pnpm format
 pnpm test          # domain + server + client vitest suites via Turbo (no network database needed)
+TEST_DATABASE_URL=<url> pnpm test   # server suite against the Docker database (see "Local database")
 ```
 
 ### Running a single workspace
@@ -46,7 +48,7 @@ packages/database  →  packages/domain  →  apps/server
 
 - **`apps/server`**: Express 5 REST API (TypeScript, Node ≥ 24.5)
 - **`apps/client`**: React 19 + React Router v7 + Vite 7 + TailwindCSS 4
-- **`packages/database`**: Prisma client + multi-file schema (`prisma/schema/` by domain), MongoDB Atlas
+- **`packages/database`**: Prisma client + multi-file schema (`prisma/schema/` by domain), MongoDB (Docker replica set locally, Atlas in production)
 - **`packages/domain`**: Single source of truth for shared types, Zod schemas, DTOs, error codes
 - **`packages/config-eslint`** / **`packages/config-typescript`**: Shared configs
 
@@ -83,6 +85,14 @@ Seed with the fixture builders in `test/helpers/database.ts` and call `resetData
 test; protected routes take a real signed JWT via `authCookie(userId)`. Files share one database,
 so `fileParallelism` is off. The mongod binary is fetched once by `pnpm install` and cached
 globally; `global-setup.ts` pins the version it runs.
+
+Setting `TEST_DATABASE_URL` skips the in-memory boot and runs the server suite against that
+database instead (schema pushed, nothing torn down), so a failed run can be inspected in Compass
+afterwards. Point it at the Docker database with its own database name, `audiophile-test`, never at
+`audiophile`: `resetDatabase` truncates every collection it knows about. The switch is keyed on
+`TEST_DATABASE_URL` only; `DATABASE_URL` is ignored by the test setup, which is what keeps a local
+`.env` and the `DATABASE_URL` CI sets from redirecting a run. In-memory stays the default, so
+`pnpm test` on a fresh clone and in CI needs no Docker.
 
 ### Validation rules
 
@@ -146,18 +156,39 @@ Used for cross-cutting concerns (auth, logging, timing). Middleware chain runs p
 3. **Every route accepting input must go through `defineHandler`** — never mount `validateSchema` by hand, and never skip it.
 4. **Build order matters**: if types are missing, ensure `packages/database` and `packages/domain` are built before `apps/server`.
 
+## Local database
+
+Dev, seeding, the opt-in test path and Compass all use the one MongoDB in `docker-compose.yml`: a
+single-node replica set (`rs0`) on `localhost:27017`, which Prisma requires because nested writes run
+in transactions. Start it with `docker compose up -d --wait`; plain `up -d` returns before the
+healthcheck has initiated the set, and the first schema push then fails. The healthcheck is what
+runs `rs.initiate()`, so the service works when started on its own.
+
+```
+dev     -> mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
+tests   -> mongodb://localhost:27017/audiophile-test?replicaSet=rs0&directConnection=true   (TEST_DATABASE_URL)
+Compass -> mongodb://localhost:27017
+```
+
+The image tag in `docker-compose.yml` and `MONGODB_VERSION` in `global-setup.ts` are one version;
+bump them together, and only after checking `fastdl.mongodb.org` has the darwin/arm64 binary and
+Docker Hub has the tag. Why it is 8.2 rather than the 8.0 Atlas runs is in
+`docs/adr/0004-local-mongodb-is-a-docker-replica-set-on-8-2.md`. Port 27017 has to be free, so a
+Homebrew `mongodb-community` service must be stopped first. No local run touches Atlas; its
+connection string belongs only to deployment.
+
 ## Environment Variables
 
 **`packages/database/.env`**
 
 ```
-DATABASE_URL=mongodb+srv://...
+DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
 ```
 
 **`apps/server/.env`**
 
 ```
-DATABASE_URL=mongodb+srv://...
+DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
 NODE_ENV=development
 JWT_SECRET=<min 32 chars>
 JWT_EXPIRES_IN=90d

--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ Ensure you have the following installed:
 
 - **Node.js** 24.5.0 or higher ([Download](https://nodejs.org/))
 - **pnpm** 10.26.2 or higher (`npm install -g pnpm`)
-- **MongoDB** Atlas account or local instance ([Sign Up](https://www.mongodb.com/atlas))
+- **Docker** for the local MongoDB replica set (`docker compose up -d --wait`); MongoDB Atlas only for deployment
 
 ### Installation
 
@@ -749,13 +749,13 @@ Create `.env` files in the following locations:
 **`packages/database/.env`**:
 
 ```env
-DATABASE_URL=mongodb+srv://[user]:[password]@[cluster].mongodb.net/[database]?retryWrites=true&w=majority&appName=[appName]
+DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
 ```
 
 **`apps/server/.env`**:
 
 ```env
-DATABASE_URL=mongodb+srv://[user]:[password]@[cluster].mongodb.net/[database]?retryWrites=true&w=majority&appName=[appName]
+DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
 NODE_ENV=development
 JWT_SECRET=your-secret-key-at-least-32-characters-long
 JWT_EXPIRES_IN=90d
@@ -1442,4 +1442,4 @@ Feel free to use this code for learning, inspiration, or your own projects!
 
 ---
 
-**Last Updated**: February 11, 2026
+**Last Updated**: September 4, 2026

--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ Ensure you have the following installed:
 
 - **Node.js** 24.5.0 or higher ([Download](https://nodejs.org/))
 - **pnpm** 10.26.2 or higher (`npm install -g pnpm`)
-- **Docker** for the local MongoDB replica set (`docker compose up -d --wait`); MongoDB Atlas only for deployment
+- **Docker** for the local MongoDB replica set (`pnpm db:up`); MongoDB Atlas only for deployment
 
 ### Installation
 
@@ -781,13 +781,13 @@ pnpm db:generate
 
 The generator emits ESM-ready imports (`.js` extensions) natively.
 
-5. **Seed the database**:
+5. **Start the database and seed it**:
 
 ```bash
-pnpm db:seed
+pnpm db:setup
 ```
 
-Seeds the database with:
+Starts the Docker replica set (`pnpm db:up`), pushes the schema, regenerates the client and seeds:
 
 - Product categories (Headphones, Earphones, Speakers)
 - Sample products with images and metadata
@@ -796,7 +796,7 @@ Seeds the database with:
 6. **Start development servers**:
 
 ```bash
-# Start both client and server
+# Start both client and server (starts the database container first)
 pnpm dev
 
 # Or start individually
@@ -960,10 +960,15 @@ pnpm dev:server       # Start only the server
 # Building
 pnpm build            # Build all packages and apps with Turborepo caching
 
-# Database
-pnpm db:generate      # Generate Prisma client + fix ESM imports (ALWAYS use this)
+# Database (local Docker replica set)
+pnpm db:up            # Start MongoDB (docker compose up -d --wait); dev runs this itself
+pnpm db:down          # Stop and remove the container (data volume kept)
+pnpm db:generate      # Generate Prisma client (ALWAYS use this after schema changes)
 pnpm db:seed          # Seed database with sample data
 pnpm db:push          # Push schema changes to database (dev only)
+pnpm db:setup         # up + push + generate + seed
+pnpm db:reset         # up + force-reset + generate + seed (wipes dev data)
+pnpm test:db          # Server test suite against the Docker database instead of in-memory
 
 # Code Quality
 pnpm lint             # Run ESLint on all packages
@@ -1442,4 +1447,4 @@ Feel free to use this code for learning, inspiration, or your own projects!
 
 ---
 
-**Last Updated**: September 4, 2026
+**Last Updated**: September 6, 2026

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -4,6 +4,6 @@ JWT_EXPIRES_IN=7d
 JWT_SECRET=AtLeast32CharactersLongSecretKeyForJWTs
 JWT_COOKIE_EXPIRES_IN=7
 VITE_APP_PORT=5173
-DATABASE_URL=mongodb://localhost:27017/audiophile
+DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
 LOG_LEVEL=debug
 ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -40,7 +40,7 @@ async function start() {
     await prisma.$runCommandRaw({ ping: 1 });
   } catch (err) {
     const hint = env.DATABASE_URL.startsWith("mongodb://localhost")
-      ? " Is the local database running? Start it with `docker compose up -d --wait`."
+      ? " Is the local database running? Start it with `pnpm db:up`."
       : "";
     logger.fatal({ err }, `database connection failed, shutting down.${hint}`);
     process.exit(1);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -36,8 +36,13 @@ process.on("uncaughtException", (err) => {
 async function start() {
   try {
     await prisma.$connect();
+    // `$connect` only starts the engine; MongoDB is not reached until a command runs.
+    await prisma.$runCommandRaw({ ping: 1 });
   } catch (err) {
-    logger.fatal({ err }, "database connection failed, shutting down");
+    const hint = env.DATABASE_URL.startsWith("mongodb://localhost")
+      ? " Is the local database running? Start it with `docker compose up -d --wait`."
+      : "";
+    logger.fatal({ err }, `database connection failed, shutting down.${hint}`);
     process.exit(1);
   }
 

--- a/apps/server/src/utils/env.ts
+++ b/apps/server/src/utils/env.ts
@@ -79,7 +79,7 @@ const createEnv = () => {
     const databaseUrlHint =
       process.env.NODE_ENV !== "production" &&
       parsedEnv.error.issues.some((issue) => issue.path[0] === "DATABASE_URL")
-        ? "Missing or invalid DATABASE_URL. Copy apps/server/.env.example to apps/server/.env, then start the local database with `docker compose up -d --wait`.\n"
+        ? "Missing or invalid DATABASE_URL. Copy apps/server/.env.example to apps/server/.env, then start the local database with `pnpm db:up`.\n"
         : "";
     throw new Error(
       `${databaseUrlHint}Invalid env provided.

--- a/apps/server/src/utils/env.ts
+++ b/apps/server/src/utils/env.ts
@@ -76,8 +76,13 @@ const createEnv = () => {
   ).safeParse(process.env);
 
   if (!parsedEnv.success) {
+    const databaseUrlHint =
+      process.env.NODE_ENV !== "production" &&
+      parsedEnv.error.issues.some((issue) => issue.path[0] === "DATABASE_URL")
+        ? "Missing or invalid DATABASE_URL. Copy apps/server/.env.example to apps/server/.env, then start the local database with `docker compose up -d --wait`.\n"
+        : "";
     throw new Error(
-      `Invalid env provided.
+      `${databaseUrlHint}Invalid env provided.
       The following variables are missing or invalid:
     ${z.prettifyError(parsedEnv.error)}`,
     );

--- a/apps/server/src/utils/env.ts
+++ b/apps/server/src/utils/env.ts
@@ -11,8 +11,8 @@ const msDurationStringCheck = z.custom<ms.StringValue>((val) => {
 type SrvConnectionString =
   `mongodb+srv://${string}:${string}@${string}/${string}?retryWrites=true&w=majority&appName=${string}`;
 
-// A directly addressed host, which is how the in-memory replica set the route
-// tests run against advertises itself.
+// A directly addressed host: the Docker replica set in dev and the in-memory
+// one the route tests boot.
 type DirectConnectionString = `mongodb://${string}`;
 
 type ConnectionString = SrvConnectionString | DirectConnectionString;

--- a/apps/server/test/env.test.ts
+++ b/apps/server/test/env.test.ts
@@ -16,7 +16,7 @@ describe("env", () => {
   it("tells the developer how to supply DATABASE_URL when it is empty", async () => {
     vi.stubEnv("DATABASE_URL", "");
     await expect(loadEnv()).rejects.toThrow(
-      /Missing or invalid DATABASE_URL[\s\S]*\.env\.example[\s\S]*docker compose up -d --wait/,
+      /Missing or invalid DATABASE_URL[\s\S]*\.env\.example[\s\S]*pnpm db:up/,
     );
   });
 

--- a/apps/server/test/env.test.ts
+++ b/apps/server/test/env.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const loadEnv = async () => {
+  vi.resetModules();
+  await import("../src/utils/env.js");
+};
+
+describe("env", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  // Stubbed empty rather than deleted: `env.ts` runs dotenv at import, which
+  // would refill a deleted variable from the package's `.env`.
+  it("tells the developer how to supply DATABASE_URL when it is empty", async () => {
+    vi.stubEnv("DATABASE_URL", "");
+    await expect(loadEnv()).rejects.toThrow(
+      /Missing or invalid DATABASE_URL[\s\S]*\.env\.example[\s\S]*docker compose up -d --wait/,
+    );
+  });
+
+  it("says the same when DATABASE_URL has the wrong shape", async () => {
+    vi.stubEnv("DATABASE_URL", "postgres://localhost/audiophile");
+    await expect(loadEnv()).rejects.toThrow(/Missing or invalid DATABASE_URL/);
+  });
+
+  it("still lists every other invalid variable", async () => {
+    vi.stubEnv("JWT_SECRET", "short");
+    await expect(loadEnv()).rejects.toThrow(/JWT_SECRET/);
+  });
+});

--- a/apps/server/test/helpers/global-setup.ts
+++ b/apps/server/test/helpers/global-setup.ts
@@ -58,7 +58,7 @@ export default async function setup({ provide }: TestProject) {
   if (externalDatabaseUrl) {
     await pushSchema(externalDatabaseUrl).catch((cause: unknown) => {
       throw new Error(
-        "TEST_DATABASE_URL is set but the schema push to it failed. Is that database running? Start the local one with `docker compose up -d --wait`.",
+        "TEST_DATABASE_URL is set but the schema push to it failed. Is that database running? Start the local one with `pnpm db:up`.",
         { cause },
       );
     });

--- a/apps/server/test/helpers/global-setup.ts
+++ b/apps/server/test/helpers/global-setup.ts
@@ -56,7 +56,12 @@ export default async function setup({ provide }: TestProject) {
   // Never DATABASE_URL: CI sets that, and a local `.env` could aim it anywhere.
   const externalDatabaseUrl = process.env.TEST_DATABASE_URL;
   if (externalDatabaseUrl) {
-    await pushSchema(externalDatabaseUrl);
+    await pushSchema(externalDatabaseUrl).catch((cause: unknown) => {
+      throw new Error(
+        "TEST_DATABASE_URL is set but the schema push to it failed. Is that database running? Start the local one with `docker compose up -d --wait`.",
+        { cause },
+      );
+    });
     provide("databaseUrl", externalDatabaseUrl);
     return;
   }

--- a/apps/server/test/helpers/global-setup.ts
+++ b/apps/server/test/helpers/global-setup.ts
@@ -6,10 +6,10 @@ import type { TestProject } from "vitest/node";
 
 const run = promisify(execFile);
 
-// Pinned so a run does not silently change engine version; the binary is
-// downloaded once at install time and cached globally after that.
+// Same version as the image in `docker-compose.yml` (docs/adr/0004); the binary
+// is downloaded once at install time and cached globally after that.
 // `.github/workflows/ci.yml` parses this line for its binary cache key.
-const MONGODB_VERSION = "8.2.6";
+const MONGODB_VERSION = "8.2.12";
 
 declare module "vitest" {
   interface ProvidedContext {
@@ -41,8 +41,8 @@ const pushSchema = (databaseUrl: string) =>
     ],
     {
       cwd: fileURLToPath(new URL("../../../..", import.meta.url)),
-      // `prisma.config.ts` loads dotenv, and the package's own `.env` points at
-      // the real cluster. Pointing dotenv at nothing keeps it out of reach
+      // `prisma.config.ts` loads dotenv, and the package's own `.env` could
+      // point anywhere. Pointing dotenv at nothing keeps it out of reach
       // rather than trusting it not to override.
       env: {
         ...process.env,
@@ -53,6 +53,14 @@ const pushSchema = (databaseUrl: string) =>
   );
 
 export default async function setup({ provide }: TestProject) {
+  // Never DATABASE_URL: CI sets that, and a local `.env` could aim it anywhere.
+  const externalDatabaseUrl = process.env.TEST_DATABASE_URL;
+  if (externalDatabaseUrl) {
+    await pushSchema(externalDatabaseUrl);
+    provide("databaseUrl", externalDatabaseUrl);
+    return;
+  }
+
   const replSet = await startDatabase();
   const databaseUrl = replSet.getUri("audiophile-test");
 

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -15,9 +15,9 @@ export default defineConfig({
     // `src/utils/env.ts` validates process.env at import time, and `app.ts`
     // imports it, so every value the schema requires has to be present before
     // the first test file loads. DATABASE_URL is the exception: the global
-    // setup boots an in-memory replica set and `test/helpers/setup.ts` injects
-    // its address. dotenv never overrides an existing variable, so a local
-    // `.env` cannot leak into a test run.
+    // setup boots an in-memory replica set (or takes TEST_DATABASE_URL) and
+    // `test/helpers/setup.ts` injects its address. dotenv never overrides an
+    // existing variable, so a local `.env` cannot leak into a test run.
     env: {
       NODE_ENV: "test",
       PORT: "8000",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,25 @@
-version: "3"
-
 volumes:
   database:
     driver: local
 
 services:
   mongodb:
-    platform: linux/amd64
-    image: mongo:7.0
-    container_name: turborepo_mongodb
-    restart: always
+    # Same version as `MONGODB_VERSION` in the server test setup; why 8.2: docs/adr/0004.
+    image: mongo:8.2.12
+    container_name: audiophile_mongodb
+    restart: unless-stopped
+    # The member below advertises this port, so it must equal the published one.
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017"]
     ports:
-      - 27017:27017
-    environment:
-      MONGO_INITDB_DATABASE: turborepo
+      - "27017:27017"
     volumes:
       - database:/data/db
+    # Initiates the set on first boot and only passes once a primary can be written to.
+    healthcheck:
+      test: >-
+        mongosh --port 27017 --quiet --eval
+        "try { rs.status() } catch { rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: 'localhost:27017' }] }) }; db.hello().isWritablePrimary || quit(1)"
+      interval: 5s
+      timeout: 10s
+      retries: 12
+      start_period: 10s

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,9 +53,13 @@ Tokens issued before a password change are rejected even if not expired — with
 | ------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | Schema flexibility | Embedded documents (e.g. `ProductImages` stored inline) avoid join overhead                         | Requires separate `product_images` table + joins  |
 | Data shape         | Products have nested, varied structures (image sets per breakpoint) that map naturally to documents | Would need normalization or JSON columns          |
-| Tradeoff           | No true foreign key constraints, no cross-collection transactions                                   | ACID transactions, enforced referential integrity |
+| Tradeoff           | No true foreign key constraints; multi-document transactions need a replica set                     | ACID transactions, enforced referential integrity |
 
 **Concrete example:** `ProductImages` is a Prisma `type` (embedded document) — responsive image URLs for desktop/tablet/mobile live inside the product document. In SQL you'd need a separate table and joins on every product query.
+
+### One Local Replica Set
+
+Prisma wraps nested writes in transactions, and MongoDB only allows those on a replica set, so even a single local node has to be one. `docker-compose.yml` runs it: MongoDB 8.2 on `localhost:27017`, initiated by its own healthcheck, with `audiophile` for dev and `audiophile-test` for the opt-in test path (`TEST_DATABASE_URL`). Route tests default to an in-memory replica set on the same pinned version, so CI and a fresh clone need no Docker. Atlas is production only. Why the pin is 8.2 rather than Atlas's 8.0 is in `docs/adr/0004-local-mongodb-is-a-docker-replica-set-on-8-2.md`.
 
 ### Multi-file Prisma Schema
 
@@ -156,4 +160,4 @@ Product catalog data is document-shaped (nested images, included items, category
 
 ---
 
-**Last Updated:** September 3, 2026
+**Last Updated:** September 6, 2026

--- a/docs/adr/0004-local-mongodb-is-a-docker-replica-set-on-8-2.md
+++ b/docs/adr/0004-local-mongodb-is-a-docker-replica-set-on-8-2.md
@@ -1,0 +1,46 @@
+# Local MongoDB is a Docker replica set on 8.2, not Atlas's 8.0
+
+Dev, seeding, the opt-in test path (`TEST_DATABASE_URL`) and Compass all use the one MongoDB
+service in `docker-compose.yml`: a single-node replica set, `rs0`, on `localhost:27017`, with
+`audiophile` for dev and `audiophile-test` for tests. Before this (#163) dev pointed at Atlas and
+tests booted their own in-memory server; the compose service was a standalone `mongo:7.0` that
+Prisma could not use, since nested writes run in transactions and MongoDB only allows those on a
+replica set.
+
+The version is pinned once in two places, the compose image tag and `MONGODB_VERSION` in
+`apps/server/test/helpers/global-setup.ts`, and #163 asked for that number to match Atlas so a local
+pass never depends on a newer engine than production. It does not: Atlas ran 8.0.30 on
+4 September 2026 and the pin is 8.2.12.
+
+## Considered options
+
+Pinning 8.0 was tried first and rejected by the machine. Docker Hub's newest 8.0 tag was 8.0.29,
+and it, every older 8.0 tag probed, and `latest` (8.3.8) exit at startup on Docker Desktop's
+kernel (linuxkit 7.0) with `Linux kernel versions 6.19 and newer has a known incompatibility with
+this version of MongoDB` (SERVER-121912). `mongo:8.2.12` starts. It is the nearest release that
+does, so it is the pin, and the in-memory binary follows it so the two paths run one engine.
+
+Bypassing the guard was rejected. It exists because of a tcmalloc `rseq` bug that corrupts memory
+under those kernels; a container that starts and then misbehaves is worse than one that refuses.
+
+Running the in-memory path on 8.0 and the container on 8.2 was rejected. One version in two files is
+already one more than ideal; two versions would make "which engine did this pass on?" a question.
+
+Keeping Atlas for dev, with the container only for tests, was the shape #136 proposed and #163
+replaced: it made Docker a cost with little return, and left every local run one `.env` away from
+the real cluster.
+
+## Consequences
+
+Docker is a dev prerequisite; `pnpm test` alone is not affected, because the in-memory path stays
+the default and CI never sets `TEST_DATABASE_URL`. `pnpm db:seed` is load-bearing, since dev data
+no longer resembles production.
+
+The pin is newer than production by one minor. When a `mongo:8.0.x` image that starts on this
+kernel is published, or Atlas moves to 8.2, re-pin both files to match Atlas. Whatever the version,
+check `fastdl.mongodb.org` has the darwin/arm64 binary and Docker Hub has the tag before bumping;
+`ci.yml` reads the `const MONGODB_VERSION = "..."` line for its cache key, so that line keeps its
+shape.
+
+Port 27017 must be free. On this machine a Homebrew `mongodb-community` service held it and was
+stopped; the container cannot bind while it runs.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "scripts": {
-    "dev": "turbo run dev --parallel",
+    "dev": "pnpm db:up && turbo run dev --parallel",
     "start": "turbo run start --parallel",
     "dev:client": "pnpm --filter \"client\" run dev",
-    "dev:server": "pnpm --filter \"server\" run dev",
+    "dev:server": "pnpm db:up && pnpm --filter \"server\" run dev",
     "prod:client": "pnpm --filter \"client\" run start",
     "prod:server": "pnpm --filter \"server\" run start",
     "build": "turbo run build",
@@ -13,10 +13,15 @@
     "db:push": "turbo run db:push",
     "db:seed": "turbo run db:seed",
     "db:generate": "turbo run db:generate",
+    "db:up": "docker compose up -d --wait",
+    "db:down": "docker compose down",
+    "db:setup": "pnpm db:up && turbo run db:setup",
+    "db:reset": "pnpm db:up && turbo run db:reset",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "test:db": "pnpm db:up && TEST_DATABASE_URL=\"mongodb://localhost:27017/audiophile-test?replicaSet=rs0&directConnection=true\" turbo run test --filter=server"
   },
   "devDependencies": {
     "prettier": "^3.8.1",

--- a/packages/database/.env.example
+++ b/packages/database/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL=mongodb://localhost:27017/audiophile
+DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -4,10 +4,10 @@ Shared Prisma client and schema for the Audiophile E-Commerce monorepo.
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and configure your MongoDB Atlas connection string:
+1. Copy `.env.example` to `.env`; it points at the Docker replica set from the repo's `docker-compose.yml` (`docker compose up -d --wait` at the repo root):
 
 ```
-DATABASE_URL=mongodb+srv://[user]:[password]@[cluster].mongodb.net/[database]?retryWrites=true&w=majority&appName=[appName]
+DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
 ```
 
 2. Run the appropriate setup command (see below).
@@ -76,4 +76,4 @@ type UserWithOrders = Prisma.UserGetPayload<{
 }>;
 ```
 
-**Last Updated:** February 10, 2026
+**Last Updated:** September 4, 2026

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -4,7 +4,7 @@ Shared Prisma client and schema for the Audiophile E-Commerce monorepo.
 
 ## Setup
 
-1. Copy `.env.example` to `.env`; it points at the Docker replica set from the repo's `docker-compose.yml` (`docker compose up -d --wait` at the repo root):
+1. Copy `.env.example` to `.env`; it points at the Docker replica set from the repo's `docker-compose.yml` (`pnpm db:up` at the repo root; `pnpm db:setup` also pushes, generates and seeds):
 
 ```
 DATABASE_URL=mongodb://localhost:27017/audiophile?replicaSet=rs0&directConnection=true
@@ -76,4 +76,4 @@ type UserWithOrders = Prisma.UserGetPayload<{
 }>;
 ```
 
-**Last Updated:** September 4, 2026
+**Last Updated:** September 6, 2026

--- a/turbo.json
+++ b/turbo.json
@@ -55,7 +55,8 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "outputs": []
+      "outputs": [],
+      "env": ["TEST_DATABASE_URL"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- `docker-compose.yml` becomes a single-node replica set (`rs0`) on 27017 with an `rs.initiate()` healthcheck that only passes once the primary is writable; both `.env` files point at it instead of Atlas
- The server test `globalSetup` gains a `TEST_DATABASE_URL` escape hatch (never `DATABASE_URL`, which CI sets); `turbo.json` declares it; the in-memory path stays the default
- One MongoDB version, 8.2.12, in compose and `global-setup.ts`. Atlas runs 8.0.30, but every published 8.0 image refuses Docker Desktop's kernel (SERVER-121912); the deviation is recorded in `docs/adr/0004`
- Root scripts: `db:up`, `db:down`, `db:setup`, `db:reset`, `test:db`; `dev` and `dev:server` start the container first
- Boot now pings MongoDB after `$connect` (the connector otherwise starts without reaching the server), and the missing-`DATABASE_URL`, database-down and `TEST_DATABASE_URL`-down failures each say to run `pnpm db:up`
- CLAUDE.md, ARCHITECTURE.md, README, Copilot instructions and the database README updated

## Test plan

- [x] `pnpm test` (in-memory default): domain, server and client suites pass; CI needs no Docker
- [x] `pnpm test:db`: 210 server tests pass against the container, unique indexes present in `audiophile-test`
- [x] `pnpm db:down` → `pnpm db:up` (healthy on existing volume) → `pnpm db:reset` reseeds dev
- [x] Server boot with the container stopped exits with the `pnpm db:up` hint; same for `TEST_DATABASE_URL`
- [x] `pnpm type-check`, `pnpm lint`, Prettier on every touched file

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)
