### PR TITLE
refactor: prune the eight ErrorCode members nothing throws

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ All errors classified to semantic types with specific codes:
 // Error codes in @repo/domain
 export enum ErrorCode {
   // 400s - Client errors
-  BAD_REQUEST = 400,
+  INVALID_ID = 400,
   UNAUTHORIZED = 401,
   FORBIDDEN = 403,
   NOT_FOUND = 404,

--- a/packages/domain/src/error-codes.ts
+++ b/packages/domain/src/error-codes.ts
@@ -8,13 +8,10 @@
 export enum ErrorCode {
   // Validation errors
   VALIDATION_ERROR = "VALIDATION_ERROR",
-  INVALID_INPUT = "INVALID_INPUT",
   INVALID_ID = "INVALID_ID",
-  MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD",
 
   // Resource errors (404, 409)
   NOT_FOUND = "NOT_FOUND",
-  ALREADY_EXISTS = "ALREADY_EXISTS",
   DUPLICATE_ENTRY = "DUPLICATE_ENTRY",
 
   // Authentication errors (401)
@@ -27,10 +24,6 @@ export enum ErrorCode {
   FORBIDDEN = "FORBIDDEN",
   INSUFFICIENT_PERMISSIONS = "INSUFFICIENT_PERMISSIONS",
 
-  // Request errors (400, 422)
-  BAD_REQUEST = "BAD_REQUEST",
-  UNPROCESSABLE_ENTITY = "UNPROCESSABLE_ENTITY",
-
   // Rate limiting errors (429)
   TOO_MANY_REQUESTS = "TOO_MANY_REQUESTS",
 
@@ -41,12 +34,10 @@ export enum ErrorCode {
   CART_NOT_FOUND = "CART_NOT_FOUND",
   CART_ITEM_NOT_FOUND = "CART_ITEM_NOT_FOUND",
   CART_EMPTY = "CART_EMPTY",
-  INSUFFICIENT_STOCK = "INSUFFICIENT_STOCK",
   INVALID_QUANTITY = "INVALID_QUANTITY",
 
   // Order errors (400, 404)
   ORDER_NOT_FOUND = "ORDER_NOT_FOUND",
-  PAYMENT_FAILED = "PAYMENT_FAILED",
   INVALID_ORDER_STATUS = "INVALID_ORDER_STATUS",
   ORDER_ALREADY_PROCESSED = "ORDER_ALREADY_PROCESSED",
 
@@ -58,7 +49,6 @@ export enum ErrorCode {
 
   // Business logic errors
   OPERATION_FAILED = "OPERATION_FAILED",
-  CONSTRAINT_VIOLATION = "CONSTRAINT_VIOLATION",
 }
 
 /**
@@ -67,14 +57,10 @@ export enum ErrorCode {
 export const ERROR_CODE_TO_STATUS: Record<ErrorCode, number> = {
   // Validation errors
   [ErrorCode.VALIDATION_ERROR]: 422,
-  [ErrorCode.INVALID_INPUT]: 400,
   [ErrorCode.INVALID_ID]: 400,
-  [ErrorCode.MISSING_REQUIRED_FIELD]: 400,
-  [ErrorCode.BAD_REQUEST]: 400,
 
   // Resource errors
   [ErrorCode.NOT_FOUND]: 404,
-  [ErrorCode.ALREADY_EXISTS]: 409,
   [ErrorCode.DUPLICATE_ENTRY]: 409,
 
   // Authentication errors (401)
@@ -87,9 +73,6 @@ export const ERROR_CODE_TO_STATUS: Record<ErrorCode, number> = {
   [ErrorCode.FORBIDDEN]: 403,
   [ErrorCode.INSUFFICIENT_PERMISSIONS]: 403,
 
-  // Request errors
-  [ErrorCode.UNPROCESSABLE_ENTITY]: 422,
-
   // Rate limiting errors (429)
   [ErrorCode.TOO_MANY_REQUESTS]: 429,
 
@@ -100,12 +83,10 @@ export const ERROR_CODE_TO_STATUS: Record<ErrorCode, number> = {
   [ErrorCode.CART_NOT_FOUND]: 404,
   [ErrorCode.CART_ITEM_NOT_FOUND]: 404,
   [ErrorCode.CART_EMPTY]: 400,
-  [ErrorCode.INSUFFICIENT_STOCK]: 400,
   [ErrorCode.INVALID_QUANTITY]: 400,
 
   // Order errors
   [ErrorCode.ORDER_NOT_FOUND]: 404,
-  [ErrorCode.PAYMENT_FAILED]: 400,
   [ErrorCode.INVALID_ORDER_STATUS]: 400,
   [ErrorCode.ORDER_ALREADY_PROCESSED]: 400,
 
@@ -115,7 +96,6 @@ export const ERROR_CODE_TO_STATUS: Record<ErrorCode, number> = {
   [ErrorCode.EXTERNAL_SERVICE_ERROR]: 502,
   [ErrorCode.SERVICE_UNAVAILABLE]: 503,
   [ErrorCode.OPERATION_FAILED]: 500,
-  [ErrorCode.CONSTRAINT_VIOLATION]: 400,
 };
 
 /**

--- a/packages/domain/test/error-codes.test.ts
+++ b/packages/domain/test/error-codes.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { ErrorCode, ErrorObjectSchema, getStatusCode } from "../src/index.js";
+import {
+  ERROR_CODE_TO_STATUS,
+  ErrorCode,
+  ErrorObjectSchema,
+  getStatusCode,
+} from "../src/index.js";
 
 // The error envelope is closed over the enum - `ErrorObjectSchema.code` is
 // `z.enum(ErrorCode)` - so a rate-limit rejection could not be expressed as an
@@ -39,5 +44,24 @@ describe("VALIDATION_ERROR", () => {
     });
 
     expect(parsed.success).toBe(true);
+  });
+});
+
+// The map is typed `Record<ErrorCode, number>`, so the compiler catches a
+// missing row - this pins the other direction, that no stale row outlives the
+// member it was written for, and that every status is a real HTTP failure.
+
+describe("ERROR_CODE_TO_STATUS", () => {
+  it("covers every ErrorCode member and nothing else", () => {
+    expect(Object.keys(ERROR_CODE_TO_STATUS).sort()).toEqual(
+      Object.values(ErrorCode).sort(),
+    );
+  });
+
+  it("maps every code to an HTTP error status", () => {
+    for (const [code, status] of Object.entries(ERROR_CODE_TO_STATUS)) {
+      expect(status, code).toBeGreaterThanOrEqual(400);
+      expect(status, code).toBeLessThanOrEqual(599);
+    }
   });
 });


### PR DESCRIPTION
Removes the eight `ErrorCode` members with zero call sites (`INVALID_INPUT`, `MISSING_REQUIRED_FIELD`, `BAD_REQUEST`, `UNPROCESSABLE_ENTITY`, `ALREADY_EXISTS`, `CONSTRAINT_VIOLATION`, `INSUFFICIENT_STOCK`, `PAYMENT_FAILED`) and their `ERROR_CODE_TO_STATUS` rows. Each was grepped across `apps/`, `packages/` and `docs/` before deletion — the only `BAD_REQUEST` hits elsewhere are Axios's unrelated `ERR_BAD_REQUEST` string.

Adds a test in `packages/domain/test/error-codes.test.ts` asserting the map's keys equal the enum's values and every status is 400–599, so the two cannot drift again.

The README snippet at line ~517 used `BAD_REQUEST = 400`; it now uses `INVALID_ID = 400` rather than the issue's suggested `NOT_FOUND = 404`, because that snippet already lists `NOT_FOUND = 404` three lines down.

Verified with `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` — all green.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)