### PR TITLE
refactor: share one calculateOrderTotals between server and checkout

### DIFF
--- a/apps/client/src/app/routes/checkout/index.tsx
+++ b/apps/client/src/app/routes/checkout/index.tsx
@@ -13,6 +13,7 @@ import { CartItem } from "@/features/cart/components/cart-item";
 import { getAuthStatusQueryOptions } from "@/lib/auth";
 import { syncLocalCartToServer } from "@/lib/cart-sync";
 import currencyFormatter from "@/utils/formatters";
+import { calculateOrderTotals } from "@repo/domain";
 import { QueryClient } from "@tanstack/react-query";
 import { Link, LoaderFunctionArgs, redirect } from "react-router";
 
@@ -55,10 +56,12 @@ export default function CheckoutPage() {
   const isUpdating = updateCartItem.isPending || removeFromCart.isPending;
 
   // Calculate totals
-  const subtotal = cart?.data.subtotal || 0;
-  const shipping = 50; // Fixed shipping cost in cents
-  const tax = Math.round(subtotal * 0.2); // 20% tax
-  const total = subtotal + shipping + tax;
+  const {
+    subtotal,
+    shippingCost: shipping,
+    tax,
+    total,
+  } = calculateOrderTotals(cart?.data.subtotal || 0);
 
   if (isLoading) {
     return (

--- a/apps/server/src/services/order.service.ts
+++ b/apps/server/src/services/order.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@repo/database";
 import {
   AppError,
+  calculateOrderTotals,
   CreateOrderInput,
   ErrorCode,
   type Meta,
@@ -81,11 +82,9 @@ export class OrderService extends AbstractCrudService<
     }
 
     // Calculate order totals
-    const subtotal = cart.subtotal;
-    const shippingCost = 50; // Fixed shipping cost (can be dynamic later)
-    const taxRate = 0.2; // 20% tax rate
-    const tax = Math.round(subtotal * taxRate);
-    const total = subtotal + shippingCost + tax;
+    const { subtotal, shippingCost, tax, total } = calculateOrderTotals(
+      cart.subtotal,
+    );
 
     // Create order with items in a transaction
     const order = await prisma.$transaction(async (tx) => {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -9,3 +9,4 @@ export * from "./auth.js";
 export * from "./app-error.js";
 export * from "./cart.js";
 export * from "./order.js";
+export * from "./pricing.js";

--- a/packages/domain/src/pricing.ts
+++ b/packages/domain/src/pricing.ts
@@ -1,0 +1,20 @@
+export const SHIPPING_COST = 50;
+export const TAX_RATE = 0.2;
+
+export type OrderTotals = {
+  subtotal: number;
+  shippingCost: number;
+  tax: number;
+  total: number;
+};
+
+export function calculateOrderTotals(subtotal: number): OrderTotals {
+  const tax = Math.round(subtotal * TAX_RATE);
+
+  return {
+    subtotal,
+    shippingCost: SHIPPING_COST,
+    tax,
+    total: subtotal + SHIPPING_COST + tax,
+  };
+}

--- a/packages/domain/test/pricing.test.ts
+++ b/packages/domain/test/pricing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { SHIPPING_COST, TAX_RATE, calculateOrderTotals } from "../src/index.js";
+
+describe("calculateOrderTotals", () => {
+  it("returns only shipping for an empty subtotal", () => {
+    expect(calculateOrderTotals(0)).toEqual({
+      subtotal: 0,
+      shippingCost: 50,
+      tax: 0,
+      total: 50,
+    });
+  });
+
+  it("rounds a fractional tax the way Math.round does", () => {
+    expect(calculateOrderTotals(1).tax).toBe(0);
+    expect(calculateOrderTotals(3).tax).toBe(1);
+    expect(calculateOrderTotals(1999).tax).toBe(400);
+  });
+
+  it("keeps total equal to subtotal plus shipping plus tax", () => {
+    for (const subtotal of [0, 3, 1999, 123456]) {
+      const totals = calculateOrderTotals(subtotal);
+
+      expect(totals.total).toBe(
+        totals.subtotal + totals.shippingCost + totals.tax,
+      );
+    }
+  });
+
+  it("exposes the shared constants", () => {
+    expect(SHIPPING_COST).toBe(50);
+    expect(TAX_RATE).toBe(0.2);
+  });
+});


### PR DESCRIPTION
`order.service.ts` and `checkout/index.tsx` each carried their own copy of the shipping constant and tax formula. Both formulas were confirmed identical before the change, so this is a pure de-duplication: `SHIPPING_COST`, `TAX_RATE`, the `OrderTotals` type and `calculateOrderTotals` now live in `packages/domain/src/pricing.ts` and both sides call it. Rendered values and the `tx.order.create` data block are unchanged.

Adds `packages/domain/test/pricing.test.ts` covering the zero-subtotal shape, `Math.round` tax behaviour, the `total = subtotal + shippingCost + tax` invariant and the exported constants.

The README's "Server-Side Price Calculation" claim is left alone — the README roadmap belongs to a separate ticket.

Verified with `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` — all green.

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)