### PR TITLE
fix: make cart sync atomic and apply the merged cart to the client cache

### DIFF
--- a/apps/client/src/lib/cart-sync.ts
+++ b/apps/client/src/lib/cart-sync.ts
@@ -1,6 +1,8 @@
 import cartKeys from "@/features/cart/api/cart-keys";
+import { getCartQueryOptions } from "@/features/cart/api/get-cart";
 import { getApi } from "@/lib/api-client";
 import { clearLocalCart, getLocalCart } from "@/lib/cart-storage";
+import { SyncCartResponseSchema } from "@repo/domain";
 import { QueryClient } from "@tanstack/react-query";
 
 /**
@@ -22,14 +24,19 @@ export async function syncLocalCartToServer(
 
   try {
     const api = getApi();
-    await api.post("/cart/sync", {
+    const response = await api.post("/cart/sync", {
       items: localCart.items.map((item) => ({
         productId: item.productId,
         quantity: item.quantity,
       })),
     });
+
+    const parsed = SyncCartResponseSchema.parse(response.data);
+
     // Clear local cart after successful sync
     clearLocalCart();
+    // Seed the authenticated cart cache so the merged cart is available at once
+    queryClient.setQueryData(getCartQueryOptions(true).queryKey, parsed);
     // Invalidate cart queries to fetch the merged server cart
     await queryClient.invalidateQueries({ queryKey: cartKeys.all });
   } catch (error) {

--- a/apps/server/src/services/cart.service.ts
+++ b/apps/server/src/services/cart.service.ts
@@ -200,8 +200,8 @@ export class CartService extends AbstractCrudService<
       existingCartItems.map((item) => [item.productId, item]),
     );
 
-    // Process items in parallel using Promise.all
-    const operations: Promise<unknown>[] = [];
+    // Collected unawaited so `$transaction` receives the array form it needs
+    const operations: Prisma.PrismaPromise<unknown>[] = [];
 
     for (const localItem of input.items) {
       // Skip items with invalid products
@@ -233,8 +233,8 @@ export class CartService extends AbstractCrudService<
       }
     }
 
-    // Execute all operations in parallel
-    await Promise.all(operations);
+    // All merge writes land together or not at all
+    await prisma.$transaction(operations);
 
     // Return updated cart
     return this.getOrCreateCart(userId);

--- a/apps/server/test/cart.route.test.ts
+++ b/apps/server/test/cart.route.test.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@repo/database";
 import { ErrorCode } from "@repo/domain";
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -81,6 +82,81 @@ describe("POST /api/v1/cart", () => {
 
     expect(res.status).toBe(404);
     expect(res.body.error.code).toBe(ErrorCode.NOT_FOUND);
+  });
+});
+
+describe("POST /api/v1/cart/sync", () => {
+  it("sums the quantities of a product held in both carts", async () => {
+    const user = await createUser();
+    const productA = await createProduct({ price: 100 });
+    const productB = await createProduct({ price: 50 });
+    const cookie = authCookie(user.id);
+
+    await request(app)
+      .post("/api/v1/cart")
+      .set("Cookie", cookie)
+      .send({ productId: productA.id, quantity: 1 });
+
+    const res = await request(app)
+      .post("/api/v1/cart/sync")
+      .set("Cookie", cookie)
+      .send({
+        items: [
+          { productId: productA.id, quantity: 2 },
+          { productId: productB.id, quantity: 1 },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ productId: productA.id, quantity: 3 }),
+        expect.objectContaining({ productId: productB.id, quantity: 1 }),
+      ]),
+    );
+    expect(res.body.data).toMatchObject({ itemCount: 4, subtotal: 350 });
+
+    const persisted = await prisma.cartItem.findMany({
+      where: { cart: { userId: user.id } },
+      select: { productId: true, quantity: true },
+    });
+    expect(persisted).toEqual(
+      expect.arrayContaining([
+        { productId: productA.id, quantity: 3 },
+        { productId: productB.id, quantity: 1 },
+      ]),
+    );
+    expect(persisted).toHaveLength(2);
+  });
+
+  it("ignores an unknown product id and merges the rest", async () => {
+    const user = await createUser();
+    const product = await createProduct({ price: 200 });
+    const cookie = authCookie(user.id);
+
+    const res = await request(app)
+      .post("/api/v1/cart/sync")
+      .set("Cookie", cookie)
+      .send({
+        items: [
+          { productId: product.id, quantity: 2 },
+          { productId: ABSENT_ID, quantity: 5 },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.items).toHaveLength(1);
+    expect(res.body.data.items[0]).toMatchObject({
+      productId: product.id,
+      quantity: 2,
+    });
+    expect(res.body.data).toMatchObject({ itemCount: 2, subtotal: 400 });
+
+    const persisted = await prisma.cartItem.findMany({
+      where: { cart: { userId: user.id } },
+      select: { productId: true, quantity: true },
+    });
+    expect(persisted).toEqual([{ productId: product.id, quantity: 2 }]);
   });
 });
 


### PR DESCRIPTION
**Server** — `CartService.syncCart` built one `update`/`create` per item and ran them with `Promise.all` outside a transaction. A single failed write left the successful ones committed while the client kept its local cart (it only clears on success), so the next login re-sent everything and double-added the already-merged items. The `operations` array is now typed `Prisma.PrismaPromise<unknown>[]` and passed to `prisma.$transaction`. The unknown-product skip and the trailing `getOrCreateCart` are unchanged, and the merge rule still sums.

**Client** — `syncLocalCartToServer` discarded the merged `CartDTO` and refetched. It now parses the response with `SyncCartResponseSchema` and seeds `getCartQueryOptions(true)` via `setQueryData` before the existing `invalidateQueries`, so the badge shows the merged count without a refetch flicker. The parse sits inside the existing `try`, so a schema mismatch takes the same path as a failed request: DEV-only log, local storage untouched.

The cached shape was checked rather than assumed: `getCartQueryOptions(...).queryFn` caches the full response envelope, and `SyncCartResponseSchema` is structurally identical to `GetCartResponseSchema`, so the parsed envelope is what goes in.

**Tests** — two route tests in `apps/server/test/cart.route.test.ts`: quantities summed for a product present in both carts (asserted in the response and in the database), and an unknown 24-char product id ignored while the valid product merges. No partial-failure test — the transaction is the guarantee.

Verified with `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` — all green.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)