### PR TITLE
feat: make product, showcase and category cards fully clickable

### DIFF
--- a/apps/client/src/features/categories/components/category-nav-list/index.tsx
+++ b/apps/client/src/features/categories/components/category-nav-list/index.tsx
@@ -20,7 +20,7 @@ const CategoryNavList = ({ clickHandler }: { clickHandler?: () => void }) => {
       <ul className="flex flex-col gap-4 text-neutral-900 md:flex-row md:justify-around lg:gap-8">
         {categoriesResponse.data.map((category) => (
           <li
-            className="col-auto grid grid-cols-1 grid-rows-[25%_1fr_80px] justify-items-center rounded-md"
+            className="relative col-auto grid grid-cols-1 grid-rows-[25%_1fr_80px] justify-items-center rounded-md"
             key={category.id}
           >
             <img
@@ -38,7 +38,7 @@ const CategoryNavList = ({ clickHandler }: { clickHandler?: () => void }) => {
               </span>
               <Link
                 to={paths.category.getHref(category.name)}
-                className="tracking-600 inline-flex items-center gap-2 text-xs font-bold uppercase opacity-50 hover:underline"
+                className="tracking-600 inline-flex items-center gap-2 text-xs font-bold uppercase opacity-50 after:absolute after:inset-0 after:z-20 after:content-[''] hover:underline"
                 onMouseEnter={() => {
                   queryClient.prefetchQuery(
                     getProductsByCategoryQueryOptions(category.name),

--- a/apps/client/src/features/products/components/featured-product-section/index.tsx
+++ b/apps/client/src/features/products/components/featured-product-section/index.tsx
@@ -39,6 +39,7 @@ const FeaturedProductSection = () => {
             slug: product.data.slug,
             description: product.data.featuredImageText || "",
           }}
+          classes="relative"
         >
           <ProductCard.NewIndicator classes="text-neutral-50 opacity-50 lg:mb-6" />
           <ProductCard.Title classes="text-3xl lg:text-5xl" />

--- a/apps/client/src/features/products/components/product-card/product-actions.tsx
+++ b/apps/client/src/features/products/components/product-card/product-actions.tsx
@@ -85,17 +85,20 @@ export default function ProductActions(props: {
   return (
     <div className={cn("flex gap-4", props.classes)}>
       {props.hasNavigateAction ? (
-        <Link
-          to={paths.product.getHref(slug)}
-          onMouseEnter={() =>
-            queryClient.prefetchQuery(getProductBySlugQueryOptions(slug))
-          }
-          onFocus={() =>
-            queryClient.prefetchQuery(getProductBySlugQueryOptions(slug))
-          }
-        >
-          <Button variant="accent">see product</Button>
-        </Link>
+        <Button variant="accent" asChild>
+          <Link
+            to={paths.product.getHref(slug)}
+            className="after:absolute after:inset-0 after:content-['']"
+            onMouseEnter={() =>
+              queryClient.prefetchQuery(getProductBySlugQueryOptions(slug))
+            }
+            onFocus={() =>
+              queryClient.prefetchQuery(getProductBySlugQueryOptions(slug))
+            }
+          >
+            see product
+          </Link>
+        </Button>
       ) : null}
       {props.hasCartAction ? (
         <>

--- a/apps/client/src/features/products/components/products-list.tsx
+++ b/apps/client/src/features/products/components/products-list.tsx
@@ -14,7 +14,7 @@ export default function ProductsList({ products }: TProductListProps) {
       {products.map((product, i) => (
         <Section key={product.id}>
           <Container
-            classes={`lg:gap-31 flex flex-col gap-8 md:gap-14 lg:flex-row ${i % 2 === 1 ? "lg:flex-row-reverse" : ""}`}
+            classes={`lg:gap-31 relative flex flex-col gap-8 md:gap-14 lg:flex-row ${i % 2 === 1 ? "lg:flex-row-reverse" : ""}`}
           >
             <ResponsivePicture
               mobileSrc={product.images.introImage.mobileSrc}

--- a/apps/client/src/features/products/components/showcase-section/index.tsx
+++ b/apps/client/src/features/products/components/showcase-section/index.tsx
@@ -28,7 +28,7 @@ const ShowCaseProductsSection = () => {
   return (
     <>
       <article>
-        <Container classes="bg-primary-500 lg:gap-30 flex flex-col items-center gap-8 overflow-hidden rounded-sm pt-24 lg:flex-row lg:items-start lg:justify-center">
+        <Container classes="bg-primary-500 lg:gap-30 relative flex flex-col items-center gap-8 overflow-hidden rounded-sm pt-24 lg:flex-row lg:items-start lg:justify-center">
           <section className="lg:max-w-102.5 mx-auto w-[60%] max-w-60 lg:mx-0 lg:-mb-2.5">
             <ResponsivePicture
               altText={showCaseCover?.images.showCaseImage?.altText || ""}
@@ -60,6 +60,7 @@ const ShowCaseProductsSection = () => {
               <Button variant={"outlineReversed"} asChild>
                 <Link
                   to={paths.product.getHref(showCaseCover?.slug as string)}
+                  className="after:absolute after:inset-0 after:content-['']"
                   onMouseEnter={() =>
                     queryClient.prefetchQuery(
                       getProductBySlugQueryOptions(
@@ -83,7 +84,7 @@ const ShowCaseProductsSection = () => {
         </Container>
       </article>
       <article>
-        <Container classes="grid h-full grid-cols-1 overflow-hidden rounded-sm">
+        <Container classes="relative grid h-full grid-cols-1 overflow-hidden rounded-sm">
           <ResponsivePicture
             altText={showCaseWide?.images.showCaseImage?.altText || ""}
             ariaLabel={showCaseWide?.images.showCaseImage?.ariaLabel || ""}
@@ -106,6 +107,7 @@ const ShowCaseProductsSection = () => {
               <Button variant={"outline"} asChild>
                 <Link
                   to={paths.product.getHref(showCaseWide?.slug as string)}
+                  className="after:absolute after:inset-0 after:content-['']"
                   onMouseEnter={() =>
                     queryClient.prefetchQuery(
                       getProductBySlugQueryOptions(
@@ -130,7 +132,7 @@ const ShowCaseProductsSection = () => {
       </article>
 
       <article>
-        <Container classes="lg: grid grid-cols-1 grid-rows-2 gap-6 md:grid-cols-2 md:grid-rows-1 md:gap-3 lg:gap-7">
+        <Container classes="lg: relative grid grid-cols-1 grid-rows-2 gap-6 md:grid-cols-2 md:grid-rows-1 md:gap-3 lg:gap-7">
           <section className="overflow-hidden rounded-sm">
             <ResponsivePicture
               altText={showCaseGrid?.images.showCaseImage?.altText || ""}
@@ -154,6 +156,7 @@ const ShowCaseProductsSection = () => {
                 <Button variant={"outline"} asChild>
                   <Link
                     to={paths.product.getHref(showCaseGrid?.slug as string)}
+                    className="after:absolute after:inset-0 after:content-['']"
                     onMouseEnter={() =>
                       queryClient.prefetchQuery(
                         getProductBySlugQueryOptions(


### PR DESCRIPTION
Applies the stretched-link pattern to the category-page product cards, the three home showcase cards and the category nav cards: the card wrapper gets `relative`, the card's single existing `<Link>` gets `after:absolute after:inset-0 after:content-['']`. The whole card becomes the click target and the DOM still has exactly one anchor per card, so tab order and screen-reader output are unchanged.

`product-actions.tsx` had a `<Link>` wrapping a `<Button>` (invalid `<a><button>`, double tab stop); it now uses `Button asChild` with the prefetch handlers still on the `Link`. The three showcase links were already `Button asChild` and needed no nesting fix.

Two things worth flagging in review:

- **`featured-product-section/index.tsx` is touched although the issue did not list it.** It is the second consumer of `hasNavigateAction` (the home hero), and with no positioned ancestor the new `after:inset-0` would have resolved against the document and made a page-sized click target. `classes="relative"` on its `ProductCard` bounds the link to the card content. This is a regression the shared-component change caused, not new scope.
- **The category-nav link uses `after:z-20`.** The category thumbnail is a grid item already carrying `z-10` to sit above the grey panel, and would otherwise paint over the stretched link and swallow clicks on the image.

No inner element needed `relative z-10` — no card in scope holds a second interactive element. The product-page card passes `hasCartAction`, never `hasNavigateAction`, so its quantity selector and add-to-cart are untouched. Hover needed no new classes: a `::after` counts as part of its originating element for `:hover`, so the existing button and `hover:underline` styles now fire from anywhere on the card.

Left for a separate ticket: `related-products/index.tsx`, whose "See Product" is a `<Button onClick={navigate}>` rather than a `Link` and needs a real anchor conversion first.

Verified with `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` — all green. The manual browser checks in the issue have not been run.

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)