### PR TITLE
revert: "feat: make product, showcase and category cards fully clickable"

### DIFF
--- a/apps/client/src/features/categories/components/category-nav-list/index.tsx
+++ b/apps/client/src/features/categories/components/category-nav-list/index.tsx
@@ -20,7 +20,7 @@ const CategoryNavList = ({ clickHandler }: { clickHandler?: () => void }) => {
       <ul className="flex flex-col gap-4 text-neutral-900 md:flex-row md:justify-around lg:gap-8">
         {categoriesResponse.data.map((category) => (
           <li
-            className="relative col-auto grid grid-cols-1 grid-rows-[25%_1fr_80px] justify-items-center rounded-md"
+            className="col-auto grid grid-cols-1 grid-rows-[25%_1fr_80px] justify-items-center rounded-md"
             key={category.id}
           >
             <img
@@ -38,7 +38,7 @@ const CategoryNavList = ({ clickHandler }: { clickHandler?: () => void }) => {
               </span>
               <Link
                 to={paths.category.getHref(category.name)}
-                className="tracking-600 inline-flex items-center gap-2 text-xs font-bold uppercase opacity-50 after:absolute after:inset-0 after:z-20 after:content-[''] hover:underline"
+                className="tracking-600 inline-flex items-center gap-2 text-xs font-bold uppercase opacity-50 hover:underline"
                 onMouseEnter={() => {
                   queryClient.prefetchQuery(
                     getProductsByCategoryQueryOptions(category.name),

--- a/apps/client/src/features/products/components/featured-product-section/index.tsx
+++ b/apps/client/src/features/products/components/featured-product-section/index.tsx
@@ -39,7 +39,6 @@ const FeaturedProductSection = () => {
             slug: product.data.slug,
             description: product.data.featuredImageText || "",
           }}
-          classes="relative"
         >
           <ProductCard.NewIndicator classes="text-neutral-50 opacity-50 lg:mb-6" />
           <ProductCard.Title classes="text-3xl lg:text-5xl" />

--- a/apps/client/src/features/products/components/product-card/product-actions.tsx
+++ b/apps/client/src/features/products/components/product-card/product-actions.tsx
@@ -85,20 +85,17 @@ export default function ProductActions(props: {
   return (
     <div className={cn("flex gap-4", props.classes)}>
       {props.hasNavigateAction ? (
-        <Button variant="accent" asChild>
-          <Link
-            to={paths.product.getHref(slug)}
-            className="after:absolute after:inset-0 after:content-['']"
-            onMouseEnter={() =>
-              queryClient.prefetchQuery(getProductBySlugQueryOptions(slug))
-            }
-            onFocus={() =>
-              queryClient.prefetchQuery(getProductBySlugQueryOptions(slug))
-            }
-          >
-            see product
-          </Link>
-        </Button>
+        <Link
+          to={paths.product.getHref(slug)}
+          onMouseEnter={() =>
+            queryClient.prefetchQuery(getProductBySlugQueryOptions(slug))
+          }
+          onFocus={() =>
+            queryClient.prefetchQuery(getProductBySlugQueryOptions(slug))
+          }
+        >
+          <Button variant="accent">see product</Button>
+        </Link>
       ) : null}
       {props.hasCartAction ? (
         <>

--- a/apps/client/src/features/products/components/products-list.tsx
+++ b/apps/client/src/features/products/components/products-list.tsx
@@ -14,7 +14,7 @@ export default function ProductsList({ products }: TProductListProps) {
       {products.map((product, i) => (
         <Section key={product.id}>
           <Container
-            classes={`lg:gap-31 relative flex flex-col gap-8 md:gap-14 lg:flex-row ${i % 2 === 1 ? "lg:flex-row-reverse" : ""}`}
+            classes={`lg:gap-31 flex flex-col gap-8 md:gap-14 lg:flex-row ${i % 2 === 1 ? "lg:flex-row-reverse" : ""}`}
           >
             <ResponsivePicture
               mobileSrc={product.images.introImage.mobileSrc}

--- a/apps/client/src/features/products/components/showcase-section/index.tsx
+++ b/apps/client/src/features/products/components/showcase-section/index.tsx
@@ -28,7 +28,7 @@ const ShowCaseProductsSection = () => {
   return (
     <>
       <article>
-        <Container classes="bg-primary-500 lg:gap-30 relative flex flex-col items-center gap-8 overflow-hidden rounded-sm pt-24 lg:flex-row lg:items-start lg:justify-center">
+        <Container classes="bg-primary-500 lg:gap-30 flex flex-col items-center gap-8 overflow-hidden rounded-sm pt-24 lg:flex-row lg:items-start lg:justify-center">
           <section className="lg:max-w-102.5 mx-auto w-[60%] max-w-60 lg:mx-0 lg:-mb-2.5">
             <ResponsivePicture
               altText={showCaseCover?.images.showCaseImage?.altText || ""}
@@ -60,7 +60,6 @@ const ShowCaseProductsSection = () => {
               <Button variant={"outlineReversed"} asChild>
                 <Link
                   to={paths.product.getHref(showCaseCover?.slug as string)}
-                  className="after:absolute after:inset-0 after:content-['']"
                   onMouseEnter={() =>
                     queryClient.prefetchQuery(
                       getProductBySlugQueryOptions(
@@ -84,7 +83,7 @@ const ShowCaseProductsSection = () => {
         </Container>
       </article>
       <article>
-        <Container classes="relative grid h-full grid-cols-1 overflow-hidden rounded-sm">
+        <Container classes="grid h-full grid-cols-1 overflow-hidden rounded-sm">
           <ResponsivePicture
             altText={showCaseWide?.images.showCaseImage?.altText || ""}
             ariaLabel={showCaseWide?.images.showCaseImage?.ariaLabel || ""}
@@ -107,7 +106,6 @@ const ShowCaseProductsSection = () => {
               <Button variant={"outline"} asChild>
                 <Link
                   to={paths.product.getHref(showCaseWide?.slug as string)}
-                  className="after:absolute after:inset-0 after:content-['']"
                   onMouseEnter={() =>
                     queryClient.prefetchQuery(
                       getProductBySlugQueryOptions(
@@ -132,7 +130,7 @@ const ShowCaseProductsSection = () => {
       </article>
 
       <article>
-        <Container classes="lg: relative grid grid-cols-1 grid-rows-2 gap-6 md:grid-cols-2 md:grid-rows-1 md:gap-3 lg:gap-7">
+        <Container classes="lg: grid grid-cols-1 grid-rows-2 gap-6 md:grid-cols-2 md:grid-rows-1 md:gap-3 lg:gap-7">
           <section className="overflow-hidden rounded-sm">
             <ResponsivePicture
               altText={showCaseGrid?.images.showCaseImage?.altText || ""}
@@ -156,7 +154,6 @@ const ShowCaseProductsSection = () => {
                 <Button variant={"outline"} asChild>
                   <Link
                     to={paths.product.getHref(showCaseGrid?.slug as string)}
-                    className="after:absolute after:inset-0 after:content-['']"
                     onMouseEnter={() =>
                       queryClient.prefetchQuery(
                         getProductBySlugQueryOptions(


### PR DESCRIPTION
Reverts `9cec980` (the squash of #177, which closed #171) at the author's request.

The five client files are restored to their state at `c556cf0` exactly — `git diff c556cf0` is empty. This undoes the stretched-link pattern on the product/showcase/category cards, the `Button asChild` change in `product-actions.tsx`, and the `relative` wrapper added to `featured-product-section/index.tsx`.

Note that this also restores the pre-existing `<Link>` wrapping `<Button>` in `product-actions.tsx` — the invalid `<a><button>` nesting and its double tab stop are back. That was a real defect independent of the clickable-card work, so it is worth fixing separately if #171 does not come back soon.

Verified with `pnpm build && pnpm lint && pnpm test && pnpm type-check && pnpm format:check` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)