### PR TITLE
feat: server-owned product slugs

### DIFF
--- a/apps/server/src/services/product.service.ts
+++ b/apps/server/src/services/product.service.ts
@@ -15,9 +15,13 @@ import {
   ProductShowCaseProductsDTO,
   ProductUpdateInput,
   ProductWhereInput,
+  slugify,
+  SlugValidator,
 } from "@repo/domain";
 import { parseOrderBy, parseSelect, type Pagination } from "../utils/query.js";
 import { AbstractCrudService } from "./abstract-crud.service.js";
+
+const PRODUCT_SLUG = SlugValidator("Product");
 
 const PRODUCT_UPDATE_FIELDS = [
   "cartLabel",
@@ -87,8 +91,43 @@ export class ProductService extends AbstractCrudService<
     return prisma.product.findUnique({ where: { id } });
   }
 
+  // A derived slug is held to the same format as one the client sends.
+  private assertDerivedSlug(slug: string) {
+    if (PRODUCT_SLUG.safeParse(slug).success) return;
+    throw new AppError(
+      "Could not derive a valid slug from the product name",
+      ErrorCode.VALIDATION_ERROR,
+    );
+  }
+
+  // An explicit slug is left to the unique index (409); only a derived one is de-duplicated.
+  private async resolveCreateSlug(input: ProductCreateInput): Promise<string> {
+    if (input.slug) return input.slug;
+
+    const base = slugify(input.name);
+    this.assertDerivedSlug(base);
+
+    const taken = new Set(
+      (
+        await prisma.product.findMany({
+          where: { slug: { startsWith: base } },
+          select: { slug: true },
+        })
+      ).map((product) => product.slug),
+    );
+
+    let candidate = base;
+    for (let suffix = 2; taken.has(candidate); suffix++) {
+      candidate = `${base}-${suffix}`;
+    }
+
+    this.assertDerivedSlug(candidate);
+    return candidate;
+  }
+
   protected async persistCreate(input: ProductCreateInput) {
-    return prisma.product.create({ data: input });
+    const slug = await this.resolveCreateSlug(input);
+    return prisma.product.create({ data: { ...input, slug } });
   }
 
   protected filterUpdateInput(input: ProductUpdateInput): ProductUpdateInput {

--- a/apps/server/test/helpers/database.ts
+++ b/apps/server/test/helpers/database.ts
@@ -65,7 +65,7 @@ export const authCookie = (userId: string) => {
   return `jwt=${token}`;
 };
 
-const image = (label: string) => ({
+export const image = (label: string) => ({
   altText: `${label} alt`,
   ariaLabel: `${label} aria`,
   desktopSrc: `https://cdn.example.com/${label}-desktop.jpg`,
@@ -73,7 +73,7 @@ const image = (label: string) => ({
   tabletSrc: `https://cdn.example.com/${label}-tablet.jpg`,
 });
 
-const thumbnail = (label: string) => ({
+export const thumbnail = (label: string) => ({
   altText: `${label} alt`,
   ariaLabel: `${label} aria`,
   src: `https://cdn.example.com/${label}-thumb.jpg`,

--- a/apps/server/test/product.route.test.ts
+++ b/apps/server/test/product.route.test.ts
@@ -6,9 +6,37 @@ import {
   ABSENT_ID,
   authCookie,
   createAdmin,
+  createCategory,
   createProduct,
+  image,
   resetDatabase,
+  thumbnail,
 } from "./helpers/database.js";
+
+/** A complete create body; every unique field is keyed off `name`. */
+const productBody = (categoryId: string, name: string) => ({
+  category: { connect: { id: categoryId } },
+  cartLabel: name,
+  name,
+  shortLabel: name,
+  description: `${name} description`,
+  price: 1000,
+  fullLabel: [name],
+  featuresText: [`${name} feature`],
+  featuredImageText: null,
+  showCaseImageText: null,
+  isNewProduct: true,
+  includedItems: [{ item: "Cable", quantity: 1 }],
+  images: {
+    featuredImage: null,
+    showCaseImage: null,
+    galleryImages: [image(`${name}-gallery`)],
+    introImage: image(`${name}-intro`),
+    primaryImage: image(`${name}-primary`),
+    relatedProductImage: image(`${name}-related`),
+    thumbnail: thumbnail(name),
+  },
+});
 
 beforeEach(resetDatabase);
 
@@ -74,6 +102,16 @@ describe("GET /api/v1/products/slug/:slug", () => {
     expect(res.status).toBe(200);
     expect(res.body.data.id).toBe(product.id);
   });
+
+  it("returns VALIDATION_ERROR for a malformed slug", async () => {
+    const res = await request(app).get("/api/v1/products/slug/Not_A_Slug");
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ path: ["params", "slug"] }],
+    });
+  });
 });
 
 describe("DELETE /api/v1/products/:id", () => {
@@ -117,6 +155,79 @@ describe("DELETE /api/v1/products/:id", () => {
   });
 });
 
+describe("POST /api/v1/products", () => {
+  it("derives the slug from the name when the body omits one", async () => {
+    const admin = await createAdmin();
+    const category = await createCategory();
+
+    const res = await request(app)
+      .post("/api/v1/products")
+      .set("Cookie", authCookie(admin.id))
+      .send(productBody(category.id, "XX99 Mark II"));
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.slug).toBe("xx99-mark-ii");
+  });
+
+  it("suffixes a derived slug that is already taken", async () => {
+    const admin = await createAdmin();
+    const existing = await createProduct({ slug: "zx9-speaker" });
+
+    const res = await request(app)
+      .post("/api/v1/products")
+      .set("Cookie", authCookie(admin.id))
+      .send(productBody(existing.categoryId, "ZX9 Speaker"));
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.slug).toBe("zx9-speaker-2");
+  });
+
+  it("rejects a malformed explicit slug", async () => {
+    const admin = await createAdmin();
+    const category = await createCategory();
+
+    const res = await request(app)
+      .post("/api/v1/products")
+      .set("Cookie", authCookie(admin.id))
+      .send({ ...productBody(category.id, "ZX7 Speaker"), slug: "Bad Slug" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      details: [{ path: ["body", "slug"] }],
+    });
+  });
+
+  it("rejects a name no valid slug can be derived from", async () => {
+    const admin = await createAdmin();
+    const category = await createCategory();
+
+    const res = await request(app)
+      .post("/api/v1/products")
+      .set("Cookie", authCookie(admin.id))
+      .send(productBody(category.id, "!!"));
+
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe(ErrorCode.VALIDATION_ERROR);
+  });
+
+  it("returns DUPLICATE_ENTRY for an explicit slug already in use", async () => {
+    const admin = await createAdmin();
+    const existing = await createProduct({ slug: "zx9-speaker" });
+
+    const res = await request(app)
+      .post("/api/v1/products")
+      .set("Cookie", authCookie(admin.id))
+      .send({
+        ...productBody(existing.categoryId, "ZX9 Speaker"),
+        slug: "zx9-speaker",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe(ErrorCode.DUPLICATE_ENTRY);
+  });
+});
+
 describe("PATCH /api/v1/products/:id", () => {
   it("returns NOT_FOUND for a well-formed id that matches nothing", async () => {
     const admin = await createAdmin();
@@ -130,6 +241,22 @@ describe("PATCH /api/v1/products/:id", () => {
     expect(res.body.error).toMatchObject({
       code: ErrorCode.NOT_FOUND,
       message: "No document found with that ID",
+    });
+  });
+
+  it("leaves the slug alone when the name changes", async () => {
+    const admin = await createAdmin();
+    const product = await createProduct({ slug: "xx99-mark-one" });
+
+    const res = await request(app)
+      .patch(`/api/v1/products/${product.id}`)
+      .set("Cookie", authCookie(admin.id))
+      .send({ name: "XX99 Mark Two" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      name: "XX99 Mark Two",
+      slug: "xx99-mark-one",
     });
   });
 });

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -5,6 +5,7 @@ export * from "./product.js";
 export * from "./error-codes.js";
 export * from "./common.js";
 export * from "./shared.js";
+export * from "./slug.js";
 export * from "./auth.js";
 export * from "./app-error.js";
 export * from "./cart.js";

--- a/packages/domain/src/product.ts
+++ b/packages/domain/src/product.ts
@@ -17,11 +17,15 @@ import {
   SingleItemResponseSchema,
 } from "./common.js";
 import { IdValidator } from "./shared.js";
+import { SlugValidator } from "./slug.js";
 
 // * ===== Database Type Re-exports (Service Generics )=====
 
 export type Product = PrismaProduct;
-export type ProductCreateInput = Prisma.ProductCreateInput;
+// `slug` is optional on the wire: the service derives it from `name` when absent.
+export type ProductCreateInput = Omit<Prisma.ProductCreateInput, "slug"> & {
+  slug?: string;
+};
 export type ProductUpdateInput = Prisma.ProductUncheckedUpdateInput;
 export type ProductWhereInput = Prisma.ProductWhereInput;
 export type ProductSelect = Prisma.ProductSelect;
@@ -79,7 +83,7 @@ const ProductPropertiesSchema = z
       .string()
       .min(1, "Showcase image text is required")
       .nullable(),
-    slug: z.string().min(1, "Slug is required"),
+    slug: SlugValidator("Product"),
     includedItems: z.array(
       z
         .object({
@@ -150,7 +154,7 @@ export const ProductGetByPathSchema = createRequestSchema({});
 // GET - Get Product by Slug
 
 export const ProductGetBySlugSchema = createRequestSchema({
-  params: z.object({ slug: z.string().min(2, "Slug is required") }).strict(),
+  params: z.object({ slug: SlugValidator("Product") }).strict(),
 });
 
 // CREATE - Create new product
@@ -159,6 +163,7 @@ export const ProductCreateRequestSchema = createRequestSchema({
     category: z.object({
       connect: z.object({ id: IdValidator("Category") }).strict(),
     }),
+    slug: SlugValidator("Product").optional(),
   }).omit({
     createdAt: true,
     categoryId: true,

--- a/packages/domain/src/shared.ts
+++ b/packages/domain/src/shared.ts
@@ -27,10 +27,3 @@ export const PasswordValidator = (identifier: string = "Password") => {
     .min(8, "Password must be at least 8 characters")
     .max(20, "Password must be at most 20 characters");
 };
-
-export const SlugValidator = (identifier: string = "Document") =>
-  z
-    .string({ message: `${identifier} Slug is required` })
-    .regex(/^[a-z0-9-]+$/i, { message: "Invalid slug format" })
-    .min(3)
-    .max(80);

--- a/packages/domain/src/slug.ts
+++ b/packages/domain/src/slug.ts
@@ -1,0 +1,18 @@
+import z from "zod";
+
+export const SlugValidator = (identifier: string = "Document") =>
+  z
+    .string({ message: `${identifier} Slug is required` })
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, { message: "Invalid slug format" })
+    .min(3)
+    .max(80);
+
+export const slugify = (input: string): string =>
+  input
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80)
+    .replace(/-+$/, "");

--- a/packages/domain/test/slug.test.ts
+++ b/packages/domain/test/slug.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { SlugValidator, slugify } from "../src/index.js";
+
+describe("slugify", () => {
+  it("lowercases and hyphenates a product name", () => {
+    expect(slugify("XX99 Mark II Headphones")).toBe("xx99-mark-ii-headphones");
+  });
+
+  it("strips diacritics", () => {
+    expect(slugify("Écouteurs Spëaker")).toBe("ecouteurs-speaker");
+  });
+
+  it("collapses leading, trailing and repeated separators", () => {
+    expect(slugify("  --ZX9 -- Speaker!!  ")).toBe("zx9-speaker");
+  });
+
+  it("cuts to 80 characters and leaves no trailing hyphen", () => {
+    const slug = slugify(`${"a".repeat(79)} b`);
+
+    expect(slug).toBe("a".repeat(79));
+  });
+});
+
+describe("SlugValidator", () => {
+  const validator = SlugValidator("Product");
+
+  it("accepts a well-formed slug", () => {
+    expect(validator.safeParse("xx59-headphones").success).toBe(true);
+  });
+
+  it.each(["Foo", "-foo", "foo-", "foo--bar", "fo", "a".repeat(81)])(
+    "rejects %s",
+    (slug) => {
+      expect(validator.safeParse(slug).success).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
Closes #172.

The server owns product slugs.

- **Create**: `slug` is optional. Absent, it is derived from `name` via a new pure `slugify` and de-duplicated with `-2`, `-3`, … past any collision found by one `startsWith` query. Present, it is validated and a duplicate still surfaces as 409 `DUPLICATE_ENTRY` through the unique index.
- **Update**: unchanged — `slug` stays in `PRODUCT_UPDATE_FIELDS` and is never regenerated when `name` changes, so URLs, bookmarks and SEO stay stable.
- **Format**: `SlugValidator` is tightened to `/^[a-z0-9]+(?:-[a-z0-9]+)*$/` (no uppercase, no leading, trailing or doubled hyphens), still 3–80 chars.

Two changes beyond the ticket's list, both from the review:

- A *derived* slug is now held to the same validator as an explicit one. Without it, `name: "ZX"` stored a two-character slug and a punctuation-only name an empty one — a broken `/products/` URL that no validation layer saw. It is a 422 instead.
- `ProductGetBySlugSchema` used `z.string().min(2)`, the one slug site left on an ad-hoc primitive; it uses `SlugValidator` now, so a malformed lookup is a 422 rather than a 404.

`SlugValidator` and `slugify` live in their own `slug` module rather than `shared.ts`, mirrored by `packages/domain/test/slug.test.ts`.

## Tests

New: `slugify` and validator unit tests in the domain package; six route tests covering a derived slug, a suffixed collision, a malformed explicit slug, an underivable name, a duplicate explicit slug, a malformed lookup, and slug stability across a `PATCH` that changes `name`.

`pnpm type-check`, `pnpm lint` and `pnpm test` all pass (219 server, 29 domain, 2 client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)