### PR TITLE
docs: rewrite the ERROR_FLOW classification tree to match processAxiosError

### DIFF
--- a/apps/client/docs/ERROR_FLOW.md
+++ b/apps/client/docs/ERROR_FLOW.md
@@ -449,79 +449,68 @@ const ContactForm = () => {
 
 ## Error Classification Strategy
 
-Errors are classified early at the API boundary using `classifyHttpError()` function, converting raw HTTP responses into typed `AppError` with semantic `ErrorCode` values.
+Errors are classified early at the API boundary by `normalizeError()`, which delegates axios failures to `processAxiosError()`, converting raw HTTP responses into typed `AppError` with semantic `ErrorCode` values.
 
 **Why classification matters:**
 
 - **Code-first approach**: Server provides semantic error type; we don't guess from status
-- **Fallback strategy**: If server doesn't provide code, we infer from HTTP semantics
+- **No status-code fallback**: a response without a usable `code` becomes `INTERNAL_ERROR, 500`; the status is never consulted
 - **Type safety**: All errors are `AppError` with known `ErrorCode` and `statusCode`
 - **Consistency**: Same classification logic across all endpoints
 
 ### Classification Decision Tree
 
 ```
-Error Received
+normalizeError(error)
     │
-    ├─ Is Axios Error (use isAxiosError())?
-    │   └─ NO → Handle as generic Error
+    ├─ error instanceof AppError?
+    │   └─ YES → return it unchanged (already normalized)
     │
-    └─ YES → Check axios error code
-        │
-        ├─ Network/Transport Errors?
-        │   ├─ ERR_NETWORK → No internet connection
-        │   ├─ ECONNABORTED → Connection aborted
-        │   ├─ ETIMEDOUT → Request timeout
-        │   ├─ ERR_BAD_RESPONSE → Invalid response format
-        │   └─ Result: AppError(EXTERNAL_SERVICE_ERROR, 503)
-        │
-        ├─ Request Errors?
-        │   ├─ ERR_BAD_REQUEST → Malformed request
-        │   ├─ ERR_INVALID_URL → Invalid URL
-        │   ├─ ERR_BAD_OPTION → Invalid axios config
-        │   └─ Result: AppError(BAD_REQUEST, 400)
-        │
-        ├─ Axios Config Errors?
-        │   ├─ ERR_BAD_OPTION_VALUE → Invalid config value
-        │   ├─ ERR_DEPRECATED → Deprecated feature used
-        │   └─ Result: AppError(INTERNAL_ERROR, 500)
-        │
-        ├─ Redirect/Cancellation Errors?
-        │   ├─ ERR_FR_TOO_MANY_REDIRECTS → Too many redirects
-        │   ├─ ERR_CANCELED → Request cancelled
-        │   └─ Result: AppError(OPERATION_FAILED, 500 or skip)
-        │
-        ├─ HTTP Response Exists?
-        │   │
-        │   ├─ Server provided custom code field?
-        │   │   ├─ YES → Map code to ErrorCode enum
-        │   │   │        Examples: "VALIDATION_ERROR", "NOT_FOUND", "UNAUTHORIZED"
-        │   │   │
-        │   │   └─ NO → Fall back to status code
-        │   │
-        │   ├─ Status 422?
-        │   │   └─ AppError(VALIDATION_ERROR, 422)
-        │   │       "Please check your input..."
-        │   │
-        │   ├─ Status 401?
-        │   │   └─ AppError(UNAUTHORIZED, 401)
-        │   │       "Please log in to continue..."
-        │   │
-        │   ├─ Status 403?
-        │   │   └─ AppError(FORBIDDEN, 403)
-        │   │       "You don't have permission..."
-        │   │
-        │   ├─ Status 404?
-        │   │   └─ AppError(NOT_FOUND, 404)
-        │   │       "Resource not found..."
-        │   │
-        │   └─ Status 5xx?
-        │       └─ AppError(INTERNAL_ERROR, 500)
-        │           "Service temporarily unavailable. Retrying..."
-        │
-        └─ No HTTP Response?
-            └─ Already handled by network/transport error check above
+    ├─ isAxiosError(error)?
+    │   └─ YES → processAxiosError(error) → see tree below
+    │
+    ├─ isClientZodError(error)?
+    │   └─ YES → AppError(VALIDATION_ERROR)
+    │            status omitted; derived from ERROR_CODE_TO_STATUS
+    │
+    ├─ error instanceof Error?
+    │   └─ YES → AppError(INTERNAL_ERROR)
+    │
+    ├─ typeof error === "string"?
+    │   └─ YES → AppError(INTERNAL_ERROR)
+    │
+    └─ anything else → AppError(INTERNAL_ERROR, 500)
 ```
+
+`processAxiosError` has exactly three outcomes, checked in this order. There is no `switch` on `error.code` and no status-code ladder:
+
+```
+processAxiosError(error)
+    │
+    ├─ error.code === "ERR_NETWORK"  OR  error.response is absent?
+    │   └─ YES → AppError(EXTERNAL_SERVICE_ERROR, 503)
+    │            "Network connection failed. Please check your
+    │             internet connection."
+    │
+    ├─ error.code === "ERR_BAD_RESPONSE" or "ERR_BAD_REQUEST"?
+    │   │        (a response exists here — branch 1 returned if it did not)
+    │   │
+    │   └─ YES → is error.response.data.error a well-formed AppError?
+    │            isAppError(): code is a known ErrorCode, statusCode is a
+    │            number, message is a string
+    │            │
+    │            ├─ YES → pass the server's error through unchanged:
+    │            │        AppError(message, code, statusCode, details)
+    │            │
+    │            └─ NO → fall through to the catch-all below
+    │
+    └─ everything else → AppError(INTERNAL_ERROR, 500)
+                         "Something went very wrong!"
+```
+
+**The pass-through branch is the only source of semantic codes.** `VALIDATION_ERROR 422`, `NOT_FOUND 404` and `UNAUTHORIZED 401` do reach the client, but they are read out of the response body — the client never derives a code from the HTTP status. A 404 from something that is not our API (a proxy, a CDN error page) carries no `data.error`, fails `isAppError`, and becomes `INTERNAL_ERROR, 500`.
+
+**Every other axios code is unhandled.** Codes such as `ETIMEDOUT` or `ERR_CANCELED` reach the 503 branch only because they usually arrive with no `error.response`; when a response is present they land on the `INTERNAL_ERROR, 500` catch-all.
 
 ### Classification Result
 
@@ -557,27 +546,15 @@ getErrorMessage(error): string
 
 **Axios Error Codes Reference:**
 
-When `isAxiosError(error)` returns true, check `error.code` for:
+`processAxiosError` matches three `error.code` values and ignores the rest:
 
-- **Network/Transport Errors:**
-  - `ERR_NETWORK` - No internet connection or network failure
-  - `ECONNABORTED` - Connection was aborted
-  - `ETIMEDOUT` - Request timeout
-  - `ERR_BAD_RESPONSE` - Server responded with invalid data format
+- `ERR_NETWORK` - no internet connection or network failure → 503 branch
+- `ERR_BAD_RESPONSE` - a 5xx response → pass-through branch
+- `ERR_BAD_REQUEST` - a 4xx response → pass-through branch
 
-- **Request/Configuration Errors:**
-  - `ERR_BAD_REQUEST` - Malformed request syntax
-  - `ERR_INVALID_URL` - URL is invalid
-  - `ERR_BAD_OPTION` - Invalid axios configuration option
-  - `ERR_BAD_OPTION_VALUE` - Invalid value for axios option
+Both pass-through codes only carry the server's error forward when `response.data.error` satisfies `isAppError`; otherwise they fall to the `INTERNAL_ERROR, 500` catch-all, as does every unmatched code (`ECONNABORTED`, `ETIMEDOUT`, `ERR_CANCELED`, `ERR_FR_TOO_MANY_REDIRECTS`, `ERR_INVALID_URL`, `ERR_BAD_OPTION`, `ERR_BAD_OPTION_VALUE`, `ERR_DEPRECATED`, `ERR_NOT_SUPPORT`) that arrives with a response.
 
-- **Axios-Specific Errors:**
-  - `ERR_FR_TOO_MANY_REDIRECTS` - Too many HTTP redirects
-  - `ERR_CANCELED` - Request was cancelled
-  - `ERR_DEPRECATED` - Using deprecated axios feature
-  - `ERR_NOT_SUPPORT` - Unsupported operation for environment
-
-**Code reference:** [apps/client/src/lib/errors.ts](apps/client/src/lib/errors.ts) and [axios documentation](https://axios-http.com/docs/intro)
+**Code reference:** [apps/client/src/lib/errors/errors.ts](apps/client/src/lib/errors/errors.ts) and [axios documentation](https://axios-http.com/docs/intro)
 
 ---
 


### PR DESCRIPTION
Closes #179

The "Classification Decision Tree" in `apps/client/docs/ERROR_FLOW.md` described four decision branches that `processAxiosError` does not have. Every answer it gave for a non-2xx response was wrong, which made it worse than no diagram — it invited a `catch` matching on a `statusCode` the client never produces.

## What changed

- **The tree** is now two trees: `normalizeError`'s six-way dispatch, then `processAxiosError`'s three real outcomes. The invented branches are deleted rather than reworded — no "Request Errors → `AppError(BAD_REQUEST, 400)`" (a code #168 removed from the enum), no redirect/cancellation branch, no 422/401/403/404/5xx status ladder.
- **The `isAppError` gate is explicit**, including the edge a reader is most likely to get wrong: a failed check falls through to `INTERNAL_ERROR, 500`.
- **A note on mechanism.** Semantic codes are read out of the response body, so a 404 from something that is not our API (a proxy, a CDN error page) becomes `INTERNAL_ERROR, 500`, not `NOT_FOUND`. The old ladder was not wrong about outcomes in the common case, but it was wrong about why — and that is the distinction that bites.
- **Prose making the same claims**: the intro named a `classifyHttpError()` that exists nowhere in the source; a bullet promised status-code inference that never happens; the axios-codes reference grouped codes into the invented branches instead of naming the three the client actually matches.

Documentation only — no source file is touched.

## Verification

Both commands from the issue's Verify section pass: `pnpm format:check` is clean and `git grep "ErrorCode.BAD_REQUEST\|AppError(BAD_REQUEST" -- apps/client/docs` returns nothing. Full `pnpm test` exits 0.

The manual check the issue asked for was done explicitly: all three `processAxiosError` returns and all six `normalizeError` returns pair 1:1 with a leaf in the new diagram, with no extra leaves, and both quoted message strings are verbatim from the source.

## Follow-up

Review surfaced drift outside the region #179 scoped ("only lines 463–524 were audited here"), left untouched here and filed as #182: the docs name three non-existent functions for `processAxiosError`, list two exports that don't exist, and document `isCriticalError` as its own inverse in three worked examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
