### PR TITLE
docs: point the client error docs at processAxiosError and fix isCriticalError (#182)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -304,11 +304,11 @@ Axios is used for making HTTP requests with automatic error classification and r
 **Common patterns:**
 
 - All HTTP requests go through `getApi()` for lazy initialization with interceptors
-- Error responses automatically classified using `classifyHttpError()`
-- 401 errors set `redirectTo` for auth layer handling
+- The interceptor is pure transport: it rejects the raw error, unclassified
+- Classification happens downstream, in `processAxiosError()` — called directly by the React Query `retry` callback, and via `normalizeError()` in boundaries and components
 - 4xx errors shown inline in UI, not as toasts
 - 5xx and network errors show toast notifications
-- All errors thrown as `AppError` to React Query for consistent handling
+- Boundaries and components normalize to `AppError` before rendering; React Query rethrows the raw error
 
 **Key file**: [apps/client/src/lib/api-client.ts](apps/client/src/lib/api-client.ts)
 

--- a/apps/client/docs/COMPONENT_ERROR_PATTERNS.md
+++ b/apps/client/docs/COMPONENT_ERROR_PATTERNS.md
@@ -52,7 +52,7 @@ export function ProductPage() {
 **Error Flow:**
 
 1. Query fails → Axios throws raw HTTP error
-2. React Query classifies via `classifyHttpError()` in retry handler
+2. React Query classifies via `processAxiosError()` in its retry handler
 3. No retry for 4xx, or retries exhausted for 5xx
 4. React Query throws `AppError` (because `throwOnError: true`)
 5. ErrorBoundary catches → shows error page
@@ -69,7 +69,7 @@ export function ProductPage() {
 
 import { useQuery } from "@tanstack/react-query";
 import { getRelatedProductsQueryOptions } from "@/lib/query-options";
-import { classifyHttpError } from "@/lib/errors";
+import { normalizeError } from "@/lib/errors/errors";
 import { toast } from "@/hooks/use-toast";
 
 export function RelatedProducts({ productId }: { productId: string }) {
@@ -86,7 +86,7 @@ export function RelatedProducts({ productId }: { productId: string }) {
   if (query.isError) {
     // Handle error inline
     const error = query.error;
-    const appError = classifyHttpError(error); // Classify here
+    const appError = normalizeError(error); // Normalize here
 
     // Show fallback UI for non-critical data
     return (
@@ -135,7 +135,7 @@ export function RelatedProducts({ productId }: { productId: string }) {
 
 import { useQuery } from "@tanstack/react-query";
 import { getProductsQueryOptions } from "@/lib/query-options";
-import { classifyHttpError } from "@/lib/errors";
+import { normalizeError } from "@/lib/errors/errors";
 import { useEffect } from "react";
 import { toast } from "@/hooks/use-toast";
 
@@ -148,7 +148,7 @@ export function ProductList() {
   // Detect refetch errors and show toast
   useEffect(() => {
     if (query.isRefetchError) {
-      const appError = classifyHttpError(query.error);
+      const appError = normalizeError(query.error);
 
       // Only toast on background/refetch errors (not initial load)
       toast({
@@ -166,7 +166,7 @@ export function ProductList() {
 
   if (query.isLoadingError) {
     // Initial load failed; show error UI
-    return <ErrorBlock error={classifyHttpError(query.error)} />;
+    return <ErrorBlock error={normalizeError(query.error)} />;
   }
 
   // Show stale data with toast message visible
@@ -202,7 +202,7 @@ export function ProductList() {
 
 import { useMutation } from "@tanstack/react-query";
 import { postSignUp } from "@/lib/api/auth";
-import { classifyHttpError, isAppError } from "@/lib/errors";
+import { normalizeError } from "@/lib/errors/errors";
 import { ErrorCode } from "@repo/domain";
 import { useState } from "react";
 
@@ -222,7 +222,7 @@ export function SignUpForm() {
       const response = await mutation.mutateAsync(formData);
       // Success; redirect or show message
     } catch (error) {
-      const appError = classifyHttpError(error);
+      const appError = normalizeError(error);
 
       // Branch on the code, never the number: the status for a rejected
       // input lives in ERROR_CODE_TO_STATUS and is free to change.
@@ -284,7 +284,7 @@ export function SignUpForm() {
 1. User submits form
 2. Request sent → Axios throws raw error
 3. Mutation catches error (no React Query retry for mutations by default)
-4. Component classifies error via `classifyHttpError()`
+4. Component normalizes the error via `normalizeError()`
 5. Check the error code:
    - `VALIDATION_ERROR` with field details: Set `fieldErrors` from `appError.details`
    - `VALIDATION_ERROR` without them: Show generic form error
@@ -466,10 +466,10 @@ Is the data REQUIRED for the page to be useful?
 // DON'T: Classify in Axios
 interceptor.response.use(
   (response) => response,
-  (error) => Promise.reject(classifyHttpError(error)), // ❌ Don't do this
+  (error) => Promise.reject(processAxiosError(error)), // ❌ Don't do this
 );
 
-// DO: Classify in React Query or component
+// DO: Normalize in React Query or component
 const query = useQuery({
   queryFn: () => getApi().get("/data"),
   throwOnError: true,
@@ -505,9 +505,9 @@ if (query.error) {
   return <div>{query.error.message}</div>; // ❌ May not have .message
 }
 
-// DO: Classify first
+// DO: Normalize first
 if (query.error) {
-  const appError = classifyHttpError(query.error);
+  const appError = normalizeError(query.error);
   return <div>{appError.message}</div>;
 }
 ```

--- a/apps/client/docs/ERROR_CHAIN_MAPPING.md
+++ b/apps/client/docs/ERROR_CHAIN_MAPPING.md
@@ -83,46 +83,56 @@ This document maps the complete error flow chain in the client application, from
 
 ## Axios Error Codes Reference
 
-When Axios encounters an error, it sets `error.code` to one of these values:
+When Axios encounters an error, it sets `error.code` to one of these values.
 
-### Network/Connection Errors (Retryable)
+**Retry is not decided from `error.code`.** The `retry` callback in
+[apps/client/src/lib/react-query.ts](apps/client/src/lib/react-query.ts) runs
+`processAxiosError(error)` and branches on the `statusCode` that comes back:
+a 4xx never retries, nor does a client-side Zod error; anything else retries up
+to twice. Since every code that
+arrives without an `error.response` classifies as `EXTERNAL_SERVICE_ERROR 503`,
+most of the codes below retry regardless of what Axios meant by them.
 
-| Error Code     | Meaning                                                                  | Retry? |
-| -------------- | ------------------------------------------------------------------------ | ------ |
-| `ERR_NETWORK`  | Network connection failed (no internet, DNS failure, connection refused) | ✅ Yes |
-| `ECONNABORTED` | Connection aborted - request was terminated before completion            | ✅ Yes |
-| `ETIMEDOUT`    | Request timeout - server didn't respond within the timeout period        | ✅ Yes |
+### Network/Connection Errors
 
-### Request/Configuration Errors (Non-Retryable)
+| Error Code     | Meaning                                                                  | `processAxiosError` result  | Retried? |
+| -------------- | ------------------------------------------------------------------------ | --------------------------- | -------- |
+| `ERR_NETWORK`  | Network connection failed (no internet, DNS failure, connection refused) | EXTERNAL_SERVICE_ERROR, 503 | Yes      |
+| `ECONNABORTED` | Connection aborted - request was terminated before completion            | EXTERNAL_SERVICE_ERROR, 503 | Yes      |
+| `ETIMEDOUT`    | Request timeout - server didn't respond within the timeout period        | EXTERNAL_SERVICE_ERROR, 503 | Yes      |
 
-| Error Code             | Meaning                                                  | Retry? |
-| ---------------------- | -------------------------------------------------------- | ------ |
-| `ERR_BAD_REQUEST`      | Malformed HTTP request or bad request syntax             | ❌ No  |
-| `ERR_INVALID_URL`      | URL provided is invalid or malformed                     | ❌ No  |
-| `ERR_BAD_OPTION`       | Invalid Axios configuration option used                  | ❌ No  |
-| `ERR_BAD_OPTION_VALUE` | Invalid value provided for an Axios configuration option | ❌ No  |
+### Request/Configuration Errors
 
-### Response Errors (Non-Retryable)
+| Error Code             | Meaning                                                  | `processAxiosError` result                             | Retried?                                     |
+| ---------------------- | -------------------------------------------------------- | ------------------------------------------------------ | -------------------------------------------- |
+| `ERR_BAD_REQUEST`      | A 4xx response from the server                           | the server's error passed through, e.g. NOT_FOUND, 404 | No, unless the body is malformed - see below |
+| `ERR_INVALID_URL`      | URL provided is invalid or malformed                     | EXTERNAL_SERVICE_ERROR, 503 (no response)              | Yes                                          |
+| `ERR_BAD_OPTION`       | Invalid Axios configuration option used                  | EXTERNAL_SERVICE_ERROR, 503 (no response)              | Yes                                          |
+| `ERR_BAD_OPTION_VALUE` | Invalid value provided for an Axios configuration option | EXTERNAL_SERVICE_ERROR, 503 (no response)              | Yes                                          |
 
-| Error Code         | Meaning                                                 | Retry? |
-| ------------------ | ------------------------------------------------------- | ------ |
-| `ERR_BAD_RESPONSE` | Server response is in an unexpected format or corrupted | ❌ No  |
+Both pass-through rows — `ERR_BAD_REQUEST` here and `ERR_BAD_RESPONSE` below —
+depend on the body: if `response.data.error` is not a well-formed `AppError`,
+they fall to the `INTERNAL_ERROR, 500` catch-all instead, and a 500 does retry.
 
-### Redirect Errors (Non-Retryable)
+### Response Errors
 
-| Error Code                  | Meaning                                          | Retry? |
-| --------------------------- | ------------------------------------------------ | ------ |
-| `ERR_FR_TOO_MANY_REDIRECTS` | Too many HTTP redirects (infinite redirect loop) | ❌ No  |
+| Error Code         | Meaning                        | `processAxiosError` result                               | Retried? |
+| ------------------ | ------------------------------ | -------------------------------------------------------- | -------- |
+| `ERR_BAD_RESPONSE` | A 5xx response from the server | the server's error passed through, or INTERNAL_ERROR 500 | Yes      |
 
-### Operation Errors (Non-Retryable)
+### Redirect Errors
 
-| Error Code        | Meaning                                                        | Retry? |
-| ----------------- | -------------------------------------------------------------- | ------ |
-| `ERR_CANCELED`    | Request was explicitly canceled via CancelToken or AbortSignal | ❌ No  |
-| `ERR_NOT_SUPPORT` | Operation is not supported in the current environment          | ❌ No  |
-| `ERR_DEPRECATED`  | Deprecated Axios feature used                                  | ❌ No  |
+| Error Code                  | Meaning                                          | `processAxiosError` result                | Retried? |
+| --------------------------- | ------------------------------------------------ | ----------------------------------------- | -------- |
+| `ERR_FR_TOO_MANY_REDIRECTS` | Too many HTTP redirects (infinite redirect loop) | EXTERNAL_SERVICE_ERROR, 503 (no response) | Yes      |
 
-**Usage in React Query:** The `retry` callback in [apps/client/src/lib/react-query.ts](apps/client/src/lib/react-query.ts) uses this information to decide whether to retry failed requests.
+### Operation Errors
+
+| Error Code        | Meaning                                                        | `processAxiosError` result                | Retried?                        |
+| ----------------- | -------------------------------------------------------------- | ----------------------------------------- | ------------------------------- |
+| `ERR_CANCELED`    | Request was explicitly canceled via CancelToken or AbortSignal | EXTERNAL_SERVICE_ERROR, 503 (no response) | n/a - a cancel is not a failure |
+| `ERR_NOT_SUPPORT` | Operation is not supported in the current environment          | EXTERNAL_SERVICE_ERROR, 503 (no response) | Yes                             |
+| `ERR_DEPRECATED`  | Deprecated Axios feature used                                  | EXTERNAL_SERVICE_ERROR, 503 (no response) | Yes                             |
 
 ### 3. Client-Side Validation Errors (Zod)
 
@@ -237,7 +247,8 @@ undefined;
 │ Location: apps/client/src/lib/react-query.ts                       │
 │ Function: retry callback                                            │
 │                                                                     │
-│ Action: classifyAxiosError(error) // For retry decision only       │
+│ Action: processAxiosError(error) // full classification; the        │
+│         retry callback reads only .statusCode off the result        │
 │ Result: status = 404 → Don't retry (4xx = client error)            │
 │                                                                     │
 │ Then: throwOnError: true → Throw error to ErrorBoundary            │
@@ -297,7 +308,7 @@ undefined;
 │ Code:                                                               │
 │   const error = useRouteError();                                    │
 │   const normalizedError = normalizeError(error); // NORMALIZATION  │
-│   let message = getErrorMessage(normalizedError);                   │
+│   let message = normalizedError.message;                            │
 │                                                                     │
 │ Why normalize again: Defensive - error might be thrown from loader │
 │ without normalization, or might be React Router Response error     │
@@ -341,8 +352,8 @@ undefined;
 ┌─────────────────────────────────────────────────────────────────────┐
 │ 3. REACT QUERY CATCHES ERROR                                        │
 ├─────────────────────────────────────────────────────────────────────┤
-│ Action: classifyAxiosError(error)                                   │
-│ Result: No response → Retry up to 2 times (network errors retry)   │
+│ Action: processAxiosError(error)                                    │
+│ Result: No response → 503 → not 4xx → retry up to 2 times        │
 │                                                                     │
 │ After retries exhausted: throwOnError: true → Throw to boundary    │
 └─────────────────────────────────────────────────────────────────────┘
@@ -352,7 +363,7 @@ undefined;
 ├─────────────────────────────────────────────────────────────────────┤
 │ Input: AxiosError with no response                                  │
 │                                                                     │
-│ classifyAxiosError() logic:                                         │
+│ processAxiosError() logic:                                          │
 │   if (error.code === "ERR_NETWORK" || !error.response) {           │
 │     return new AppError(                                            │
 │       "Network connection failed...",                               │
@@ -548,7 +559,7 @@ undefined;
 
 ### Point 2: Axios Error → AppError
 
-**Location:** `classifyAxiosError()` in `apps/client/src/lib/errors/errors.ts`
+**Location:** `processAxiosError()` in `apps/client/src/lib/errors/errors.ts`
 
 **Before:**
 
@@ -730,7 +741,7 @@ const normalizedError = normalizeError(error); // ← Defensive normalization
 
 ```typescript
 retry: (failureCount, error) => {
-  const classifiedError = classifyAxiosError(error); // ← For retry logic
+  const classifiedError = processAxiosError(error as AxiosError<ErrorResponse>); // ← Same classification as everywhere else
   const status = classifiedError.statusCode;
   if (status >= 400 && status < 500) return false; // Don't retry
   return failureCount < 2;
@@ -749,7 +760,7 @@ Error Occurs
     │            ↓
     │       React Query catches raw AxiosError
     │            ↓
-    │       Decides retry (calls classifyAxiosError for status only)
+    │       Decides retry (processAxiosError, then reads .statusCode)
     │            ↓
     │       throwOnError: true → Throw to boundary
     │            ↓
@@ -803,7 +814,7 @@ All boundaries work with `AppError` after normalization, simplifying logic:
 
 ```typescript
 const normalizedError = normalizeError(error); // Now guaranteed AppError
-const message = getErrorMessage(normalizedError); // Type-safe
+const message = normalizedError.message; // Type-safe
 if (isCriticalError(normalizedError)) { ... } // Type-safe
 ```
 

--- a/apps/client/docs/ERROR_FLOW.md
+++ b/apps/client/docs/ERROR_FLOW.md
@@ -84,15 +84,14 @@ Axios makes HTTP request
     └─→ HTTP Error (any status)
             ↓
         Axios Interceptor (response.use())
-            ├─ Classify error via _classifyAxiosError()
-            ├─ If 401: Set redirectTo in error.details
-            └─ Throw AppError with ErrorCode
+            └─ Reject the raw AxiosError; no classification here
                 ↓
-            React Query catches AppError
-                ├─ Check status code for retry decision
-                ├─ If 4xx: No retry, throw to component
-                ├─ If 5xx: Retry up to 2x with backoff
-                └─ After retries exhausted OR 4xx: throw to ErrorBoundary
+            React Query catches the raw AxiosError
+                ├─ retry callback: processAxiosError() → read statusCode
+                ├─ If 4xx (or a Zod error): No retry
+                ├─ Otherwise: Retry up to 2x with backoff
+                └─ After retries exhausted OR 4xx: throw the raw error
+                   to the ErrorBoundary
                     ↓
                 ErrorBoundary catches error
                     ├─ Call normalizeError(error) → AppError
@@ -104,8 +103,8 @@ Axios makes HTTP request
 
 **Key characteristics of current flow:**
 
-- ✅ Axios classifies errors at transport layer (produces AppError)
-- ✅ React Query handles retry strategy based on status code
+- ✅ Axios is pure transport; it rejects the raw error unclassified
+- ✅ React Query handles retry strategy based on the classified status code
 - ✅ All errors normalized via `normalizeError()` before processing
 - ✅ Components/queries decide toast and UI handling
 - ✅ Errors bubble to appropriate boundary
@@ -199,7 +198,6 @@ Axios makes HTTP request
 
 **Behavior:**
 
-- For 401: Sets `redirectTo` flag on error object
 - For all errors: Throws raw HTTP error (no classification)
 - No toasts, no retries, no UI decisions
 - Pure transport: just passes error up
@@ -210,7 +208,7 @@ Axios makes HTTP request
 
 **Location:** Data fetching layer
 
-**Purpose:** Cache management, retry logic, and error classification
+**Purpose:** Cache management and retry logic
 
 **Catches:**
 
@@ -220,12 +218,14 @@ Axios makes HTTP request
 
 **Behavior:**
 
-- Classifies error: `classifyHttpError(error)` → `AppError`
-- Decides retry based on classification:
-  - 4xx errors: No retry (user's fault, fail fast)
-  - 5xx errors: Retry up to 2x with exponential backoff
-- Throws classified `AppError` to ErrorBoundary (if `throwOnError: true`)
-- Stores classified error in query state (if `throwOnError: false`)
+- Classifies error: `processAxiosError(error)` → `AppError`, then reads only
+  its `statusCode`; the `AppError` itself is discarded
+- Decides retry from that status:
+  - 4xx errors, and client-side Zod errors: No retry (fail fast)
+  - Everything else: Retry up to 2x with exponential backoff
+- Throws the **raw** error to ErrorBoundary (if `throwOnError: true`), which
+  normalizes it there
+- Stores the raw error in query state (if `throwOnError: false`)
 - Does NOT handle toasts; components decide
 
 **Code:** `apps/client/src/lib/react-query.ts`
@@ -238,7 +238,7 @@ All errors are normalized through a **single entry point** before any processing
 // lib/errors/errors.ts
 export function normalizeError(error: unknown): AppError {
   if (isAxiosError(error)) {
-    return _classifyAxiosError(error); // HTTP classification
+    return processAxiosError(error); // HTTP classification
   } else if (error instanceof ZodError) {
     // Validation errors from forms
     const message = `Validation failed: ${error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")}`;
@@ -534,15 +534,16 @@ isAxiosError(error): boolean
 // Use this FIRST to differentiate axios-specific errors from generic errors
 
 // Check if error is AppError (vs generic Error)
+// Module-private: used inside processAxiosError, never exported
 isAppError(error): boolean
 
 // Check if error is critical (should bubble to parent boundary)
 isCriticalError(error): boolean
-// Critical codes: UNAUTHORIZED, INVALID_TOKEN, TOKEN_EXPIRED, VALIDATION_ERROR
-
-// Get user-friendly message from error
-getErrorMessage(error): string
+// Critical: INTERNAL_ERROR, EXTERNAL_SERVICE_ERROR, or any statusCode >= 500
 ```
+
+The module exports exactly four things: `isClientZodError`, `processAxiosError`,
+`isCriticalError` and `normalizeError`.
 
 **Axios Error Codes Reference:**
 
@@ -571,15 +572,15 @@ Error Occurs in Component
     │   │
     │   ├─ isCriticalError(error)?
     │   │   ├─ YES → Re-throw to parent (RouteErrorBoundary)
-    │   │   │        Critical error codes:
-    │   │   │        - UNAUTHORIZED (auth required)
-    │   │   │        - INVALID_TOKEN (session invalid)
-    │   │   │        - TOKEN_EXPIRED (token expired)
-    │   │   │        - VALIDATION_ERROR (form errors)
+    │   │   │        Critical when the code is:
+    │   │   │        - INTERNAL_ERROR (server error from a loader/API)
+    │   │   │        - EXTERNAL_SERVICE_ERROR (network failure)
+    │   │   │        or when statusCode >= 500, whatever the code
     │   │   │
     │   │   └─ NO → Handle locally
     │   │            Display: title, message, retry button
-    │   │            Examples: 404 Not Found, 500 Server Error
+    │   │            Examples: 404 Not Found, 401 Unauthorized,
+    │   │                      422 Validation Error
     │
     ├─ Route-level ErrorBoundary (RouteErrorBoundary)
     │   │
@@ -588,9 +589,11 @@ Error Occurs in Component
     │   │            - Status 404 → "Page Not Found"
     │   │            - Status 400 → "Bad Request"
     │   │
-    │   ├─ isAppError()?
-    │   │   └─ YES → Extract statusCode and message
-    │   │            - Status 404 → title: "Not Found"
+    │   ├─ Anything else → normalizeError(error) → AppError
+    │   │   └─ Extract statusCode and message
+    │   │            - Code NOT_FOUND → title: "Not Found"
+    │   │            - isCriticalError() → title: "Critical Application Error"
+    │   │              (message sanitized)
     │   │            - Other → title: "Request Failed"
     │   │
     │   ├─ Unknown Error
@@ -1312,7 +1315,7 @@ export function RouteErrorBoundary() {
 interceptor.response.use(
   (response) => response.data,
   (error) => {
-    throw classifyHttpError(error); // That's it!
+    throw processAxiosError(error); // That's it!
   },
 );
 ```
@@ -1411,14 +1414,14 @@ Moving from current state (v1) to target state (v2) can be done in phases:
 
 ## Key Components
 
-### apps/client/src/lib/errors.ts
+### apps/client/src/lib/errors/errors.ts
 
-**Functions:**
+**Exports:**
 
-- `classifyHttpError(axiosError): AppError` - Classify raw HTTP error
-- `isAppError(error): boolean` - Type guard for AppError
+- `normalizeError(error): AppError` - Single entry point; normalizes any error
+- `processAxiosError(axiosError): AppError` - Classify an Axios error
+- `isClientZodError(error): error is ZodError` - Type guard for Zod errors
 - `isCriticalError(error): boolean` - Check if error is critical
-- `getErrorMessage(error): string` - Get user-friendly message
 
 ### apps/client/src/lib/api-client.ts
 
@@ -1456,27 +1459,27 @@ useQuery(loginQueryOptions)
     ↓
 POST /auth/login { email, password }
     ↓
-Server returns 401 UNAUTHORIZED { code: "UNAUTHORIZED" }
+Server returns 401 with { error: { code: "UNAUTHORIZED", ... } }
     ↓
-Axios interceptor catches response error
+Axios interceptor rejects the raw AxiosError (code ERR_BAD_REQUEST)
     ↓
-classifyHttpError() → AppError(UNAUTHORIZED, 401, "Invalid credentials")
+React Query retry callback: processAxiosError() → 401 → 4xx, no retry
     ↓
-Throw AppError to React Query
+throwOnError: true → Throw the raw AxiosError to the ErrorBoundary
     ↓
-React Query throwOnError: true → Throw error to ErrorBoundary
+LoginForm ErrorBoundary catches, calls normalizeError() → processAxiosError()
     ↓
-LoginForm ErrorBoundary catches
+Pass-through branch: response.data.error is a well-formed AppError
     ↓
-Check: isCriticalError(error)? → YES (UNAUTHORIZED is critical)
+AppError(UNAUTHORIZED, 401, "Invalid credentials")
+    (the code comes from the response body, never from the 401 status)
     ↓
-Re-throw to parent (RouteErrorBoundary)
+Check: isCriticalError(error)? → NO
+       UNAUTHORIZED is not in criticalCodes, and 401 < 500
     ↓
-RouteErrorBoundary catches
+Handle locally with ErrorBlock
     ↓
-Show: "Invalid email or password"
-    ↓
-Display login form again
+Show: "Invalid email or password" beside the login form
 ```
 
 ### Example 2: 5xx Server Error During Product Load
@@ -1488,37 +1491,31 @@ Route loader calls useQuery(getProductsQueryOptions)
     ↓
 GET /api/products
     ↓
-Server returns 500 INTERNAL_ERROR
+Server returns 500 with { error: { code: "INTERNAL_ERROR", ... } }
     ↓
-Axios interceptor catches
+Axios interceptor rejects the raw AxiosError (code ERR_BAD_RESPONSE)
     ↓
-Show toast: "Server error. Retrying..."
-    ↓
-classifyHttpError() → AppError(INTERNAL_ERROR, 500)
-    ↓
-Throw AppError to React Query
-    ↓
-React Query: Is 5xx? → Retry (up to 2 times)
+React Query retry callback: processAxiosError() → 500 → not 4xx, retry
     │
     ├─ Retry 1: Still 500
     ├─ Wait 1s
     ├─ Retry 2: Still 500
     ├─ Wait 2s
-    └─ Give up, still errored
+    └─ Give up (failureCount === 2), still errored
     ↓
-throwOnError: true → Throw error to ErrorBoundary
+throwOnError: true → Throw the raw AxiosError to the ErrorBoundary
     ↓
-ProductList ErrorBoundary catches
+ProductList ErrorBoundary catches, calls normalizeError()
     ↓
-Check: isCriticalError(error)? → NO (INTERNAL_ERROR is not critical)
+Pass-through branch → AppError(INTERNAL_ERROR, 500)
     ↓
-Render error inline with ErrorBlock
+Check: isCriticalError(error)? → YES
+       INTERNAL_ERROR is in criticalCodes, and 500 >= 500
     ↓
-Show: "Failed to load products. Please try again."
+Re-throw to parent (RouteErrorBoundary)
     ↓
-Show retry button
-    ↓
-User clicks retry → refetch happens
+Show: "Critical Application Error", message sanitized to
+      "A critical error occurred. Please try again later."
 ```
 
 ### Example 3: Validation Error on Form Submit
@@ -1528,36 +1525,29 @@ User submits form with invalid data
     ↓
 Form validation component checks fields
     ↓
-isMutation(submitFormMutation)
+useMutation(submitFormMutation) with throwOnError: false
     ↓
 POST /api/user/update { ...invalid data }
     ↓
-Server returns 422 VALIDATION_ERROR with field errors
+Server returns 422 with { error: { code: "VALIDATION_ERROR", details: [...] } }
     ├─ "email" → "Invalid email format"
     ├─ "age" → "Must be 18 or older"
     └─ "name" → "Required"
     ↓
-Axios interceptor catches
+Axios interceptor rejects the raw AxiosError (code ERR_BAD_REQUEST)
     ↓
-No toast (4xx error)
+Mutation rejects; no retry (mutations do not retry by default)
     ↓
-classifyHttpError() → AppError(VALIDATION_ERROR, 422, "Invalid input")
+Component catches and calls normalizeError()
     ↓
-AppError.details = { email, age, name } (field errors)
+Pass-through branch → AppError(VALIDATION_ERROR, 422, "Invalid input")
+    with details carried over from the response body
+    (the code comes from the body, never from the 422 status)
     ↓
-Throw AppError to React Query
+Check: isCriticalError(error)? → NO
+       VALIDATION_ERROR is not in criticalCodes, and 422 < 500
     ↓
-React Query: Is 4xx? → No retry
-    ↓
-throwOnError: true → Throw error to ErrorBoundary
-    ↓
-Form component ErrorBoundary catches
-    ↓
-Check: isCriticalError(error)? → YES (VALIDATION_ERROR is critical)
-    ↓
-Re-throw to parent form boundary
-    ↓
-Parent can access error.details for field-level errors
+Handle locally: branch on error.code, read error.details
     ↓
 Show field-level errors next to inputs
     ↓
@@ -1581,29 +1571,27 @@ React Query starts refetch (refetchOnMount: "stale")
     ↓
 GET /api/products/:id (no network)
     ↓
-Axios throws ERR_NETWORK
+Axios throws ERR_NETWORK (no error.response)
     ↓
-Axios interceptor catches
+Axios interceptor rejects the raw AxiosError
     ↓
-classifyHttpError() → AppError(EXTERNAL_SERVICE_ERROR, 503)
-    ↓
-Show toast: "Network connection lost..."
-    ↓
-Throw AppError to React Query
-    ↓
-React Query: Is network error? → Retry (up to 2x)
+React Query retry callback: processAxiosError() → 503 → not 4xx, retry
     │
     ├─ Retry 1: Still no network
     ├─ Wait 1s
     ├─ Retry 2: Network restored!
     └─ Success
     ↓
-Toast updates: "Connection restored!"
-    ↓
-Data refetches successfully
+Data refetches successfully; no error ever reaches a boundary
     ↓
 Component shows updated data
 ```
+
+Had the retries been exhausted instead, the boundary's `normalizeError()`
+would produce `AppError(EXTERNAL_SERVICE_ERROR, 503)`, and
+`isCriticalError()` returns **YES** for it — it is in `criticalCodes`, and
+503 >= 500 — so the error re-throws to `RouteErrorBoundary` rather than
+rendering inline.
 
 ## Development vs Production Errors
 


### PR DESCRIPTION
Closes #182.

The client error docs named three functions that do not exist (`classifyHttpError`, `classifyAxiosError`, `_classifyAxiosError`) for the one that does (`processAxiosError`), listed two non-existent exports, and documented `isCriticalError` as its own inverse. Documents only — the diff is four `.md` files, no source touched.

## Changes

1. **Renames.** Every `classifyHttpError` / `classifyAxiosError` / `_classifyAxiosError` is gone from `ERROR_FLOW.md`, `COMPONENT_ERROR_PATTERNS.md`, `ERROR_CHAIN_MAPPING.md` and `.github/copilot-instructions.md`.
2. **Phantom exports.** `getErrorMessage` deleted; `isAppError` marked module-private and dropped from the export list, which now names the four real exports (`isClientZodError`, `processAxiosError`, `isCriticalError`, `normalizeError`).
3. **The four worked examples** rewritten — the code comes from the response body via the pass-through branch, not from the HTTP status, matching the tree #179 rewrote.
4. **`isCriticalError`.** Code list and boundary-hierarchy tree corrected to `INTERNAL_ERROR` / `EXTERNAL_SERVICE_ERROR` / `statusCode >= 500`; the three inverted verdicts flipped; the "500 Server Error" non-critical example replaced.
5. **The axios retry table** in `ERROR_CHAIN_MAPPING.md` rebuilt around what `react-query.ts` actually does. Its old "Retryable / Non-Retryable" grouping came from axios' own semantics and was wrong for five rows — `ERR_BAD_RESPONSE`, `ERR_INVALID_URL`, `ERR_FR_TOO_MANY_REDIRECTS`, `ERR_BAD_OPTION` and `ERR_BAD_OPTION_VALUE` all classify to 503 or a 5xx and do retry.

## Two judgement calls worth a look

**Deviation from item 1.** Six snippets in `COMPONENT_ERROR_PATTERNS.md` classify `query.error` or a caught `error` — both `unknown`. `processAxiosError` takes `AxiosError<ErrorResponse>`, so a literal rename would have left six snippets that do not type-check. Those name `normalizeError` instead, imported from `@/lib/errors/errors` (there is no barrel at `@/lib/errors`). `processAxiosError` stayed where the doc really means the retry handler or the interceptor.

**Scope beyond the ticket's listed lines.** Renaming into the flow diagram and the Layer 4/5 sections exposed a second self-contradiction of exactly the #179 kind: they had the axios interceptor classifying errors and setting a `redirectTo` that exists nowhere in `apps/client/src`, while the same file's Layer 4 three lines below already said "pure transport: just passes error up". Rather than leave a contradiction with a correct function name freshly planted in it, the diagram, those bullets and the matching `copilot-instructions.md` bullets were fixed too. Revert those hunks if they would rather go in their own ticket.

## Follow-ups filed

- #184 — `ERROR_FLOW.md` PART 5 and PART 7 snippets still call the now-module-private `isAppError`.
- #185 — `isCriticalError` contradicts its own docstring: auth and token failures are documented as critical but are not. Needs a decision, not a patch.

## Verification

- `pnpm format:check` — clean
- `git grep -n "classifyHttpError\|classifyAxiosError" -- '*.md' '.github'` — no hits
- `git grep -n "getErrorMessage" -- '*.md'` — no hits
- `pnpm test` — full suite passed
- Manual: every `isCriticalError` verdict in the docs checked against `errors.ts` lines 80-91 for that code and status

🤖 Generated with [Claude Code](https://claude.com/claude-code)