### PR TITLE
fix: split isAuthError out of isCriticalError and redirect dead sessions to login

### DIFF
--- a/apps/client/docs/COMPONENT_ERROR_PATTERNS.md
+++ b/apps/client/docs/COMPONENT_ERROR_PATTERNS.md
@@ -581,11 +581,11 @@ describe('ProductList error handling', () => {
 
 ## Summary
 
-| Layer             | Responsibility                                     | Does NOT Do                              |
-| ----------------- | -------------------------------------------------- | ---------------------------------------- |
-| **Axios**         | Transport only; handle 401 redirects               | No classification, no toasts, no retries |
-| **React Query**   | Classify errors; decide retries; throw if critical | Handle UI; show toasts                   |
-| **Component**     | Classify errors; show inline/toast; error handling | Make HTTP requests directly              |
-| **ErrorBoundary** | Catch thrown errors; show error page               | Handle optional/background errors        |
+| Layer             | Responsibility                                     | Does NOT Do                                            |
+| ----------------- | -------------------------------------------------- | ------------------------------------------------------ |
+| **Axios**         | Transport only                                     | No classification, no toasts, no retries, no redirects |
+| **React Query**   | Classify errors; decide retries; throw if critical | Handle UI; show toasts                                 |
+| **Component**     | Classify errors; show inline/toast; error handling | Make HTTP requests directly                            |
+| **ErrorBoundary** | Catch thrown errors; show error page               | Handle optional/background errors                      |
 
-**Last Updated:** December 18, 2025
+**Last Updated:** September 6, 2026

--- a/apps/client/docs/ERROR_CHAIN_MAPPING.md
+++ b/apps/client/docs/ERROR_CHAIN_MAPPING.md
@@ -288,6 +288,9 @@ undefined;
 │                                                                     │
 │ Code:                                                               │
 │   const normalizedError = normalizeError(error); // NORMALIZATION  │
+│   if (isAuthError(normalizedError)) {                              │
+│     return <RedirectToLogin />; // Dead session, go sign in        │
+│   }                                                                 │
 │   if (isCriticalError(normalizedError)) {                          │
 │     throw normalizedError; // Re-throw to RouteErrorBoundary       │
 │   }                                                                 │
@@ -721,6 +724,7 @@ try {
 ```typescript
 FallbackComponent={({ error }) => {
   const normalizedError = normalizeError(error); // ← Normalize caught error
+  if (isAuthError(normalizedError)) return <RedirectToLogin />;
   if (isCriticalError(normalizedError)) throw normalizedError;
   return <ErrorBlock message={normalizedError.message} />;
 }}
@@ -832,4 +836,4 @@ if (isCriticalError(normalizedError)) { ... } // Type-safe
 
 ---
 
-**Last Updated:** December 21, 2025
+**Last Updated:** September 6, 2026

--- a/apps/client/docs/ERROR_FLOW.md
+++ b/apps/client/docs/ERROR_FLOW.md
@@ -49,12 +49,13 @@ The current implementation uses a **5-layer error handling approach** without ce
 │                                                                    │
 │  Layer 3: Component-level ErrorBoundary (ErrorBlock)              │
 │           └─ Catches: Feature-specific errors, query errors       │
-│           └─ Re-throws: Critical errors (auth, validation)        │
+│           └─ Re-throws: Critical errors                           │
+│           └─ Redirects: Auth failures, to the login page          │
 │           └─ STATUS: ✅ Implemented                               │
 │                                                                    │
 │  Layer 4: API Client (Axios Interceptor)                          │
 │           └─ Classifies: HTTP errors → AppError                   │
-│           └─ Handles: 401 redirects; classification only (no UI)  │
+│           └─ Classification only: no redirects, no UI             │
 │           └─ STATUS: ✅ Implemented                               │
 │                                                                    │
 │  Layer 5: React Query                                             │
@@ -173,14 +174,18 @@ Axios makes HTTP request
 
 - Shows inline error UI
 - Offers retry button
+- Redirects auth failures to the login page
 - Re-throws critical errors to parent
 - Keeps rest of app functional
 
-**Code:** `apps/client/src/components/errors/ErrorBlock.tsx`
+**Code:** `apps/client/src/components/errors/error-block.tsx`
 
-**Re-throw rule:**
+**Classification rule:**
 
-- Catches error and checks `isCriticalError(error)`
+- Catches error and checks `isAuthError(error)` first
+- If YES → Render `RedirectToLogin` (no retry button; a retry would reuse the
+  same dead cookie)
+- Otherwise checks `isCriticalError(error)`
 - If YES → Re-throw (bubbles to RouteErrorBoundary)
 - If NO → Handle locally with inline UI
 
@@ -361,10 +366,12 @@ export const FeaturedSection = () => {
 
 1. Catch error from child component
 2. Call `normalizeError(error)` → consistent AppError
-3. Check `isCriticalError(normalizedError)` → DEFENSIVE re-throw
+3. Check `isAuthError(normalizedError)` → render `RedirectToLogin`
+   - The session is dead; a "Retry" button would refetch with the same cookie
+4. Check `isCriticalError(normalizedError)` → DEFENSIVE re-throw
    - ⚠️ **This is a safety net**: Critical errors should fail in loaders
    - If we reach here, we forgot to handle something → rethrow to RouteErrorBoundary
-4. For non-critical errors: Render ErrorBlock with title, message, "Retry" button
+5. For everything else: Render ErrorBlock with title, message, "Retry" button
 
 ---
 
@@ -540,10 +547,19 @@ isAppError(error): boolean
 // Check if error is critical (should bubble to parent boundary)
 isCriticalError(error): boolean
 // Critical: INTERNAL_ERROR, EXTERNAL_SERVICE_ERROR, or any statusCode >= 500
+
+// Check if the session is dead (should redirect to login)
+isAuthError(error): boolean
+// Auth: UNAUTHORIZED, INVALID_TOKEN, TOKEN_EXPIRED
+// NOT INVALID_CREDENTIALS - a rejected login is not an expired session
 ```
 
-The module exports exactly four things: `isClientZodError`, `processAxiosError`,
-`isCriticalError` and `normalizeError`.
+The module exports exactly five things: `isClientZodError`, `processAxiosError`,
+`isCriticalError`, `isAuthError` and `normalizeError`.
+
+The two predicates are disjoint and neither subsumes the other: a critical error
+means the route cannot render, an auth error means the route could render for
+somebody who is signed in.
 
 **Axios Error Codes Reference:**
 
@@ -570,6 +586,17 @@ Error Occurs in Component
     │
     ├─ Component-level ErrorBoundary (ErrorBlock)
     │   │
+    │   ├─ isAuthError(error)?
+    │   │   ├─ YES → Render RedirectToLogin
+    │   │   │        Auth when the code is:
+    │   │   │        - UNAUTHORIZED (no or unusable session)
+    │   │   │        - INVALID_TOKEN (cookie does not verify)
+    │   │   │        - TOKEN_EXPIRED (cookie outlived its JWT)
+    │   │   │        Clears the cached auth status, then navigates to
+    │   │   │        /auth/login?redirectTo=<current location>
+    │   │   │
+    │   │   └─ NO → fall through
+    │   │
     │   ├─ isCriticalError(error)?
     │   │   ├─ YES → Re-throw to parent (RouteErrorBoundary)
     │   │   │        Critical when the code is:
@@ -579,8 +606,8 @@ Error Occurs in Component
     │   │   │
     │   │   └─ NO → Handle locally
     │   │            Display: title, message, retry button
-    │   │            Examples: 404 Not Found, 401 Unauthorized,
-    │   │                      422 Validation Error
+    │   │            Examples: 404 Not Found, 422 Validation Error,
+    │   │                      401 INVALID_CREDENTIALS
     │
     ├─ Route-level ErrorBoundary (RouteErrorBoundary)
     │   │
@@ -591,6 +618,7 @@ Error Occurs in Component
     │   │
     │   ├─ Anything else → normalizeError(error) → AppError
     │   │   └─ Extract statusCode and message
+    │   │            - isAuthError() → RedirectToLogin
     │   │            - Code NOT_FOUND → title: "Not Found"
     │   │            - isCriticalError() → title: "Critical Application Error"
     │   │              (message sanitized)
@@ -798,17 +826,18 @@ Check: Is this "optional-data" query?
     │
     └─ NO → Throw error
             ↓
-            ErrorBoundary catches (checks isCriticalError)
+            ErrorBoundary catches (checks isAuthError, then isCriticalError)
             ↓
+            If auth: Redirect to login
             If critical: Show error page
-            If not critical: ErrorBlock handles locally
+            Otherwise: ErrorBlock handles locally
 ```
 
 **Why throw all errors?**
 
 - Simpler error handling flow (ErrorBoundary hierarchy handles all cases)
 - Avoids duplicate error handling in every component
-- ErrorBoundary's `isCriticalError()` check determines final behavior
+- ErrorBoundary's `isAuthError()` / `isCriticalError()` checks determine final behavior
 - Components can still use `query.error` if they want to handle locally
 
 **When `throwOnError: false` (alternative approach):**
@@ -1383,6 +1412,9 @@ Moving from current state (v1) to target state (v2) can be done in phases:
 | ----------- | ---------------------- | ----------------------- | ------------------------ |
 | 422         | VALIDATION_ERROR       | Invalid input           | Fix and retry            |
 | 401         | UNAUTHORIZED           | Not authenticated       | Log in                   |
+| 401         | INVALID_TOKEN          | Cookie does not verify  | Log in                   |
+| 401         | TOKEN_EXPIRED          | Cookie outlived its JWT | Log in                   |
+| 401         | INVALID_CREDENTIALS    | Login attempt rejected  | Correct the form         |
 | 403         | FORBIDDEN              | Not authorized          | Contact support          |
 | 404         | NOT_FOUND              | Resource missing        | Navigate elsewhere       |
 | 500         | INTERNAL_ERROR         | Server error            | Retry or contact support |
@@ -1397,6 +1429,11 @@ Moving from current state (v1) to target state (v2) can be done in phases:
 - INVALID_TOKEN
 - TOKEN_EXPIRED
 - FORBIDDEN (403)
+
+The first three are what `isAuthError` matches: the session is dead and a
+redirect to login fixes it. `FORBIDDEN` is not — the session is fine, the user
+just may not do this — and neither is `INVALID_CREDENTIALS`, which belongs to
+the login form.
 
 **Validation (form errors)**
 
@@ -1422,6 +1459,7 @@ Moving from current state (v1) to target state (v2) can be done in phases:
 - `processAxiosError(axiosError): AppError` - Classify an Axios error
 - `isClientZodError(error): error is ZodError` - Type guard for Zod errors
 - `isCriticalError(error): boolean` - Check if error is critical
+- `isAuthError(error): boolean` - Check if the session is dead
 
 ### apps/client/src/lib/api-client.ts
 
@@ -1445,41 +1483,76 @@ Moving from current state (v1) to target state (v2) can be done in phases:
 - `MainErrorFallback` - Root error boundary UI
 - `RouteErrorBoundary` - Route-level error boundary
 - `ErrorBlock` - Feature-level error boundary
+- `SafeRenderWithErrorBlock` - Suspense + ErrorBoundary wrapper around a feature
+- `RedirectToLogin` - Clears the cached auth status, then navigates to login
 
 ## Error Flow Examples
 
 ### Example 1: Failed Login
 
+A rejected login never reaches an error boundary: it is a mutation, and the form
+reports it itself.
+
 ```
 User enters invalid password
     ↓
-Form submission
-    ↓
-useQuery(loginQueryOptions)
-    ↓
 POST /auth/login { email, password }
     ↓
-Server returns 401 with { error: { code: "UNAUTHORIZED", ... } }
+Server returns 401 with { error: { code: "INVALID_CREDENTIALS", ... } }
+    (and clears the jwt cookie)
     ↓
 Axios interceptor rejects the raw AxiosError (code ERR_BAD_REQUEST)
     ↓
-React Query retry callback: processAxiosError() → 401 → 4xx, no retry
+useLogin mutation: onError runs (mutations do not use throwOnError)
     ↓
-throwOnError: true → Throw the raw AxiosError to the ErrorBoundary
-    ↓
-LoginForm ErrorBoundary catches, calls normalizeError() → processAxiosError()
+LoginForm calls normalizeError() → processAxiosError()
     ↓
 Pass-through branch: response.data.error is a well-formed AppError
     ↓
-AppError(UNAUTHORIZED, 401, "Invalid credentials")
+AppError(INVALID_CREDENTIALS, 401, "Invalid email or password")
     (the code comes from the response body, never from the 401 status)
     ↓
-Check: isCriticalError(error)? → NO
-       UNAUTHORIZED is not in criticalCodes, and 401 < 500
+Show: a destructive toast, "Login Failed" + the server's message
     ↓
-Handle locally with ErrorBlock
+The user stays on the form and can try again
+```
+
+`INVALID_CREDENTIALS` is a 401 but is deliberately **not** an auth error by
+`isAuthError`. Signing in again is exactly what the user is already doing;
+redirecting them to the login page they are standing on would be a loop.
+
+### Example 1b: Expired Session on a Protected Query
+
+```
+User's cookie outlives its JWT (or the signing secret rotated)
     ↓
-Show: "Invalid email or password" beside the login form
+Cached auth status still says isAuthenticated: true (staleTime: Infinity)
+    ↓
+UserAreaLayout renders, useSuspenseQuery(getUserQueryOptions)
+    (in the component body, ABOVE the SafeRenderWithErrorBlock it renders,
+     so that boundary cannot catch this one)
+    ↓
+GET /api/v1/users/me
+    ↓
+Server returns 401 with { error: { code: "TOKEN_EXPIRED", ... } }
+    ↓
+React Query retry callback: 401 → 4xx, no retry
+    ↓
+throwOnError: true → Throw past the layout to the route errorElement,
+                     RouteErrorBoundary on the /account subtree
+    ↓
+normalizeError() → AppError(TOKEN_EXPIRED, 401)
+    ↓
+Check: isAuthError(error)? → YES
+    ↓
+RedirectToLogin: write isAuthenticated: false into the auth status cache,
+                 null the cached user, THEN navigate
+    (order matters - the auth layout's loader reads that cached status and
+     would bounce a stale `true` straight back to /account)
+    ↓
+Navigate to /auth/login?redirectTo=/account/profile
+    ↓
+User signs in; LoginForm reads redirectTo and returns them to /account/profile
 ```
 
 ### Example 2: 5xx Server Error During Product Load
@@ -1825,5 +1898,5 @@ When testing error handling, verify:
 
 ---
 
-**Last Updated:** December 20, 2025
+**Last Updated:** September 6, 2026
 **Status:** Current implementation complete (v1), Target state documented (v2)

--- a/apps/client/src/app/router.tsx
+++ b/apps/client/src/app/router.tsx
@@ -78,6 +78,7 @@ const createAppRouter = (queryClient: QueryClient) =>
                   convert(queryClient),
                 ),
               path: paths.account.root.path,
+              errorElement: <RouteErrorBoundary />,
               children: [
                 {
                   element: <Navigate to={paths.account.profile.path} replace />,

--- a/apps/client/src/components/errors/redirect-to-login.tsx
+++ b/apps/client/src/components/errors/redirect-to-login.tsx
@@ -1,0 +1,25 @@
+import { paths } from "@/config/paths";
+import { markSignedOut } from "@/lib/auth";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { Navigate, useLocation } from "react-router";
+
+/**
+ * Sends a dead session back to the login page, carrying the current location
+ * as `redirectTo` so signing in returns the user where they were.
+ */
+export const RedirectToLogin = () => {
+  const queryClient = useQueryClient();
+  const { pathname, search } = useLocation();
+  const [isSignedOut, setIsSignedOut] = useState(false);
+
+  useEffect(() => {
+    // Must land before the navigation: the auth layout's loader reads this.
+    markSignedOut(queryClient);
+    setIsSignedOut(true);
+  }, [queryClient]);
+
+  if (!isSignedOut) return null;
+
+  return <Navigate to={paths.auth.login.getHref(pathname + search)} replace />;
+};

--- a/apps/client/src/components/errors/route-error-boundary.tsx
+++ b/apps/client/src/components/errors/route-error-boundary.tsx
@@ -1,9 +1,14 @@
 import { Button } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
 import { paths } from "@/config/paths";
-import { isCriticalError, normalizeError } from "@/lib/errors/errors";
+import {
+  isAuthError,
+  isCriticalError,
+  normalizeError,
+} from "@/lib/errors/errors";
 import { ErrorCode } from "@repo/domain";
 import { isRouteErrorResponse, useNavigate, useRouteError } from "react-router";
+import { RedirectToLogin } from "./redirect-to-login";
 
 export function RouteErrorBoundary() {
   const error = useRouteError();
@@ -27,6 +32,12 @@ export function RouteErrorBoundary() {
   } else {
     // All other errors - normalize first
     const normalizedError = normalizeError(error);
+
+    // A dead session cannot be retried; only signing in again fixes it.
+    if (isAuthError(normalizedError)) {
+      return <RedirectToLogin />;
+    }
+
     statusCode = normalizedError.statusCode;
     title = "Request Failed";
     message = normalizedError.message;

--- a/apps/client/src/components/errors/safe-render-with-error-block.tsx
+++ b/apps/client/src/components/errors/safe-render-with-error-block.tsx
@@ -1,10 +1,15 @@
 import LoadingSpinner from "@/components/ui/loading-spinner";
 import { cn } from "@/lib/cn";
-import { isCriticalError, normalizeError } from "@/lib/errors/errors";
+import {
+  isAuthError,
+  isCriticalError,
+  normalizeError,
+} from "@/lib/errors/errors";
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
 import { PropsWithChildren, Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorBlock from "./error-block";
+import { RedirectToLogin } from "./redirect-to-login";
 
 type TSafeRenderWithErrorBlockProps = {
   title: string;
@@ -26,6 +31,10 @@ export const SafeRenderWithErrorBlock = ({
         <ErrorBoundary
           FallbackComponent={({ error, resetErrorBoundary }) => {
             const normalizedError = normalizeError(error);
+            // A dead session cannot be retried; only signing in again fixes it.
+            if (isAuthError(normalizedError)) {
+              return <RedirectToLogin />;
+            }
             // DEFENSIVE CHECK: Critical errors should be thrown from loaders using ensureQueryData()
             // and caught by RouteErrorBoundary. If a critical error reaches here, it means
             // we forgot to fail in the loader,rethrow it to prevent silent failures.

--- a/apps/client/src/components/layouts/content-layout/nav-bar/cart-button.tsx
+++ b/apps/client/src/components/layouts/content-layout/nav-bar/cart-button.tsx
@@ -1,0 +1,26 @@
+import CartIcon from "@/assets/icon-cart.svg?react";
+import { useCart } from "@/features/cart/api/get-cart";
+
+type TCartButtonProps = {
+  onOpen: () => void;
+};
+
+export const CartButton = ({ onOpen }: TCartButtonProps) => {
+  const { data: cart } = useCart();
+  const itemCount = cart?.data.itemCount ?? 0;
+
+  return (
+    <button
+      onClick={onOpen}
+      className="hover:*:fill-primary-500 focus-visible:*:fill-primary-500 relative cursor-pointer"
+      aria-label="Open cart"
+    >
+      <CartIcon title="cart icon" />
+      {itemCount > 0 ? (
+        <span className="bg-primary-500 absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full text-xs font-bold text-white">
+          {itemCount}
+        </span>
+      ) : null}
+    </button>
+  );
+};

--- a/apps/client/src/components/layouts/content-layout/nav-bar/index.tsx
+++ b/apps/client/src/components/layouts/content-layout/nav-bar/index.tsx
@@ -1,15 +1,14 @@
-import CartIcon from "@/assets/icon-cart.svg?react";
 import Logo from "@/assets/logo.svg?react";
 import { SafeRenderWithErrorBlock } from "@/components/errors/safe-render-with-error-block";
 import NavBarDialog from "@/components/layouts/content-layout/nav-bar/nav-bar-dialog";
 import { Container } from "@/components/ui/container";
 import { paths } from "@/config/paths";
-import { useCart } from "@/features/cart/api/get-cart";
 import { MiniCart } from "@/features/cart/components/mini-cart";
 import useMedia from "@/hooks/useMedia";
 import { HomeIcon } from "lucide-react";
 import { useState } from "react";
 import { Link } from "react-router";
+import { CartButton } from "./cart-button";
 import { NavLinks } from "./nav-links";
 import { UserDropdown } from "./user-dropdown";
 import LoadingSpinner from "@/components/ui/loading-spinner";
@@ -18,7 +17,6 @@ export const Navbar = () => {
   const isLarge = useMedia("lg");
   const isSmall = useMedia("sm");
   const [cartOpen, setCartOpen] = useState(false);
-  const { data: cart } = useCart();
 
   return (
     <>
@@ -54,23 +52,19 @@ export const Navbar = () => {
               >
                 <UserDropdown />
               </SafeRenderWithErrorBlock>
-              <button
-                onClick={() => setCartOpen(true)}
-                className="hover:*:fill-primary-500 focus-visible:*:fill-primary-500 relative cursor-pointer"
-                aria-label="Open cart"
+              <SafeRenderWithErrorBlock
+                title="Error loading cart"
+                fallback={<LoadingSpinner size="md" />}
               >
-                <CartIcon title="cart icon" />
-                {cart?.data.itemCount && cart.data.itemCount > 0 ? (
-                  <span className="bg-primary-500 absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full text-xs font-bold text-white">
-                    {cart.data.itemCount}
-                  </span>
-                ) : null}
-              </button>
+                <CartButton onOpen={() => setCartOpen(true)} />
+              </SafeRenderWithErrorBlock>
             </div>
           </div>
         </Container>
       </nav>
-      <MiniCart open={cartOpen} onOpenChange={setCartOpen} />
+      <SafeRenderWithErrorBlock title="Error loading cart">
+        <MiniCart open={cartOpen} onOpenChange={setCartOpen} />
+      </SafeRenderWithErrorBlock>
     </>
   );
 };

--- a/apps/client/src/lib/auth/index.tsx
+++ b/apps/client/src/lib/auth/index.tsx
@@ -51,6 +51,13 @@ export const getAuthStatusQueryOptions = () =>
     select: (data) => data?.data, // Return only the user DTO
   });
 
+/** Record locally that the session is over; the cookie behind it is already dead. */
+export const markSignedOut = (queryClient: QueryClient) =>
+  queryClient.setQueryData<AuthCheckStatusResponse>(
+    [AUTH_STATUS_QUERY_KEY],
+    (previous) => previous && { ...previous, data: { isAuthenticated: false } },
+  );
+
 // ** Get User (Me)
 
 type TGetUser = TBaseHandler<UserDTOResponse>;

--- a/apps/client/src/lib/errors/errors.ts
+++ b/apps/client/src/lib/errors/errors.ts
@@ -75,20 +75,37 @@ export function processAxiosError(error: AxiosError<ErrorResponse>): AppError {
 
 /**
  * Check if error is critical and should bubble up to router boundary.
- * Critical errors: env validation, auth failures, token issues, internal server errors.
+ * Critical means the route cannot render: internal server errors, network
+ * failures, and anything 5xx. Auth failures are not critical - they are
+ * recoverable by signing in again, and belong to `isAuthError`.
  */
 export function isCriticalError(error: AppError): boolean {
-  // Only data-loading and auth errors are critical and should crash the route.
+  // Only data-loading errors are critical and should crash the route.
   // Component composition errors and other 4xx errors should be caught by SafeRenderWithErrorBlock.
-  const criticalCodes = [
+  const criticalCodes: ErrorCode[] = [
     ErrorCode.INTERNAL_ERROR, // Server errors from loaders/API
     ErrorCode.EXTERNAL_SERVICE_ERROR, // Network issues from loaders
   ];
 
-  const isCriticalCode = criticalCodes.includes(error.code as ErrorCode);
+  const isCriticalCode = criticalCodes.includes(error.code);
   const isServerError = error.statusCode >= 500;
 
   return isCriticalCode || isServerError;
+}
+
+/**
+ * Check if error means the session is dead and the user has to sign in again.
+ * `INVALID_CREDENTIALS` is deliberately absent: it is a rejected login attempt,
+ * which the login form reports inline, not an expired session.
+ */
+export function isAuthError(error: AppError): boolean {
+  const authCodes: ErrorCode[] = [
+    ErrorCode.UNAUTHORIZED,
+    ErrorCode.INVALID_TOKEN,
+    ErrorCode.TOKEN_EXPIRED,
+  ];
+
+  return authCodes.includes(error.code);
 }
 
 /**

--- a/apps/client/test/errors.test.ts
+++ b/apps/client/test/errors.test.ts
@@ -1,8 +1,18 @@
-import { ErrorCode, ErrorResponse, getStatusCode } from "@repo/domain";
+import {
+  AppError,
+  ErrorCode,
+  ErrorResponse,
+  getStatusCode,
+} from "@repo/domain";
 import { AxiosError, AxiosHeaders } from "axios";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { normalizeError, processAxiosError } from "../src/lib/errors/errors";
+import {
+  isAuthError,
+  isCriticalError,
+  normalizeError,
+  processAxiosError,
+} from "../src/lib/errors/errors";
 
 // The same rejection can be produced by the API or by a schema parse in the
 // browser. Both have to carry one status, or a form would branch differently
@@ -64,5 +74,48 @@ describe("client validation errors", () => {
     expect(clientSide.code).toBe(ErrorCode.VALIDATION_ERROR);
     expect(clientSide.statusCode).toBe(serverSide.statusCode);
     expect(clientSide.statusCode).toBe(VALIDATION_STATUS);
+  });
+});
+
+// A dead session and a rejected login are both 401s, but only one of them is
+// fixed by signing in again. The two predicates have to disagree about them.
+
+describe("auth errors", () => {
+  it.each([
+    ErrorCode.UNAUTHORIZED,
+    ErrorCode.INVALID_TOKEN,
+    ErrorCode.TOKEN_EXPIRED,
+  ])("treats %s as an auth error, not a critical one", (code) => {
+    const error = new AppError("dead session", code);
+
+    expect(isAuthError(error)).toBe(true);
+    expect(isCriticalError(error)).toBe(false);
+  });
+
+  it("leaves INVALID_CREDENTIALS to the login form", () => {
+    const error = new AppError(
+      "Invalid email or password",
+      ErrorCode.INVALID_CREDENTIALS,
+    );
+
+    expect(isAuthError(error)).toBe(false);
+    expect(isCriticalError(error)).toBe(false);
+  });
+
+  it.each([ErrorCode.INTERNAL_ERROR, ErrorCode.EXTERNAL_SERVICE_ERROR])(
+    "keeps %s critical and not an auth error",
+    (code) => {
+      const error = new AppError("boom", code);
+
+      expect(isCriticalError(error)).toBe(true);
+      expect(isAuthError(error)).toBe(false);
+    },
+  );
+
+  it("does not treat a 404 as either", () => {
+    const error = new AppError("nope", ErrorCode.NOT_FOUND);
+
+    expect(isAuthError(error)).toBe(false);
+    expect(isCriticalError(error)).toBe(false);
   });
 });

--- a/apps/server/src/middlewares/error.middleware.ts
+++ b/apps/server/src/middlewares/error.middleware.ts
@@ -7,6 +7,7 @@ import {
   isPrismaKnownRequestError,
   isPrismaValidationError,
 } from "../utils/prisma-errors.js";
+import { isJwtError, toJwtAppError } from "../utils/jwt-errors.js";
 import { zodIssuesToDetails } from "../utils/zodDetails.js";
 
 // ------------------ Specific Error Handlers ------------------
@@ -48,25 +49,7 @@ const handleZodError = (err: ZodError) => {
   return new AppError(message, ErrorCode.VALIDATION_ERROR, undefined, details);
 };
 
-const handleJWTError = () =>
-  new AppError("Invalid token. Please log in again!", ErrorCode.INVALID_TOKEN);
-
-const handleJWTExpiredError = () =>
-  new AppError(
-    "Your token has expired! Please log in again.",
-    ErrorCode.TOKEN_EXPIRED,
-  );
-
 // ------------------ Type guards ------------------
-const isErrorNamed = (err: unknown, name: string): err is Error =>
-  err instanceof Error && err.name === name;
-
-const isJwtExpiredError = (err: unknown): boolean =>
-  isErrorNamed(err, "TokenExpiredError");
-
-const isJwtError = (err: unknown): err is Error =>
-  isErrorNamed(err, "JsonWebTokenError") || isJwtExpiredError(err);
-
 const isZodError = (err: unknown): err is ZodError => {
   return err instanceof ZodError;
 };
@@ -100,7 +83,7 @@ const normalizeError = (err: unknown): AppError | unknown => {
 
   // JWT errors
   if (isJwtError(err)) {
-    return isJwtExpiredError(err) ? handleJWTExpiredError() : handleJWTError();
+    return toJwtAppError(err);
   }
 
   // Unknown error type - return as is

--- a/apps/server/src/services/auth.service.ts
+++ b/apps/server/src/services/auth.service.ts
@@ -9,6 +9,7 @@ import {
 } from "@repo/domain";
 import jwt from "jsonwebtoken";
 import { env } from "../utils/env.js";
+import { isJwtError, toJwtAppError } from "../utils/jwt-errors.js";
 
 type AuthSessionDTO = {
   user: UserDTO;
@@ -191,7 +192,14 @@ export class AuthService {
    * @returns Decoded token payload
    */
   private verifyToken(token: string): jwt.JwtPayload {
-    const decoded = jwt.verify(token, env.JWT_SECRET);
+    let decoded: string | jwt.JwtPayload;
+    try {
+      decoded = jwt.verify(token, env.JWT_SECRET);
+    } catch (error) {
+      // Classified here, not at the boundary, so checkIsAuthenticated can read it.
+      if (!isJwtError(error)) throw error;
+      throw toJwtAppError(error);
+    }
     if (!decoded || typeof decoded === "string") {
       throw new AppError("Invalid token", ErrorCode.INVALID_TOKEN);
     }
@@ -202,6 +210,7 @@ export class AuthService {
     const tokenValidationErrors = [
       ErrorCode.UNAUTHORIZED,
       ErrorCode.INVALID_TOKEN,
+      ErrorCode.TOKEN_EXPIRED,
     ];
     try {
       await this.validateTokenAndGetUser(token);

--- a/apps/server/src/utils/jwt-errors.ts
+++ b/apps/server/src/utils/jwt-errors.ts
@@ -1,0 +1,22 @@
+import { AppError, ErrorCode } from "@repo/domain";
+
+const isErrorNamed = (err: unknown, name: string): err is Error =>
+  err instanceof Error && err.name === name;
+
+export const isJwtExpiredError = (err: unknown): boolean =>
+  isErrorNamed(err, "TokenExpiredError");
+
+export const isJwtError = (err: unknown): err is Error =>
+  isErrorNamed(err, "JsonWebTokenError") || isJwtExpiredError(err);
+
+/** The AppError a raw `jsonwebtoken` rejection stands for. */
+export const toJwtAppError = (err: unknown): AppError =>
+  isJwtExpiredError(err)
+    ? new AppError(
+        "Your token has expired! Please log in again.",
+        ErrorCode.TOKEN_EXPIRED,
+      )
+    : new AppError(
+        "Invalid token. Please log in again!",
+        ErrorCode.INVALID_TOKEN,
+      );

--- a/apps/server/test/auth.route.test.ts
+++ b/apps/server/test/auth.route.test.ts
@@ -5,7 +5,9 @@ import app from "../src/app.js";
 import {
   authCookie,
   createUser,
+  expiredAuthCookie,
   resetDatabase,
+  tamperedAuthCookie,
   TEST_PASSWORD,
 } from "./helpers/database.js";
 
@@ -129,5 +131,66 @@ describe("GET /api/v1/auth/status", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data).toEqual({ isAuthenticated: false });
+  });
+
+  // The status route answers a question; a dead cookie is an answer, not a
+  // failure. A 401 here breaks the client loaders that gate on it.
+  it("reports an expired token as not authenticated", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/auth/status")
+      .set("Cookie", expiredAuthCookie(user.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ isAuthenticated: false });
+  });
+
+  it("reports a tampered token as not authenticated", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/auth/status")
+      .set("Cookie", tamperedAuthCookie(user.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ isAuthenticated: false });
+  });
+
+  it("reports a deleted user as not authenticated", async () => {
+    const user = await createUser();
+    const cookie = authCookie(user.id);
+    await resetDatabase();
+
+    const res = await request(app)
+      .get("/api/v1/auth/status")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ isAuthenticated: false });
+  });
+});
+
+describe("protected routes still reject a dead cookie", () => {
+  it("returns TOKEN_EXPIRED for an expired token", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/users/me")
+      .set("Cookie", expiredAuthCookie(user.id));
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe(ErrorCode.TOKEN_EXPIRED);
+  });
+
+  it("returns INVALID_TOKEN for a tampered token", async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .get("/api/v1/users/me")
+      .set("Cookie", tamperedAuthCookie(user.id));
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe(ErrorCode.INVALID_TOKEN);
   });
 });

--- a/apps/server/test/helpers/database.ts
+++ b/apps/server/test/helpers/database.ts
@@ -65,6 +65,18 @@ export const authCookie = (userId: string) => {
   return `jwt=${token}`;
 };
 
+/** A genuinely signed JWT whose expiry has already passed. */
+export const expiredAuthCookie = (userId: string) => {
+  const token = jwt.sign({ id: userId }, env.JWT_SECRET, { expiresIn: "-1s" });
+  return `jwt=${token}`;
+};
+
+/** A well-formed JWT signed with the wrong secret. */
+export const tamperedAuthCookie = (userId: string) => {
+  const token = jwt.sign({ id: userId }, `${env.JWT_SECRET}-wrong`);
+  return `jwt=${token}`;
+};
+
 export const image = (label: string) => ({
   altText: `${label} alt`,
   ariaLabel: `${label} aria`,


### PR DESCRIPTION
Implements **option C** from #185: keep `isCriticalError` meaning "the route cannot render", add `isAuthError` for a dead session, and give that case a redirect instead of a Retry button that refetches with the same dead cookie.

## The contradiction, resolved

`isCriticalError`'s docstring and inline comment both promised auth failures and token issues were critical. `criticalCodes` held neither, and every auth code maps to 401, so the `statusCode >= 500` clause missed them too. The docstring, the comment and the list now agree, and the auth case has its own predicate.

`INVALID_CREDENTIALS` is deliberately excluded from `isAuthError`. The issue worried option A would swallow "Invalid email or password"; that turned out not to apply — a rejected login is reported inline by the login form's mutation `onError`, never by a boundary. Redirecting to the login page the user is standing on would loop.

## The server half, which the issue did not anticipate

The issue states `/auth/status` "returns 200 with `{isAuthenticated: false}`, never a 401". That holds for a missing cookie and a deleted user, but **not** for an expired or tampered one: `checkIsAuthenticated` caught `AppError` while `jwt.verify` throws raw errors, so those returned 401 `TOKEN_EXPIRED` / `INVALID_TOKEN`.

That mattered more than the reported bug. The root layout's loader awaits `/auth/status` on every page and the root `errorElement` is `MainErrorFallback`, so a stale cookie bricked the entire app on every route — a full-screen "Ooops, something went wrong" whose Refresh button reloads and fails identically.

`verifyToken` now classifies through a shared `jwt-errors` util — the same split `prisma-errors.ts` already uses — which the error middleware reuses in place of its own private copies, so there is one source of truth and no dead code.

## Ordering that is easy to get wrong

`RedirectToLogin` marks the session signed out **before** navigating. The auth layout's loader reads that cached status and would bounce a stale `true` straight back into the failing route.

The `/account` subtree gains its own `RouteErrorBoundary`: `UserAreaLayout` calls `useSuspenseQuery` above the `SafeRenderWithErrorBlock` it renders, so its 401 fell through to `MainErrorFallback`. The nav bar had the same shape — `useCart` in `Navbar`'s body — so the button moved into its own `CartButton` component and it and `MiniCart` are now guarded too.

## Docs

`ERROR_FLOW.md`'s boundary tree, exports list and critical-code list gain the auth branch. Four stale claims corrected: "Re-throws: Critical errors (auth, validation)", the phantom "Axios handles 401 redirects" in two files, and a login-401 worked example that described an `ErrorBlock` beside the form when the real flow is a toast carrying `INVALID_CREDENTIALS`.

## Verification

- 5 new server route tests covering expired, tampered and deleted-user cookies against `/auth/status`, plus protected routes still 401ing with the specific code; 2 new cookie fixtures.
- 7 new client predicate tests pinning the two predicates as disjoint.
- Full suite 262 passing; type-check clean; lint unchanged at its existing cap.

**Not covered by tests:** the client vitest setup is node-only with no jsdom, so `isAuthError` is unit-tested but `RedirectToLogin` and the boundary wiring are verified by type-check and by reading the loader interaction, not by execution.

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)